### PR TITLE
backend: fix setup plan generation (schema + max_tokens)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -331,9 +331,35 @@ def register_api_routes(app: FastAPI) -> None:
         session = await manager.get_session(session_id)
         if session.state != SessionState.SETUP:
             return {"ok": True, "state": session.state.value}
+        # Snapshot the audit "high-water mark" before the LLM call so
+        # we can return *only* the diagnostics emitted by THIS reply
+        # (older ones from previous replies stay invisible to this
+        # response — they're still in /activity).
+        before = len(manager.audit().dump(session_id))
         await driver.run_setup_turn(session=session)
-        await manager.get_session(session_id)
-        return {"ok": True}
+        after = await manager.get_session(session_id)
+        # Disambiguate the "AI didn't propose a plan" failure mode for
+        # the frontend. Previously the frontend could only tell that
+        # ``after.plan`` was None and showed a generic "try again"
+        # message. Now it can render the specific reason (validation
+        # error / max_tokens truncation / etc.).
+        new_audit = manager.audit().dump(session_id)[before:]
+        diagnostics = [
+            {
+                "kind": evt.kind,
+                "name": evt.payload.get("name"),
+                "tier": evt.payload.get("tier"),
+                "reason": evt.payload.get("reason"),
+                "hint": evt.payload.get("hint"),
+            }
+            for evt in new_audit
+            if evt.kind in {"tool_use_rejected", "llm_truncated"}
+        ]
+        return {
+            "ok": True,
+            "plan_proposed": after.plan is not None,
+            "diagnostics": diagnostics,
+        }
 
     @router.post("/sessions/{session_id}/setup/skip")
     async def setup_skip(session_id: str, request: Request) -> dict[str, Any]:
@@ -836,6 +862,21 @@ def register_api_routes(app: FastAPI) -> None:
             "turn_count": len(session.turns),
             "message_count": len(session.messages),
             "setup_note_count": len(session.setup_notes),
+            # Backend-side trouble surfaced to the creator UI so the
+            # activity panel can show "model rejected the plan tool 3x"
+            # or "setup tier hit max_tokens" without requiring an SSH
+            # into the container. Newest-first, capped to 5.
+            "recent_diagnostics": [
+                {
+                    "kind": evt.kind,
+                    "ts": evt.ts.isoformat(),
+                    "name": evt.payload.get("name"),
+                    "tier": evt.payload.get("tier"),
+                    "reason": evt.payload.get("reason"),
+                    "hint": evt.payload.get("hint"),
+                }
+                for evt in manager.audit().recent_diagnostics(session_id)
+            ],
         }
 
     @router.get("/sessions/{session_id}/debug")

--- a/backend/app/auth/audit.py
+++ b/backend/app/auth/audit.py
@@ -72,6 +72,32 @@ class AuditLog:
 
         return list(self._buffers.get(session_id, ()))
 
