### PR TITLE
docs(claude): track phases via GitHub milestones, not labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,17 +32,17 @@ All config is via environment variables. The full reference lives in [`docs/conf
 
 ## Milestones
 
-This project is tracked by GitHub issues, labelled `phase-1` / `phase-2` / `phase-3`. **Always list the current scope before starting work**:
+Phase grouping is tracked via GitHub **milestones**, not labels. **Always list the current scope before starting work**:
 
 ```
-mcp__github__list_issues   owner=nebriv  repo=ai-tabletop-facilitator  labels=["phase-1"]  state=OPEN
-mcp__github__list_issues   owner=nebriv  repo=ai-tabletop-facilitator  labels=["phase-2"]  state=OPEN
-mcp__github__list_issues   owner=nebriv  repo=ai-tabletop-facilitator  labels=["phase-3"]  state=OPEN
+mcp__github__search_issues  query='repo:nebriv/ai-tabletop-facilitator is:issue is:open milestone:"Phase 1"'
+mcp__github__search_issues  query='repo:nebriv/ai-tabletop-facilitator is:issue is:open milestone:"Phase 2"'
+mcp__github__search_issues  query='repo:nebriv/ai-tabletop-facilitator is:issue is:open milestone:"Phase 3"'
 ```
 
-- **Phase 1 — Architecture & Bootstrap**: devcontainer, Docker, CI, docs, scaffolding. Granular issues (#1–#10).
-- **Phase 2 — MVP**: 9 epics (#11–#19) — split into per-component issues at Phase 2 kickoff.
-- **Phase 3 — Value-add**: 6 epics (#20–#25) — define their own success criteria when picked up.
+- **Phase 1 — Architecture & Bootstrap** (milestone #1): devcontainer, Docker, CI, docs, scaffolding. **Complete** — all 10 issues closed.
+- **Phase 2 — MVP** (milestone #2): 9 epics (#11–#19) — split into per-component issues at Phase 2 kickoff.
+- **Phase 3 — Value-add** (milestone #3): 6 epics (#20–#25) — define their own success criteria when picked up.
 
 ## Sub-agent review protocol
 


### PR DESCRIPTION
## Summary

CLAUDE.md was telling future agents to filter issues by `phase-1`/`phase-2`/`phase-3` **labels** that don't exist on the repo. Switch to GitHub **milestones** (which you created and populated) using `mcp__github__search_issues` queries — exactly what issue #5's body asked for.

## What changed

- Replaced the three `mcp__github__list_issues … labels=["phase-N"]` queries with `mcp__github__search_issues` queries using `milestone:"Phase N"`.
- Noted the milestone numbers (#1 / #2 / #3) and that Phase 1 is now complete (all 10 issues closed).

## Verification

```
mcp__github__search_issues  query='repo:nebriv/ai-tabletop-facilitator milestone:"Phase 1"'  → 10 issues, all CLOSED
mcp__github__search_issues  query='repo:nebriv/ai-tabletop-facilitator is:open milestone:"Phase 2"'  → 9 epics
mcp__github__search_issues  query='repo:nebriv/ai-tabletop-facilitator is:open milestone:"Phase 3"'  → 6 epics
```

https://claude.ai/code/session_01QBjoMQrf71qdBokzdWwyh1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBjoMQrf71qdBokzdWwyh1)_