+    def recent_diagnostics(
+        self,
+        session_id: str,
+        *,
+        kinds: tuple[str, ...] = ("tool_use_rejected", "llm_truncated"),
+        limit: int = 5,
+    ) -> list[AuditEvent]:
+        """Most-recent operator-facing failure events, newest first.
+
+        Used by ``/activity`` and ``/setup/reply`` to surface
+        backend-side trouble (rejected tool calls, truncated LLM
+        outputs) to the creator instead of leaving them buried in
+        container stdout. Non-destructive read.
+        """
+
+        buf = self._buffers.get(session_id)
+        if not buf:
+            return []
+        out: list[AuditEvent] = []
+        for evt in reversed(buf):
+            if evt.kind in kinds:
+                out.append(evt)
+                if len(out) >= limit:
+                    break
+        return out
+
     def drop(self, session_id: str) -> None:
         """Forget a session's audit trail (used after export retention)."""
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,7 +38,15 @@ _TIER_DEFAULTS: dict[ModelTier, str] = {
 # ``docs/configuration.md``.
 _MAX_TOKENS_DEFAULTS: dict[ModelTier, int] = {
     "play": 1024,
-    "setup": 1024,
+    # ``setup`` needs more headroom than ``play`` because a full plan
+    # tool call (title, executive_summary, ≥3 objectives, ≥3 narrative
+    # beats with nested ``expected_actors`` arrays, 2–3 injects with
+    # trigger/type/summary, plus guardrails / success_criteria /
+    # out_of_scope) routinely runs past 1024 output tokens. Truncated
+    # plan calls were the cause of the "AI didn't propose a plan yet"
+    # loop observed on 2026-04-29 — every retry hit ``stop_reason:
+    # max_tokens`` and the partial JSON failed validation.
+    "setup": 4096,
     "aar": 4096,
     "guardrail": 12,
 }

--- a/backend/app/llm/tools.py
+++ b/backend/app/llm/tools.py
@@ -13,6 +13,35 @@ from __future__ import annotations
 
 from typing import Any
 
+# Nested item schemas for the scenario-plan tool calls. Without these the
+# model treats ``narrative_arc`` / ``injects`` as opaque arrays and
+# improvises the per-item shape — observed failure mode is the model
+# emitting ``<parameter name="beat">1`` / ``<item>...</item>`` XML soup
+# as raw strings, which then fails Pydantic validation. Mirrors
+# ``ScenarioBeat`` / ``ScenarioInject`` in ``sessions/models.py``.
+_NARRATIVE_BEAT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "beat": {"type": "integer"},
+        "label": {"type": "string"},
+        "expected_actors": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "required": ["beat", "label", "expected_actors"],
+}
+
+_SCENARIO_INJECT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "trigger": {"type": "string"},
+        "type": {"type": "string", "enum": ["event", "critical"]},
+        "summary": {"type": "string"},
+    },
+    "required": ["trigger", "type", "summary"],
+}
+
 PLAY_TOOLS: list[dict[str, Any]] = [
     {
         "name": "address_role",
@@ -261,8 +290,16 @@ SETUP_TOOLS: list[dict[str, Any]] = [
                     "items": {"type": "string"},
                     "minItems": 1,
                 },
-                "narrative_arc": {"type": "array", "minItems": 1},
-                "injects": {"type": "array", "minItems": 1},
+                "narrative_arc": {
+                    "type": "array",
+                    "items": _NARRATIVE_BEAT_SCHEMA,
+                    "minItems": 1,
+                },
+                "injects": {
+                    "type": "array",
+                    "items": _SCENARIO_INJECT_SCHEMA,
+                    "minItems": 1,
+                },
                 "guardrails": {"type": "array", "items": {"type": "string"}},
                 "success_criteria": {"type": "array", "items": {"type": "string"}},
                 "out_of_scope": {"type": "array", "items": {"type": "string"}},
@@ -293,8 +330,16 @@ SETUP_TOOLS: list[dict[str, Any]] = [
                     "items": {"type": "string"},
                     "minItems": 1,
                 },
-                "narrative_arc": {"type": "array", "minItems": 1},
-                "injects": {"type": "array", "minItems": 1},
+                "narrative_arc": {
+                    "type": "array",
+                    "items": _NARRATIVE_BEAT_SCHEMA,
+                    "minItems": 1,
+                },
+                "injects": {
+                    "type": "array",
+                    "items": _SCENARIO_INJECT_SCHEMA,
+                    "minItems": 1,
+                },
                 "guardrails": {"type": "array", "items": {"type": "string"}},
                 "success_criteria": {"type": "array", "items": {"type": "string"}},
                 "out_of_scope": {"type": "array", "items": {"type": "string"}},

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from ..auth.audit import AuditEvent
 from ..extensions.registry import FrozenRegistry
 from ..llm.client import LLMResult
 from ..llm.dispatch import DispatchOutcome
@@ -59,6 +60,51 @@ _logger = get_logger("session.turn_driver")
 class TurnDriver:
     def __init__(self, *, manager: SessionManager) -> None:
         self._manager = manager
+
+    def _check_truncation(
+        self,
+        *,
+        session_id: str,
+        tier: str,
+        result: LLMResult,
+        turn_id: str | None = None,
+    ) -> None:
+        """Emit an audit event when an LLM call hit ``max_tokens``.
+
+        ``stop_reason == "max_tokens"`` always means the per-tier
+        budget is too small for the call the prompt is asking for —
+        the model is truncated mid-output. That used to surface only
+        in container stdout; now it lives in the audit ring buffer so
+        the creator's activity panel and ``/setup/reply`` can show it
+        without an SSH session.
+        """
+
+        if result.stop_reason != "max_tokens":
+            return
+        _logger.warning(
+            "llm_truncated",
+            session_id=session_id,
+            tier=tier,
+            model=result.model,
+            output_tokens=result.usage.get("output_tokens"),
+        )
+        self._manager.audit().emit(
+            AuditEvent(
+                kind="llm_truncated",
+                session_id=session_id,
+                turn_id=turn_id,
+                payload={
+                    "tier": tier,
+                    "model": result.model,
+                    "output_tokens": result.usage.get("output_tokens"),
+                    "hint": (
+                        "raise LLM_MAX_TOKENS_"
+                        + tier.upper()
+                        + " — current call hit the per-tier ceiling"
+                    ),
+                },
+            )
+        )
 
     async def run_setup_turn(self, *, session: Session) -> Session:
         """Drive one setup-tier turn. May loop internally if Claude chains tools."""
@@ -99,6 +145,7 @@ class TurnDriver:
                 session_id=session.id,
             )
             await self._apply_cost(session.id, result)
+            self._check_truncation(session_id=session.id, tier="setup", result=result)
 
             tool_uses = _tool_uses(result)
             if not tool_uses:
@@ -262,6 +309,9 @@ class TurnDriver:
                 tool_choice=tool_choice,
             )
             await self._apply_cost(session.id, result)
+            self._check_truncation(
+                session_id=session.id, tier="play", result=result, turn_id=turn.id
+            )
 
             tool_uses = _tool_uses(result)
             outcome = await dispatcher.dispatch(

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -81,12 +81,13 @@ class TurnDriver:
 
         if result.stop_reason != "max_tokens":
             return
+        output_tokens = result.usage.get("output")
         _logger.warning(
             "llm_truncated",
             session_id=session_id,
             tier=tier,
             model=result.model,
-            output_tokens=result.usage.get("output_tokens"),
+            output_tokens=output_tokens,
         )
         self._manager.audit().emit(
             AuditEvent(
@@ -96,7 +97,7 @@ class TurnDriver:
                 payload={
                     "tier": tier,
                     "model": result.model,
-                    "output_tokens": result.usage.get("output_tokens"),
+                    "output_tokens": output_tokens,
                     "hint": (
                         "raise LLM_MAX_TOKENS_"
                         + tier.upper()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -98,7 +98,7 @@ def test_max_tokens_for_uses_tier_defaults(monkeypatch) -> None:
         monkeypatch.delenv(key, raising=False)
     s = Settings()
     assert s.max_tokens_for("play") == 1024
-    assert s.max_tokens_for("setup") == 1024
+    assert s.max_tokens_for("setup") == 4096
     assert s.max_tokens_for("aar") == 4096
     assert s.max_tokens_for("guardrail") == 12
 
@@ -110,7 +110,7 @@ def test_max_tokens_env_override_wins(monkeypatch) -> None:
     assert s.max_tokens_for("play") == 2048
     assert s.max_tokens_for("guardrail") == 16
     # Untouched tiers keep their defaults.
-    assert s.max_tokens_for("setup") == 1024
+    assert s.max_tokens_for("setup") == 4096
     assert s.max_tokens_for("aar") == 4096
 
 

--- a/backend/tests/test_tools_schema.py
+++ b/backend/tests/test_tools_schema.py
@@ -1,0 +1,85 @@
+"""Schema-shape regression tests for the tool definitions.
+
+The 2026-04-29 plan-generation outage was caused by a tool
+``input_schema`` declaring ``narrative_arc`` and ``injects`` as bare
+arrays without a per-item shape. Without the ``items`` schema Claude
+improvised the shape and emitted XML-style strings that failed Pydantic
+validation, locking the setup loop.
+
+This test walks every tool we expose and asserts that every ``array``
+field carries an ``items`` schema, recursively. A new array property
+that lands without ``items`` will fail this test before it ever ships.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.llm.tools import AAR_TOOL, PLAY_TOOLS, SETUP_TOOLS
+
+
+def _walk_arrays(node: Any, *, path: str) -> list[str]:
+    """Return paths to ``array`` schemas missing an ``items`` definition."""
+
+    missing: list[str] = []
+    if not isinstance(node, dict):
+        return missing
+    node_type = node.get("type")
+    if node_type == "array":
+        items = node.get("items")
+        if not isinstance(items, dict) or "type" not in items:
+            missing.append(path)
+        else:
+            missing.extend(_walk_arrays(items, path=f"{path}.items"))
+    if node_type == "object":
+        props = node.get("properties") or {}
+        for prop_name, prop_schema in props.items():
+            missing.extend(_walk_arrays(prop_schema, path=f"{path}.{prop_name}"))
+    return missing
+
+
+def _all_tools() -> list[dict[str, Any]]:
+    return [*SETUP_TOOLS, *PLAY_TOOLS, AAR_TOOL]
+
+
+@pytest.mark.parametrize("tool", _all_tools(), ids=lambda t: t["name"])
+def test_every_array_property_has_items_schema(tool: dict[str, Any]) -> None:
+    """Anthropic accepts arrays without ``items`` but Claude then
+    hallucinates the per-item shape, which fails Pydantic validation
+    on the dispatcher side. Every array must declare its element
+    type so the model's output is constrained.
+    """
+
+    schema = tool.get("input_schema", {})
+    missing = _walk_arrays(schema, path=tool["name"])
+    assert not missing, (
+        f"tool {tool['name']!r} has array fields without ``items``: {missing}. "
+        "Add an explicit ``items`` schema (object with required keys for "
+        "structured arrays, or {'type': 'string'} / etc. for primitive arrays). "
+        "See backend/app/llm/tools.py:_NARRATIVE_BEAT_SCHEMA for an example."
+    )
+
+
+def test_propose_scenario_plan_nested_shapes_match_pydantic() -> None:
+    """``narrative_arc`` and ``injects`` items must mirror the
+    ``ScenarioBeat`` and ``ScenarioInject`` Pydantic models. Drift
+    between the tool schema and the Pydantic invariants is what
+    produced the original validation-loop bug.
+    """
+
+    propose = next(t for t in SETUP_TOOLS if t["name"] == "propose_scenario_plan")
+    finalize = next(t for t in SETUP_TOOLS if t["name"] == "finalize_setup")
+    for tool in (propose, finalize):
+        props = tool["input_schema"]["properties"]
+        beat_items = props["narrative_arc"]["items"]
+        assert beat_items["type"] == "object"
+        assert set(beat_items["required"]) >= {"beat", "label", "expected_actors"}
+        assert beat_items["properties"]["beat"]["type"] == "integer"
+        assert beat_items["properties"]["expected_actors"]["type"] == "array"
+        assert beat_items["properties"]["expected_actors"]["items"]["type"] == "string"
+
+        inject_items = props["injects"]["items"]
+        assert inject_items["type"] == "object"
+        assert set(inject_items["required"]) >= {"trigger", "type", "summary"}

--- a/backend/tests/test_turn_engine.py
+++ b/backend/tests/test_turn_engine.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
+from app.auth.audit import AuditLog
+from app.llm.client import LLMResult
 from app.sessions.models import Session, SessionState, Turn
+from app.sessions.turn_driver import TurnDriver
 from app.sessions.turn_engine import (
     IllegalTransitionError,
     all_submitted,
@@ -63,3 +66,62 @@ def test_critical_inject_rate_limit() -> None:
     # Advance the turn index by 6 — window slides
     s.turns.append(Turn(index=6, active_role_ids=[]))
     assert critical_inject_allowed(s, max_per_5_turns=1) is True
+
+
+class _StubManager:
+    """Minimal SessionManager stand-in for ``TurnDriver._check_truncation``.
+
+    The method only touches ``self._manager.audit()``; constructing a full
+    manager (which needs an LLM client, dispatcher, registry, settings,
+    repository, …) just to exercise an audit emission would be churn.
+    """
+
+    def __init__(self, audit: AuditLog) -> None:
+        self._audit = audit
+
+    def audit(self) -> AuditLog:
+        return self._audit
+
+
+def _llm_result(*, stop_reason: str, output: int = 1024) -> LLMResult:
+    return LLMResult(
+        model="claude-test",
+        content=[],
+        stop_reason=stop_reason,
+        usage={"input": 0, "output": output, "cache_read": 0, "cache_creation": 0},
+        estimated_usd=0.0,
+    )
+
+
+def test_check_truncation_records_output_token_count() -> None:
+    """Regression for PR #60: the audit payload + log line must read
+    ``LLMResult.usage["output"]`` (the normalized key emitted by
+    ``_normalize_response``), not ``"output_tokens"`` (the raw
+    Anthropic key, which is always absent post-normalization). A
+    silent ``None`` would defeat the whole point of surfacing
+    ``llm_truncated`` to the operator panel.
+    """
+
+    audit = AuditLog(ring_size=10)
+    driver = TurnDriver(manager=_StubManager(audit))
+    result = _llm_result(stop_reason="max_tokens", output=1024)
+    driver._check_truncation(session_id="s1", tier="setup", result=result)
+
+    events = audit.dump("s1")
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.kind == "llm_truncated"
+    assert evt.payload["output_tokens"] == 1024
+    assert evt.payload["tier"] == "setup"
+    assert "LLM_MAX_TOKENS_SETUP" in evt.payload["hint"]
+
+
+def test_check_truncation_noop_on_other_stop_reasons() -> None:
+    audit = AuditLog(ring_size=10)
+    driver = TurnDriver(manager=_StubManager(audit))
+    driver._check_truncation(
+        session_id="s1",
+        tier="setup",
+        result=_llm_result(stop_reason="end_turn"),
+    )
+    assert audit.dump("s1") == []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ rationale for each default lives in `backend/app/config.py`
 | Var | Default | Effect |
 |---|---|---|
 | `LLM_MAX_TOKENS_PLAY` | `1024` | Per-turn cap during play. Bump to ~2048 if Sonnet is truncating beats. |
-| `LLM_MAX_TOKENS_SETUP` | `1024` | Per-turn cap during setup. |
+| `LLM_MAX_TOKENS_SETUP` | `4096` | Per-turn cap during setup. Sized to fit a full `propose_scenario_plan` tool call (≥3 nested beats, 2–3 injects, plus optional arrays); raise further if the model still truncates. |
 | `LLM_MAX_TOKENS_AAR` | `4096` | Cap on the AAR report tokens. |
 | `LLM_MAX_TOKENS_GUARDRAIL` | `12` | Cap on the guardrail classifier (one-word verdict). |
 | `LLM_TEMPERATURE_PLAY` | _SDK default_ | Higher = more narrative variance. |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -87,6 +87,27 @@ export interface ScenarioPlan {
   out_of_scope: string[];
 }
 
+export interface BackendDiagnostic {
+  /** ``tool_use_rejected`` or ``llm_truncated``. */
+  kind: string;
+  /** Tool name that was rejected, when applicable. */
+  name?: string | null;
+  /** LLM tier (``setup`` / ``play`` / ``aar`` / ``guardrail``). */
+  tier?: string | null;
+  /** Human-readable validator / dispatcher message. */
+  reason?: string | null;
+  /** Operator hint (e.g. "raise LLM_MAX_TOKENS_SETUP"). */
+  hint?: string | null;
+}
+
+export interface SetupReplyResult {
+  ok: boolean;
+  /** True iff the AI's tool call set a draft scenario plan. */
+  plan_proposed?: boolean;
+  /** Backend-side rejections / truncations that occurred during this reply. */
+  diagnostics?: BackendDiagnostic[];
+}
+
 /**
  * Strip query-string secrets ({@code token=...}) from a path before logging.
  * Tokens are bearer credentials — leaking them via console is a real bug.
@@ -151,8 +172,16 @@ export const api = {
     return request("GET", `/api/sessions/${sessionId}?token=${encodeURIComponent(token)}`);
   },
 
-  async setupReply(sessionId: string, token: string, content: string): Promise<{ ok: boolean }> {
-    return request("POST", `/api/sessions/${sessionId}/setup/reply?token=${encodeURIComponent(token)}`, { content });
+  async setupReply(
+    sessionId: string,
+    token: string,
+    content: string,
+  ): Promise<SetupReplyResult> {
+    return request(
+      "POST",
+      `/api/sessions/${sessionId}/setup/reply?token=${encodeURIComponent(token)}`,
+      { content },
+    );
   },
 
   async setupFinalize(

--- a/frontend/src/components/SessionActivityPanel.tsx
+++ b/frontend/src/components/SessionActivityPanel.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { RoleView, api } from "../api/client";
 
+interface ActivityDiagnostic {
+  kind: string;
+  ts: string;
+  name?: string | null;
+  tier?: string | null;
+  reason?: string | null;
+  hint?: string | null;
+}
+
 interface ActivitySnapshot {
   state: string;
   turn: {
@@ -18,6 +27,7 @@ interface ActivitySnapshot {
   turn_count: number;
   message_count: number;
   setup_note_count: number;
+  recent_diagnostics?: ActivityDiagnostic[];
 }
 
 interface Props {
@@ -230,6 +240,36 @@ export function SessionActivityPanel({
           <p className="text-[10px] text-slate-500">
             {data.turn_count} turns · {data.message_count} msgs · {data.setup_note_count} setup notes
           </p>
+
+          {data.recent_diagnostics && data.recent_diagnostics.length > 0 ? (
+            <details className="rounded border border-amber-700/40 bg-amber-950/20 p-1.5 text-xs">
+              <summary className="cursor-pointer text-amber-200">
+                Recent backend diagnostics ({data.recent_diagnostics.length})
+              </summary>
+              <ul className="mt-1 flex flex-col gap-1">
+                {data.recent_diagnostics.map((diag, idx) => (
+                  <li
+                    key={`${diag.ts}-${idx}`}
+                    className="rounded bg-slate-950 px-2 py-1 text-[11px] text-slate-200"
+                  >
+                    <span className="font-semibold text-amber-200">{diag.kind}</span>
+                    {diag.tier ? (
+                      <span className="ml-1 text-slate-400">[{diag.tier}]</span>
+                    ) : null}
+                    {diag.name ? (
+                      <span className="ml-1 text-slate-300">{diag.name}</span>
+                    ) : null}
+                    {diag.reason ? (
+                      <p className="text-slate-300">{diag.reason}</p>
+                    ) : null}
+                    {diag.hint ? (
+                      <p className="text-emerald-300">→ {diag.hint}</p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ) : null}
         </>
       )}
 

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -432,7 +432,7 @@ export function Facilitator() {
     setBusy(true);
     setBusyMessage("Asking the AI to draft the plan…");
     try {
-      await api.setupReply(state.sessionId, state.token, NUDGE_PROPOSE);
+      const reply = await api.setupReply(state.sessionId, state.token, NUDGE_PROPOSE);
       const snap = await api.getSession(state.sessionId, state.token);
       setSnapshot(snap);
       if (snap.plan) {
@@ -441,9 +441,26 @@ export function Facilitator() {
         const after = await api.getSession(state.sessionId, state.token);
         setSnapshot(after);
       } else {
-        setError(
-          "The AI didn't propose a plan yet. Try once more, or share a bit more context first.",
-        );
+        // Disambiguate the failure mode using server-side diagnostics
+        // so the operator knows whether to raise max_tokens, share more
+        // context, or report a model regression. Without this every
+        // failure looked identical in the UI.
+        const diags = reply.diagnostics ?? [];
+        const truncated = diags.find((d) => d.kind === "llm_truncated");
+        const rejected = diags.find((d) => d.kind === "tool_use_rejected");
+        let message: string;
+        if (truncated) {
+          message =
+            `The AI's plan call was truncated (${truncated.tier ?? "setup"} tier hit max_tokens). ` +
+            (truncated.hint ?? "Raise LLM_MAX_TOKENS_SETUP and retry.");
+        } else if (rejected) {
+          const tool = rejected.name ?? "tool";
+          message = `The AI tried to call ${tool} but the engine rejected it: ${rejected.reason ?? "see backend logs"}`;
+        } else {
+          message =
+            "The AI didn't propose a plan yet. Try once more, or share a bit more context first.";
+        }
+        setError(message);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

Setup loop was rejecting every `propose_scenario_plan` / `finalize_setup` call with `7 validation errors for ScenarioPlan / Input should be a valid list`, surfacing in the UI as "The AI didn't propose a plan yet." Two compounding root causes:

1. **Underspecified array `items` schemas.** `narrative_arc` and `injects` were declared as `{"type": "array", "minItems": 1}` with no per-item shape. Claude Haiku improvised and emitted literal `<parameter name="key_objectives"><item>...</item>` XML soup as raw strings, which then failed Pydantic validation against `ScenarioBeat` / `ScenarioInject`. Added explicit nested object schemas mirroring the Pydantic models (`beat`/`label`/`expected_actors` for beats, `trigger`/`type`/`summary` for injects).
2. **`setup` tier `max_tokens=1024` was too small.** Every retry in the failing session logged `stop_reason: max_tokens` — the JSON tool input was being truncated mid-call. A full plan (title, exec summary, ≥3 objectives, ≥3 nested beats with `expected_actors` arrays, 2–3 injects, plus optional arrays) doesn't fit. Bumped the default to 4096 (same as `aar`). Operators can still override via `LLM_MAX_TOKENS_SETUP`.

## Files

- `backend/app/llm/tools.py` — added `_NARRATIVE_BEAT_SCHEMA` and `_SCENARIO_INJECT_SCHEMA` constants and wired them into both `propose_scenario_plan` and `finalize_setup`.
- `backend/app/config.py` — `setup` default `max_tokens` 1024 → 4096 with rationale comment.
- `backend/tests/test_config.py` — updated default-value assertions.

## Test plan

- [ ] Existing tests pass: `cd backend && pytest -q` (couldn't run locally — no pydantic in this env; relies on CI / docker).
- [ ] Manually run a setup → plan flow end-to-end: scenario seed, ~3 setup answers, click "Looks ready — propose the plan". Confirm `propose_scenario_plan` succeeds and the plan view renders with at least 3 beats, 3 objectives, ≥1 inject.
- [ ] Confirm `stop_reason` is no longer `max_tokens` in the LLM call logs for the setup tier on a typical roster.
- [ ] Verify the plan-edit REST endpoint still validates correctly (no regression on `_normalize_plan` / `_validate_plan_completeness`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqo7wLKbYjUZF8oVa2EeRM)_