### PR TITLE
frontend: top action bar + pre-declare roles on intro (#61, #62)

### DIFF
--- a/backend/app/ws/connection_manager.py
+++ b/backend/app/ws/connection_manager.py
@@ -114,6 +114,19 @@ class ConnectionManager:
                 seen[c.role_id] = True
             return list(seen.keys())
 
+    async def connection_count(self, session_id: str) -> int:
+        """Total number of open WS connections (tabs) on this session.
+
+        Distinct from ``connected_role_ids`` which de-dupes by role —
+        a single role with two tabs open counts as 1 in
+        ``connected_role_ids`` but 2 here. The creator surfaces this in
+        the top bar so they can tell at a glance "how many tabs are
+        watching" while facilitating.
+        """
+
+        async with self._lock:
+            return len(self._connections.get(session_id, ()))
+
     async def role_has_other_connections(
         self, session_id: str, role_id: str, *, exclude: _Connection | None = None
     ) -> bool:

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -184,8 +184,17 @@ def register_ws_routes(app: FastAPI) -> None:
         # event after the player has actually disconnected would be
         # misleading. See issue #52.
         connected = await connections.connected_role_ids(session_id)
+        # Total open WS tabs (distinct from ``connected`` role count). The
+        # creator's top bar surfaces this so they can see at a glance how
+        # many participant tabs are watching the session — useful when
+        # facilitating to spot dropped tabs vs stale invitee links.
+        conn_count = await connections.connection_count(session_id)
         await websocket.send_json(
-            {"type": "presence_snapshot", "role_ids": connected}
+            {
+                "type": "presence_snapshot",
+                "role_ids": connected,
+                "connection_count": conn_count,
+            }
         )
         await connections.broadcast(
             session_id,
@@ -193,6 +202,7 @@ def register_ws_routes(app: FastAPI) -> None:
                 "type": "presence",
                 "role_id": payload["role_id"],
                 "active": True,
+                "connection_count": conn_count,
             },
             record=False,
         )
@@ -228,6 +238,13 @@ def register_ws_routes(app: FastAPI) -> None:
             still_connected = await connections.role_has_other_connections(
                 session_id, payload["role_id"]
             )
+            # Recompute the total connection count *after* this conn has
+            # been unregistered so the broadcast reflects the new tab
+            # total. Always emit on disconnect (even when the role is
+            # still connected via another tab) so the count stays
+            # accurate — a creator with two tabs who closes one should
+            # see the count drop in real time.
+            conn_count = await connections.connection_count(session_id)
             if not still_connected:
                 await connections.broadcast(
                     session_id,
@@ -235,6 +252,20 @@ def register_ws_routes(app: FastAPI) -> None:
                         "type": "presence",
                         "role_id": payload["role_id"],
                         "active": False,
+                        "connection_count": conn_count,
+                    },
+                    record=False,
+                )
+            else:
+                # Role still has other tabs — but the tab count changed,
+                # so emit a count-only update for the top-bar chip.
+                await connections.broadcast(
+                    session_id,
+                    {
+                        "type": "presence",
+                        "role_id": payload["role_id"],
+                        "active": True,
+                        "connection_count": conn_count,
                     },
                     record=False,
                 )

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -122,6 +122,13 @@ describe("TopBar (issue #62)", () => {
     backendState: "READY",
     wsStatus: "open" as const,
     godMode: false,
+    // Round 3 telemetry props.
+    turnIndex: null,
+    rationaleCount: 0,
+    connectionCount: null,
+    lastEventAt: null,
+    cost: null,
+    messageCount: 0,
   };
 
   it("renders Start session disabled when plan not finalized", () => {
@@ -217,6 +224,89 @@ describe("TopBar (issue #62)", () => {
     expect(
       screen.queryByRole("button", { name: "View AAR" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("surfaces turn / message / rationale / tabs / cost telemetry chips", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={3}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        turnIndex={4}
+        messageCount={42}
+        rationaleCount={7}
+        connectionCount={5}
+        cost={{
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_read_tokens: 200,
+          cache_creation_tokens: 100,
+          estimated_usd: 0.0234,
+        }}
+      />,
+    );
+    expect(screen.getByText("T#4")).toBeInTheDocument();
+    expect(screen.getByText("42 msgs")).toBeInTheDocument();
+    expect(screen.getByText("Rationale: 7")).toBeInTheDocument();
+    expect(screen.getByText("Tabs: 5")).toBeInTheDocument();
+    expect(screen.getByText("Cost: $0.0234")).toBeInTheDocument();
+  });
+
+  it("renders dash placeholders when telemetry is null", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="setup"
+        playerCount={1}
+        hasFinalizedPlan={false}
+        aarStatus={null}
+      />,
+    );
+    expect(screen.getByText("T#—")).toBeInTheDocument();
+    expect(screen.getByText("Tabs: —")).toBeInTheDocument();
+    expect(screen.getByText("Cost: $—")).toBeInTheDocument();
+    expect(screen.getByText("Last: —")).toBeInTheDocument();
+  });
+
+  it("renders 'Last: <Ns ago' once a lastEventAt timestamp is set", () => {
+    const fiveSecondsAgo = Date.now() - 5_500;
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        lastEventAt={fiveSecondsAgo}
+      />,
+    );
+    expect(screen.getByText(/Last: 5s ago/)).toBeInTheDocument();
+  });
+
+  it("expands the cost chip to show the token breakdown", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        cost={{
+          input_tokens: 12345,
+          output_tokens: 6789,
+          cache_read_tokens: 100,
+          cache_creation_tokens: 50,
+          estimated_usd: 1.2345,
+        }}
+      />,
+    );
+    const summary = screen.getByText("Cost: $1.2345");
+    fireEvent.click(summary);
+    expect(screen.getByText("Cost — token breakdown")).toBeInTheDocument();
+    expect(screen.getByText("12,345")).toBeInTheDocument();
+    expect(screen.getByText("6,789")).toBeInTheDocument();
   });
 
   it("always renders 'Start a new session' regardless of phase", () => {

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Facilitator, SessionActionBar } from "../pages/Facilitator";
+import { api } from "../api/client";
+
+// The intro page renders both an `<ol>` ("What to expect") and the chip
+// list in the fieldset, so a bare `getByRole("list")` is ambiguous.
+// Scope every chip-list query to the fieldset group via its legend.
+function getChipList(): HTMLElement {
+  const fieldset = screen.getByRole("group", { name: /Roles to invite/i });
+  return within(fieldset).getByRole("list");
+}
+
+describe("Facilitator intro — Roles to invite (issue #61)", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("seeds three default invitee chips", () => {
+    render(<Facilitator />);
+    const list = getChipList();
+    expect(within(list).getByText("IR Lead")).toBeInTheDocument();
+    expect(within(list).getByText("Legal")).toBeInTheDocument();
+    expect(within(list).getByText("Comms")).toBeInTheDocument();
+  });
+
+  it("adds a new role via the Add role button", () => {
+    render(<Facilitator />);
+    const draft = screen.getByLabelText("New role label") as HTMLInputElement;
+    fireEvent.change(draft, { target: { value: "SOC Analyst" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add role" }));
+    expect(within(getChipList()).getByText("SOC Analyst")).toBeInTheDocument();
+    expect(draft.value).toBe("");
+  });
+
+  it("adds a new role via the Enter key without submitting the form", () => {
+    const createSpy = vi.spyOn(api, "createSession");
+    render(<Facilitator />);
+    const draft = screen.getByLabelText("New role label") as HTMLInputElement;
+    fireEvent.change(draft, { target: { value: "Threat Intel" } });
+    fireEvent.keyDown(draft, { key: "Enter" });
+    expect(within(getChipList()).getByText("Threat Intel")).toBeInTheDocument();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicates case-insensitively without altering the chip list", () => {
+    render(<Facilitator />);
+    const draft = screen.getByLabelText("New role label") as HTMLInputElement;
+    fireEvent.change(draft, { target: { value: "legal" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add role" }));
+    expect(within(getChipList()).getAllByText(/legal/i)).toHaveLength(1);
+    expect(draft.value).toBe("");
+  });
+
+  it("ignores blank / whitespace-only role labels", () => {
+    render(<Facilitator />);
+    const before = getChipList().children.length;
+    const draft = screen.getByLabelText("New role label") as HTMLInputElement;
+    const addButton = screen.getByRole("button", { name: "Add role" });
+    expect(addButton).toBeDisabled();
+    fireEvent.change(draft, { target: { value: "   " } });
+    fireEvent.click(addButton);
+    fireEvent.keyDown(draft, { key: "Enter" });
+    expect(getChipList().children.length).toBe(before);
+  });
+
+  it("removes a chip when the X button is clicked", () => {
+    render(<Facilitator />);
+    fireEvent.click(screen.getByLabelText("Remove Legal"));
+    const list = getChipList();
+    expect(within(list).queryByText("Legal")).not.toBeInTheDocument();
+    expect(within(list).getByText("IR Lead")).toBeInTheDocument();
+  });
+
+  it("Clear all empties the chip list and shows the empty state", () => {
+    render(<Facilitator />);
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    const fieldset = screen.getByRole("group", { name: /Roles to invite/i });
+    expect(within(fieldset).queryByRole("list")).not.toBeInTheDocument();
+    expect(
+      within(fieldset).getByText(/No invitee roles yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("Reset to defaults restores IR Lead/Legal/Comms after clearing", () => {
+    render(<Facilitator />);
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset to defaults" }));
+    const list = getChipList();
+    expect(within(list).getByText("IR Lead")).toBeInTheDocument();
+    expect(within(list).getByText("Legal")).toBeInTheDocument();
+    expect(within(list).getByText("Comms")).toBeInTheDocument();
+  });
+
+  it("warns when the creator label collides with an invitee chip", () => {
+    render(<Facilitator />);
+    const labelInput = screen.getByPlaceholderText(
+      /Your role label/i,
+    ) as HTMLInputElement;
+    fireEvent.change(labelInput, { target: { value: "IR Lead" } });
+    expect(
+      screen.getByText(/won't be auto-added as a separate invitee/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SessionActionBar (issue #62)", () => {
+  const baseProps = {
+    onStart: vi.fn(),
+    onForceAdvance: vi.fn(),
+    onEnd: vi.fn(),
+    onNewSession: vi.fn(),
+    onViewAar: vi.fn(),
+    busy: false,
+  };
+
+  it("renders Start session disabled when plan not finalized", () => {
+    render(
+      <SessionActionBar
+        {...baseProps}
+        phase="setup"
+        playerCount={3}
+        hasFinalizedPlan={false}
+        aarStatus={null}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Start session" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders Start session disabled when fewer than 2 players", () => {
+    render(
+      <SessionActionBar
+        {...baseProps}
+        phase="ready"
+        playerCount={1}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Start session" })).toBeDisabled();
+  });
+
+  it("enables Start session when plan finalized and ≥2 players", () => {
+    render(
+      <SessionActionBar
+        {...baseProps}
+        phase="ready"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Start session" });
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+    expect(baseProps.onStart).toHaveBeenCalled();
+  });
+
+  it("renders force-advance + end buttons during play", () => {
+    render(
+      <SessionActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={3}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "AI: take next beat" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "End session" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Start session" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders View AAR when ended phase + AAR ready", () => {
+    render(
+      <SessionActionBar
+        {...baseProps}
+        phase="ended"
+        playerCount={3}
+        hasFinalizedPlan={true}
+        aarStatus="ready"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "View AAR" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders AAR generating status when ended phase + AAR pending", () => {
+    render(
+      <SessionActionBar
+        {...baseProps}
+        phase="ended"
+        playerCount={3}
+        hasFinalizedPlan={true}
+        aarStatus="pending"
+      />,
+    );
+    expect(screen.getByText(/AAR generating/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "View AAR" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("always renders 'Start a new session' regardless of phase", () => {
+    for (const phase of ["setup", "ready", "play", "ended"] as const) {
+      const { unmount } = render(
+        <SessionActionBar
+          {...baseProps}
+          phase={phase}
+          playerCount={2}
+          hasFinalizedPlan={true}
+          aarStatus="ready"
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Start a new session" }),
+      ).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -129,6 +129,8 @@ describe("TopBar (issue #62)", () => {
     lastEventAt: null,
     cost: null,
     messageCount: 0,
+    // Round 4 — LLM tier chip (#9).
+    activeTiers: [] as string[],
   };
 
   it("renders Start session disabled when plan not finalized", () => {
@@ -283,6 +285,48 @@ describe("TopBar (issue #62)", () => {
       />,
     );
     expect(screen.getByText(/Last: 5s ago/)).toBeInTheDocument();
+  });
+
+  it("renders 'LLM: idle' when no LLM calls are in flight", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+      />,
+    );
+    expect(screen.getByText("LLM: idle")).toBeInTheDocument();
+  });
+
+  it("renders 'LLM: <tier>' when a single tier is active", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        activeTiers={["play"]}
+      />,
+    );
+    expect(screen.getByText("LLM: play")).toBeInTheDocument();
+    expect(screen.queryByText("LLM: idle")).not.toBeInTheDocument();
+  });
+
+  it("joins multiple concurrent tiers with '+' (e.g. guardrail + play)", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        activeTiers={["guardrail", "play"]}
+      />,
+    );
+    expect(screen.getByText("LLM: guardrail+play")).toBeInTheDocument();
   });
 
   it("expands the cost chip to show the token breakdown", () => {

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { Facilitator, SessionActionBar } from "../pages/Facilitator";
+import { Facilitator, TopBar } from "../pages/Facilitator";
 import { api } from "../api/client";
 
 // The intro page renders both an `<ol>` ("What to expect") and the chip
@@ -110,19 +110,23 @@ describe("Facilitator intro — Roles to invite (issue #61)", () => {
   });
 });
 
-describe("SessionActionBar (issue #62)", () => {
+describe("TopBar (issue #62)", () => {
   const baseProps = {
     onStart: vi.fn(),
     onForceAdvance: vi.fn(),
     onEnd: vi.fn(),
     onNewSession: vi.fn(),
     onViewAar: vi.fn(),
+    onToggleGodMode: vi.fn(),
     busy: false,
+    backendState: "READY",
+    wsStatus: "open" as const,
+    godMode: false,
   };
 
   it("renders Start session disabled when plan not finalized", () => {
     render(
-      <SessionActionBar
+      <TopBar
         {...baseProps}
         phase="setup"
         playerCount={3}
@@ -136,7 +140,7 @@ describe("SessionActionBar (issue #62)", () => {
 
   it("renders Start session disabled when fewer than 2 players", () => {
     render(
-      <SessionActionBar
+      <TopBar
         {...baseProps}
         phase="ready"
         playerCount={1}
@@ -149,7 +153,7 @@ describe("SessionActionBar (issue #62)", () => {
 
   it("enables Start session when plan finalized and ≥2 players", () => {
     render(
-      <SessionActionBar
+      <TopBar
         {...baseProps}
         phase="ready"
         playerCount={2}
@@ -165,7 +169,7 @@ describe("SessionActionBar (issue #62)", () => {
 
   it("renders force-advance + end buttons during play", () => {
     render(
-      <SessionActionBar
+      <TopBar
         {...baseProps}
         phase="play"
         playerCount={3}
@@ -186,7 +190,7 @@ describe("SessionActionBar (issue #62)", () => {
 
   it("renders View AAR when ended phase + AAR ready", () => {
     render(
-      <SessionActionBar
+      <TopBar
         {...baseProps}
         phase="ended"
         playerCount={3}
@@ -201,7 +205,7 @@ describe("SessionActionBar (issue #62)", () => {
 
   it("renders AAR generating status when ended phase + AAR pending", () => {
     render(
-      <SessionActionBar
+      <TopBar
         {...baseProps}
         phase="ended"
         playerCount={3}
@@ -218,7 +222,7 @@ describe("SessionActionBar (issue #62)", () => {
   it("always renders 'Start a new session' regardless of phase", () => {
     for (const phase of ["setup", "ready", "play", "ended"] as const) {
       const { unmount } = render(
-        <SessionActionBar
+        <TopBar
           {...baseProps}
           phase={phase}
           playerCount={2}

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -54,9 +54,9 @@ export type ServerEvent =
       type: "presence";
       role_id: string;
       active: boolean;
-      /** Total open WS tabs on this session (added in PR #66 round 3 for
-       *  the top-bar "Tabs: N" chip). May be undefined when received from
-       *  an older backend; treat as "unknown". */
+      /** Total open WS tabs on this session, used for the top-bar
+       *  "Tabs: N" chip. May be undefined when received from an older
+       *  backend; treat as "unknown". */
       connection_count?: number;
     }
   | {

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -50,8 +50,20 @@ export type ServerEvent =
       for_role_id?: string | null;
     }
   | { type: "typing"; role_id: string; typing: boolean }
-  | { type: "presence"; role_id: string; active: boolean }
-  | { type: "presence_snapshot"; role_ids: string[] }
+  | {
+      type: "presence";
+      role_id: string;
+      active: boolean;
+      /** Total open WS tabs on this session (added in PR #66 round 3 for
+       *  the top-bar "Tabs: N" chip). May be undefined when received from
+       *  an older backend; treat as "unknown". */
+      connection_count?: number;
+    }
+  | {
+      type: "presence_snapshot";
+      role_ids: string[];
+      connection_count?: number;
+    }
   | {
       type: "decision_logged";
       entry: {
@@ -180,9 +192,11 @@ export class WsClient {
           case "presence":
             safe.role_id = parsed.role_id;
             safe.active = parsed.active;
+            safe.connection_count = parsed.connection_count;
             break;
           case "presence_snapshot":
             safe.role_count = parsed.role_ids?.length ?? 0;
+            safe.connection_count = parsed.connection_count;
             break;
           case "decision_logged":
             // Don't log the rationale text itself — it's debug content

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1030,21 +1030,15 @@ export function Facilitator() {
           onAcknowledge={() => setCriticalBanner(null)}
         />
       ) : null}
-      <StatusBar
+      {/* Issue #62 (round 2): consolidated top bar — debug telemetry +
+          phase CTA + meta actions on a single row. See ``TopBar`` for
+          layout rationale. */}
+      <TopBar
         phase={phase}
         backendState={snapshot.state}
         wsStatus={wsStatus}
-        busy={busy}
-        busyMessage={busyMessage}
-        onToggleGodMode={() => setGodMode((g) => !g)}
         godMode={godMode}
-      />
-      {/* Issue #62: pin the session controls (Start / Force-advance / End /
-          View AAR / New session) to a horizontal bar at the very top of
-          the layout so the primary CTA is always reachable on narrow
-          viewports without scrolling past the role roster. */}
-      <SessionActionBar
-        phase={phase}
+        onToggleGodMode={() => setGodMode((g) => !g)}
         onStart={handleStart}
         onForceAdvance={handleForceAdvance}
         onEnd={handleEnd}
@@ -1116,6 +1110,7 @@ export function Facilitator() {
               onSkipSetup={handleSkipSetup}
               onPickOption={(opt) => callSetup(opt, "Sending your selection to the AI…")}
               busy={busy}
+              busyMessage={busyMessage}
             />
           ) : null}
           {phase === "ready" ? (
@@ -1213,6 +1208,10 @@ export function Facilitator() {
             // transcript length. ``shrink-0`` here is what keeps Submit
             // reachable on a 30-message exercise.
             <div className="shrink-0">
+              {/* Operator-action busy chip — moved out of the top bar so
+                  the "is the AI thinking or stuck?" signal sits where
+                  the operator's eye already is during a turn. */}
+              <BusyChip busy={busy} message={busyMessage} />
               {!isMyTurn && snapshot.current_turn?.active_role_ids?.length ? (
                 <WaitingChip
                   activeRoleIds={activeRoleIds}
@@ -1311,73 +1310,218 @@ export function Facilitator() {
   );
 }
 
-function StatusBar({
-  phase,
-  backendState,
-  wsStatus,
-  busy,
-  busyMessage,
-  onToggleGodMode,
-  godMode,
-}: {
+/**
+ * Issue #62 (round 2): single consolidated top bar that combines the
+ * pre-merge ``StatusBar`` (debug pills + God Mode) with the
+ * ``SessionActionBar`` (phase CTA / supporting buttons / "Start a new
+ * session"). Two stacked bars wasted vertical space and read as
+ * redundant; one bar with the CTA on the left and debug telemetry on the
+ * right keeps every datum we surface today while halving the chrome
+ * height. Mobile lets the bar wrap naturally — content rolls onto
+ * additional rows but still sits at the top of the viewport.
+ *
+ * Layout:
+ *   [title] [phase CTA] [supporting buttons] [helper text]
+ *                          ml-auto →
+ *   [state pill] [ws pill] [build SHA] [God Mode] [Start a new session]
+ *
+ * The "AI is thinking…" / generic-busy chip lives next to the Composer
+ * (see ``BusyChip`` below) per the operator's instruction to keep the
+ * stuck-vs-thinking signal at the bottom of the transcript where their
+ * eye already is during a turn.
+ */
+export function TopBar(props: {
   phase: Phase;
   backendState: string;
   wsStatus: "connecting" | "open" | "closed" | "error";
-  busy: boolean;
-  onToggleGodMode: () => void;
   godMode: boolean;
-  busyMessage: string | null;
+  onToggleGodMode: () => void;
+  // Session-action props (was SessionActionBar):
+  onStart: () => void;
+  onForceAdvance: () => void;
+  onEnd: () => void;
+  onNewSession: () => void;
+  /** Opens the single AAR popup (which contains the actual Download button). */
+  onViewAar: () => void;
+  playerCount: number;
+  hasFinalizedPlan: boolean;
+  /** "pending" | "generating" | "ready" | "failed" — null while loading. */
+  aarStatus: string | null;
+  busy: boolean;
 }) {
   const wsColour =
-    wsStatus === "open"
+    props.wsStatus === "open"
       ? "text-emerald-300"
-      : wsStatus === "connecting"
+      : props.wsStatus === "connecting"
         ? "text-amber-300"
         : "text-red-300";
+  const canStart =
+    (props.phase === "ready" || props.phase === "setup") &&
+    props.hasFinalizedPlan &&
+    props.playerCount >= 2;
+
   return (
-    <header className="border-b border-slate-800 bg-slate-900/70 px-4 py-2 text-xs">
-      <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-4">
+    <header
+      role="banner"
+      className="border-b border-slate-800 bg-slate-900/70 px-4 py-2 text-xs"
+    >
+      <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center gap-2">
+        {/* Left cluster: title + phase-conditional primary actions. The
+            CTA sits early in the row so an LTR reader's eye lands on the
+            verb before the debug pills. */}
         <span className="font-semibold uppercase tracking-widest text-slate-400">
           Facilitator
         </span>
-        <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-200">
-          state: {backendState} · phase: {phase}
-        </span>
-        <span className={wsColour}>● ws: {wsStatus}</span>
-        {/* Build identification — surfaced so a creator filing a bug
-            report can tell us which version they're on without opening
-            DevTools. Vite injects ``__ATF_GIT_SHA__`` at build time. */}
-        <span
-          className="rounded bg-slate-800 px-2 py-0.5 font-mono text-[10px] text-slate-400"
-          title={`Build: ${__ATF_GIT_SHA__} · ${__ATF_BUILD_TS__}`}
-        >
-          v {__ATF_GIT_SHA__}
-        </span>
-        {busy ? (
-          <span
-            role="status"
-            aria-live="polite"
-            className="inline-flex items-center gap-2 rounded bg-sky-900/40 px-2 py-0.5 text-sky-200"
-          >
-            <Spinner /> {busyMessage ?? "Working…"}
-          </span>
+
+        {props.phase === "ready" || props.phase === "setup" ? (
+          <>
+            <button
+              type="button"
+              onClick={props.onStart}
+              disabled={!canStart || props.busy}
+              className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+              title={
+                !props.hasFinalizedPlan
+                  ? "Finalize the plan first"
+                  : props.playerCount < 2
+                    ? "Add at least 2 player roles"
+                    : ""
+              }
+            >
+              Start session
+            </button>
+            <span className="text-slate-400">
+              Players: {props.playerCount} (need ≥ 2 to start)
+            </span>
+          </>
         ) : null}
-        <button
-          type="button"
-          onClick={onToggleGodMode}
-          aria-pressed={godMode}
-          className={
-            "ml-auto rounded border px-2 py-0.5 font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-purple-300 " +
-            (godMode
-              ? "border-purple-500 bg-purple-700/40 text-purple-100"
-              : "border-purple-700/40 text-purple-300 hover:bg-purple-900/30")
-          }
-          title="Toggle full debug overlay (audit log, system prompt, etc). Creator-only."
-        >
-          {godMode ? "● God Mode" : "○ God Mode"}
-        </button>
+
+        {props.phase === "play" ? (
+          <>
+            <button
+              type="button"
+              onClick={props.onForceAdvance}
+              disabled={props.busy}
+              className="rounded border border-emerald-500 bg-emerald-900/30 px-3 py-1 text-sm font-semibold text-emerald-100 hover:bg-emerald-700/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:opacity-50"
+              title="Hand the turn to the AI now. Use when conversation has stalled OR when one player is unresponsive."
+            >
+              AI: take next beat
+            </button>
+            <button
+              type="button"
+              onClick={props.onEnd}
+              disabled={props.busy}
+              className="rounded border border-red-500 px-3 py-1 text-sm font-semibold text-red-300 hover:bg-red-900/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-300 disabled:opacity-50"
+            >
+              End session
+            </button>
+          </>
+        ) : null}
+
+        {props.phase === "ended"
+          ? (() => {
+              if (props.aarStatus === "ready") {
+                return (
+                  <button
+                    type="button"
+                    onClick={props.onViewAar}
+                    className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300"
+                  >
+                    View AAR
+                  </button>
+                );
+              }
+              if (props.aarStatus === "failed") {
+                return (
+                  <span
+                    role="status"
+                    className="inline-flex items-center gap-1 rounded border border-red-500/60 bg-red-950/30 px-2 py-0.5 text-red-200"
+                  >
+                    AAR failed — see Retry in main panel.
+                  </span>
+                );
+              }
+              return (
+                <span
+                  role="status"
+                  aria-live="polite"
+                  className="inline-flex items-center gap-1.5 rounded bg-slate-800/80 px-2 py-0.5 text-slate-300"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400"
+                  />
+                  AAR generating… (~30 s)
+                </span>
+              );
+            })()
+          : null}
+
+        {/* Right cluster: debug telemetry + meta actions. Wrapped in its
+            own container so ``ml-auto`` reliably pushes the whole group
+            to the row's end (and stays grouped when the row wraps on
+            mobile). Per operator request, every debug datum currently
+            shown is preserved — only the layout changed. */}
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-200">
+            state: {props.backendState} · phase: {props.phase}
+          </span>
+          <span className={wsColour}>● ws: {props.wsStatus}</span>
+          {/* Build identification — surfaced so a creator filing a bug
+              report can tell us which version they're on without opening
+              DevTools. Vite injects ``__ATF_GIT_SHA__`` at build time. */}
+          <span
+            className="rounded bg-slate-800 px-2 py-0.5 font-mono text-[10px] text-slate-400"
+            title={`Build: ${__ATF_GIT_SHA__} · ${__ATF_BUILD_TS__}`}
+          >
+            v {__ATF_GIT_SHA__}
+          </span>
+          <button
+            type="button"
+            onClick={props.onToggleGodMode}
+            aria-pressed={props.godMode}
+            className={
+              "rounded border px-2 py-0.5 font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-purple-300 " +
+              (props.godMode
+                ? "border-purple-500 bg-purple-700/40 text-purple-100"
+                : "border-purple-700/40 text-purple-300 hover:bg-purple-900/30")
+            }
+            title="Toggle full debug overlay (audit log, system prompt, etc). Creator-only."
+          >
+            {props.godMode ? "● God Mode" : "○ God Mode"}
+          </button>
+          <button
+            type="button"
+            onClick={props.onNewSession}
+            disabled={props.busy}
+            className="rounded border border-slate-600 px-2 py-0.5 text-slate-300 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-300 disabled:opacity-50"
+            title="End the current session (if any) and return to the new-session form."
+          >
+            Start a new session
+          </button>
+        </div>
       </div>
     </header>
+  );
+}
+
+/**
+ * Operator-action busy chip. Pre-merge this lived in the top bar; the
+ * operator preferred it pinned near the transcript bottom (where their
+ * eye is during a turn) so it reads as a "is the AI stuck or thinking?"
+ * signal rather than disappearing into the chrome at the top of the
+ * page. Renders nothing when no operation is in flight.
+ */
+function BusyChip({ busy, message }: { busy: boolean; message: string | null }) {
+  if (!busy) return null;
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      className="mb-1 inline-flex shrink-0 items-center gap-2 self-start rounded bg-sky-900/40 px-2 py-1 text-xs text-sky-200"
+    >
+      <Spinner /> {message ?? "Working…"}
+    </span>
   );
 }
 
@@ -1527,125 +1671,6 @@ function WaitingChip({
  * viewport the Start button was below the fold, requiring a scroll past
  * the entire role roster + activity panel to reach it.
  */
-export function SessionActionBar(props: {
-  phase: Phase;
-  onStart: () => void;
-  onForceAdvance: () => void;
-  onEnd: () => void;
-  onNewSession: () => void;
-  /** Opens the single AAR popup (which contains the actual Download button). */
-  onViewAar: () => void;
-  playerCount: number;
-  hasFinalizedPlan: boolean;
-  /** "pending" | "generating" | "ready" | "failed" — null while loading. */
-  aarStatus: string | null;
-  busy: boolean;
-}) {
-  const canStart =
-    (props.phase === "ready" || props.phase === "setup") &&
-    props.hasFinalizedPlan &&
-    props.playerCount >= 2;
-
-  return (
-    <div className="border-b border-slate-800 bg-slate-900/60 px-4 py-2">
-      <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center gap-2 text-sm">
-        {props.phase === "ready" || props.phase === "setup" ? (
-          <>
-            <button
-              onClick={props.onStart}
-              disabled={!canStart || props.busy}
-              className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
-              title={
-                !props.hasFinalizedPlan
-                  ? "Finalize the plan first"
-                  : props.playerCount < 2
-                    ? "Add at least 2 player roles"
-                    : ""
-              }
-            >
-              Start session
-            </button>
-            <span className="text-xs text-slate-400">
-              Players: {props.playerCount} (need ≥ 2 to start)
-            </span>
-          </>
-        ) : null}
-
-        {props.phase === "play" ? (
-          <>
-            <button
-              onClick={props.onForceAdvance}
-              disabled={props.busy}
-              className="rounded border border-emerald-500 bg-emerald-900/30 px-3 py-1 text-sm font-semibold text-emerald-100 hover:bg-emerald-700/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:opacity-50"
-              title="Hand the turn to the AI now. Use when conversation has stalled OR when one player is unresponsive."
-            >
-              AI: take next beat
-            </button>
-            <button
-              onClick={props.onEnd}
-              disabled={props.busy}
-              className="rounded border border-red-500 px-3 py-1 text-sm font-semibold text-red-300 hover:bg-red-900/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-300 disabled:opacity-50"
-            >
-              End session
-            </button>
-            <span className="text-[11px] leading-tight text-slate-500">
-              "Take next beat" marks the current player turn complete
-              (skipping any missing voices).
-            </span>
-          </>
-        ) : null}
-
-        {props.phase === "ended"
-          ? (() => {
-              if (props.aarStatus === "ready") {
-                return (
-                  <button
-                    onClick={props.onViewAar}
-                    className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300"
-                  >
-                    View AAR
-                  </button>
-                );
-              }
-              if (props.aarStatus === "failed") {
-                return (
-                  <span
-                    role="status"
-                    className="inline-flex items-center gap-1 rounded border border-red-500/60 bg-red-950/30 px-2 py-1 text-xs text-red-200"
-                  >
-                    AAR generation failed — use Retry in the main panel.
-                  </span>
-                );
-              }
-              return (
-                <span
-                  role="status"
-                  aria-live="polite"
-                  className="inline-flex items-center gap-1.5 rounded bg-slate-800/80 px-2 py-1 text-xs text-slate-300"
-                >
-                  <span
-                    aria-hidden="true"
-                    className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400"
-                  />
-                  AAR generating… (~30 s)
-                </span>
-              );
-            })()
-          : null}
-
-        <button
-          onClick={props.onNewSession}
-          disabled={props.busy}
-          className="ml-auto rounded border border-slate-600 px-3 py-1 text-xs text-slate-300 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-300 disabled:opacity-50"
-          title="End the current session (if any) and return to the new-session form."
-        >
-          Start a new session
-        </button>
-      </div>
-    </div>
-  );
-}
-
 function SetupView({
   snapshot,
   setupReply,
@@ -1656,6 +1681,7 @@ function SetupView({
   onSkipSetup,
   onPickOption,
   busy,
+  busyMessage,
 }: {
   snapshot: SessionSnapshot;
   setupReply: string;
@@ -1666,6 +1692,7 @@ function SetupView({
   onSkipSetup: () => void;
   onPickOption: (option: string) => void;
   busy: boolean;
+  busyMessage: string | null;
 }) {
   const hasPlan = Boolean(snapshot.plan);
   const notes = snapshot.setup_notes ?? [];
@@ -1691,6 +1718,12 @@ function SetupView({
       ) : null}
 
       <SetupChat notes={notes} busy={busy} onPickOption={onPickOption} />
+
+      {/* Operator-action busy chip — pinned with the reply form so the
+          "is the AI thinking?" signal stays where the operator's eye is.
+          See the play-phase BusyChip above the Composer for the same
+          pattern. */}
+      <BusyChip busy={busy} message={busyMessage} />
 
       <form onSubmit={onSubmit} className="flex flex-col gap-2">
         <textarea

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -171,6 +171,16 @@ export function Facilitator() {
   // local state with the canonical server list to avoid drift if a
   // WebSocket frame was missed during reconnect.
   const [decisionLog, setDecisionLog] = useState<DecisionLogEntry[]>([]);
+  // Issue #62 round 3 — per-bar telemetry. ``lastEventAt`` is bumped on
+  // every incoming WS frame so the top bar can render "Last: Xs ago",
+  // which fills the diagnostic gap between the binary ``ws: open`` pill
+  // (the socket is up) and "is anything actually flowing?". A frozen
+  // counter is a strong signal the backend went quiet even when TCP is
+  // still healthy. ``connectionCount`` is server-pushed via the existing
+  // ``presence`` / ``presence_snapshot`` events and tells the creator
+  // how many tabs are currently watching the session.
+  const [lastEventAt, setLastEventAt] = useState<number | null>(null);
+  const [connectionCount, setConnectionCount] = useState<number | null>(null);
   const wsRef = useRef<WsClient | null>(null);
   const forceAdvanceTimerRef = useRef<number | null>(null);
   useEffect(() => {
@@ -338,6 +348,12 @@ export function Facilitator() {
   }, [state?.sessionId, state?.token]);
 
   function handleEvent(evt: ServerEvent) {
+    // Top-bar "Last: Xs ago" — bump on every frame regardless of type.
+    // We *don't* try to filter to "interesting" events here because the
+    // signal we're surfacing is "is the connection delivering anything?";
+    // typing pings, heartbeats and presence updates are all valid
+    // liveness evidence.
+    setLastEventAt(Date.now());
     switch (evt.type) {
       case "message_chunk":
         setStreamingText((t) => t + evt.text);
@@ -419,9 +435,15 @@ export function Facilitator() {
           else next.delete(evt.role_id);
           return next;
         });
+        if (typeof evt.connection_count === "number") {
+          setConnectionCount(evt.connection_count);
+        }
         break;
       case "presence_snapshot":
         setPresence(new Set(evt.role_ids));
+        if (typeof evt.connection_count === "number") {
+          setConnectionCount(evt.connection_count);
+        }
         break;
       case "typing":
         setTyping((prev) => {
@@ -664,6 +686,8 @@ export function Facilitator() {
     setDecisionLog([]);
     setPresence(new Set());
     setCost(null);
+    setLastEventAt(null);
+    setConnectionCount(null);
     setSetupReply("");
     setError(null);
   }
@@ -1048,6 +1072,12 @@ export function Facilitator() {
         hasFinalizedPlan={Boolean(snapshot.plan)}
         aarStatus={snapshot.aar_status ?? null}
         busy={busy}
+        turnIndex={snapshot.current_turn?.index ?? null}
+        rationaleCount={decisionLog.length}
+        connectionCount={connectionCount}
+        lastEventAt={lastEventAt}
+        cost={cost ?? snapshot.cost}
+        messageCount={snapshot.messages.length}
       />
       <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-4 p-4 lg:min-h-0 lg:grid-cols-[280px_1fr_280px] lg:overflow-hidden">
         <aside className="flex flex-col gap-4 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
@@ -1075,7 +1105,6 @@ export function Facilitator() {
             busy={busy || forceAdvanceCooldown}
           />
           <DecisionLogPanel entries={decisionLog} />
-          <CostMeter cost={cost ?? snapshot.cost} />
         </aside>
 
         <section className="flex min-w-0 flex-col gap-3 lg:min-h-0 lg:overflow-hidden">
@@ -1348,6 +1377,21 @@ export function TopBar(props: {
   /** "pending" | "generating" | "ready" | "failed" — null while loading. */
   aarStatus: string | null;
   busy: boolean;
+  // Round 3 telemetry — see ``Facilitator`` state for source-of-truth
+  // notes. Each prop is optional / nullable so the bar still renders
+  // before the first WS frame / snapshot fetch lands.
+  /** ``snapshot.current_turn?.index`` — null when no turn is active. */
+  turnIndex: number | null;
+  /** ``decisionLog.length`` — count of AI rationale entries logged. */
+  rationaleCount: number;
+  /** Server-pushed total open WS tabs on this session, or null if unknown. */
+  connectionCount: number | null;
+  /** ``Date.now()`` of the last received WS frame; null until first frame. */
+  lastEventAt: number | null;
+  /** Latest cost snapshot — drives the click-to-expand chip. */
+  cost: CostSnapshot | null;
+  /** ``snapshot.messages.length`` — raw message-count debug telemetry. */
+  messageCount: number;
 }) {
   const wsColour =
     props.wsStatus === "open"
@@ -1359,6 +1403,29 @@ export function TopBar(props: {
     (props.phase === "ready" || props.phase === "setup") &&
     props.hasFinalizedPlan &&
     props.playerCount >= 2;
+  // ``Last: Xs ago`` chip — re-render once a second so the displayed
+  // delta stays fresh without bumping component state from outside. We
+  // tick a meaningless integer; React diffs the rendered string. The
+  // 1 s cadence matches the resolution of the data we have (Date.now()
+  // is millisecond-precise but a sub-second indicator would just look
+  // jittery).
+  const [, _setTick] = useState(0);
+  useEffect(() => {
+    if (props.lastEventAt === null) return;
+    const id = setInterval(() => _setTick((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [props.lastEventAt]);
+  const lastEventLabel = props.lastEventAt === null
+    ? "—"
+    : (() => {
+        const ms = Math.max(0, Date.now() - props.lastEventAt);
+        if (ms < 1000) return "<1s ago";
+        const s = Math.floor(ms / 1000);
+        if (s < 60) return `${s}s ago`;
+        const m = Math.floor(s / 60);
+        if (m < 60) return `${m}m ago`;
+        return `${Math.floor(m / 60)}h ago`;
+      })();
 
   return (
     <header
@@ -1463,10 +1530,51 @@ export function TopBar(props: {
             mobile). Per operator request, every debug datum currently
             shown is preserved — only the layout changed. */}
         <div className="ml-auto flex flex-wrap items-center gap-2">
+          {/* Turn / message / rationale / tabs / last-event chips. All
+              read straight off existing snapshot + WS state; no extra
+              round-trip. Useful for "what's happening?" diagnostics
+              while the app is under active development. */}
+          <span
+            className="rounded bg-slate-800 px-2 py-0.5 text-slate-200"
+            title="Current turn index from snapshot.current_turn.index"
+          >
+            T#{props.turnIndex ?? "—"}
+          </span>
+          <span
+            className="rounded bg-slate-800 px-2 py-0.5 text-slate-200"
+            title="Total messages on the session (snapshot.messages.length)"
+          >
+            {props.messageCount} msgs
+          </span>
+          <span
+            className="rounded bg-slate-800 px-2 py-0.5 text-slate-200"
+            title="AI rationale entries logged via record_decision_rationale"
+          >
+            Rationale: {props.rationaleCount}
+          </span>
+          <span
+            className="rounded bg-slate-800 px-2 py-0.5 text-slate-200"
+            title="Total open WebSocket tabs watching this session (server-reported)"
+          >
+            Tabs: {props.connectionCount ?? "—"}
+          </span>
+          <span
+            className="rounded bg-slate-800 px-2 py-0.5 text-slate-300"
+            title="Time since the last WebSocket frame arrived. Stalls here mean the connection is silent even if ws: open."
+          >
+            Last: {lastEventLabel}
+          </span>
+          {/* Cost: click-to-expand chip. The summary shows the dollar
+              amount; the disclosure body shows the token breakdown
+              (mirrors the old sidebar CostMeter, but inline). Native
+              <details> gives focus management + Esc-to-collapse for
+              free; the popup positions absolutely so it overlays the
+              page chrome below the bar without pushing layout. */}
+          <CostChip cost={props.cost} />
+          <span className={wsColour}>● ws: {props.wsStatus}</span>
           <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-200">
             state: {props.backendState} · phase: {props.phase}
           </span>
-          <span className={wsColour}>● ws: {props.wsStatus}</span>
           {/* Build identification — surfaced so a creator filing a bug
               report can tell us which version they're on without opening
               DevTools. Vite injects ``__ATF_GIT_SHA__`` at build time. */}
@@ -1534,23 +1642,73 @@ function Spinner() {
   );
 }
 
-function CostMeter({ cost }: { cost: CostSnapshot | null }) {
-  if (!cost) return null;
-  return (
-    <div className="rounded border border-slate-700 bg-slate-900 p-2 text-xs text-slate-300">
-      <p className="uppercase tracking-widest text-slate-500">Cost (creator only)</p>
-      <p>
-        in {cost.input_tokens.toLocaleString()} · out {cost.output_tokens.toLocaleString()} · cache_r{" "}
-        {cost.cache_read_tokens.toLocaleString()}
-      </p>
-      <p className="font-semibold text-emerald-300">≈ ${cost.estimated_usd.toFixed(4)}</p>
-      <p
-        className="mt-0.5 text-[10px] leading-tight text-slate-500"
-        title="Anthropic API spend, attributed to the operator's ANTHROPIC_API_KEY. Not billed to participants."
+/**
+ * Top-bar cost chip with a click-to-expand disclosure (Anthropic
+ * plan-usage popup style). Replaces the old ``CostMeter`` sidebar card —
+ * the dollar number now lives in the always-visible debug strip and
+ * clicking it reveals the token breakdown that previously took up a
+ * fixed sidebar slot. Native ``<details>`` gives keyboard + screen
+ * reader behavior for free; ``open`` is internal to the element.
+ */
+function CostChip({ cost }: { cost: CostSnapshot | null }) {
+  if (!cost) {
+    // Render a placeholder chip so the bar's column count is stable
+    // before the first ``cost_updated`` arrives. The "Cost: $—" form
+    // also tells the creator the channel exists but is empty rather
+    // than missing.
+    return (
+      <span
+        className="rounded bg-slate-800 px-2 py-0.5 text-slate-400"
+        title="No cost data yet — first LLM call will populate this."
       >
-        Charged to the operator's Anthropic key. Cumulative for this session.
-      </p>
-    </div>
+        Cost: $—
+      </span>
+    );
+  }
+  return (
+    <details className="relative">
+      <summary
+        className="cursor-pointer list-none rounded bg-slate-800 px-2 py-0.5 font-semibold text-emerald-300 hover:bg-slate-700/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300"
+        title="Cumulative Anthropic API spend for this session. Click to expand the token breakdown."
+      >
+        Cost: ${cost.estimated_usd.toFixed(4)}
+      </summary>
+      {/* Absolutely-positioned popover so the disclosure body doesn't
+          push siblings around when toggled. ``z-20`` keeps it above the
+          page grid; matching the bar's right-side anchor lets it expand
+          left without leaving the viewport. */}
+      <div className="absolute right-0 top-full z-20 mt-1 w-72 rounded border border-slate-700 bg-slate-900 p-3 text-xs text-slate-200 shadow-lg">
+        <p className="mb-1 uppercase tracking-widest text-slate-400">
+          Cost — token breakdown
+        </p>
+        <dl className="grid grid-cols-2 gap-x-3 gap-y-1">
+          <dt className="text-slate-400">Input</dt>
+          <dd className="text-right text-slate-100">
+            {cost.input_tokens.toLocaleString()}
+          </dd>
+          <dt className="text-slate-400">Output</dt>
+          <dd className="text-right text-slate-100">
+            {cost.output_tokens.toLocaleString()}
+          </dd>
+          <dt className="text-slate-400">Cache read</dt>
+          <dd className="text-right text-slate-100">
+            {cost.cache_read_tokens.toLocaleString()}
+          </dd>
+          <dt className="text-slate-400">Cache create</dt>
+          <dd className="text-right text-slate-100">
+            {cost.cache_creation_tokens.toLocaleString()}
+          </dd>
+          <dt className="font-semibold text-emerald-300">Estimated</dt>
+          <dd className="text-right font-semibold text-emerald-300">
+            ${cost.estimated_usd.toFixed(4)}
+          </dd>
+        </dl>
+        <p className="mt-2 text-[10px] leading-tight text-slate-500">
+          Charged to the operator's Anthropic key. Cumulative for this
+          session.
+        </p>
+      </div>
+    </details>
   );
 }
 

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1433,12 +1433,22 @@ export function TopBar(props: {
   // 1 s cadence matches the resolution of the data we have (Date.now()
   // is millisecond-precise but a sub-second indicator would just look
   // jittery).
+  //
+  // Depend on the *boolean* presence of a timestamp rather than its
+  // value: ``lastEventAt`` is bumped on every WS frame (including
+  // typing pings + heartbeats), so a value-dep would tear down and
+  // re-create the timer hundreds of times a minute under load. The
+  // boolean only flips once (null → number on first frame), so the
+  // interval is created exactly once per session. The timer reads the
+  // latest timestamp from ``props`` on each tick via ``lastEventLabel``
+  // below, which closes over ``props`` afresh on every render.
+  const hasLastEvent = props.lastEventAt !== null;
   const [, _setTick] = useState(0);
   useEffect(() => {
-    if (props.lastEventAt === null) return;
+    if (!hasLastEvent) return;
     const id = setInterval(() => _setTick((n) => n + 1), 1000);
     return () => clearInterval(id);
-  }, [props.lastEventAt]);
+  }, [hasLastEvent]);
   const lastEventLabel = props.lastEventAt === null
     ? "—"
     : (() => {

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -148,13 +148,20 @@ export function Facilitator() {
   // before kicking off the exercise.
   const [presence, setPresence] = useState<Set<string>>(() => new Set());
   // Real-time AI-thinking tracking — same shape as Play.tsx. ``aiCalls``
-  // collects in-flight LLM ``call_id``s from ``ai_thinking`` boundary
+  // maps in-flight LLM ``call_id`` → tier (``setup`` / ``play`` / ``aar``
+  // / ``guardrail`` / ``interject``) from ``ai_thinking`` boundary
   // events; ``aiStatus`` carries the labelled phase/attempt/recovery
   // breadcrumb the turn-driver emits at known points. Together they let
   // the operator distinguish "thinking" from "stuck" during the
   // strict-retry loop and see interject / setup / AAR work that doesn't
-  // change ``session.state`` (issue #63).
-  const [aiCalls, setAiCalls] = useState<Set<string>>(() => new Set());
+  // change ``session.state`` (issue #63). The tier is what powers the
+  // top-bar ``LLM: <tier>`` chip (round 4 of issue #62) — the operator
+  // wanted to see *which* tier is currently active, not just that
+  // *something* is in flight, so they can spot e.g. guardrail spikes
+  // separately from play-tier turns.
+  const [aiCalls, setAiCalls] = useState<Map<string, string>>(
+    () => new Map(),
+  );
   const [aiStatus, setAiStatus] = useState<{
     phase: "play" | "interject" | "setup" | "briefing" | "aar";
     attempt?: number;
@@ -372,7 +379,7 @@ export function Facilitator() {
         // when the engine actually moves to a non-busy state.
         if (evt.state !== "AI_PROCESSING" && evt.state !== "BRIEFING") {
           setAiStatus(null);
-          setAiCalls(new Set());
+          setAiCalls(new Map());
         }
         break;
       case "turn_changed":
@@ -384,10 +391,14 @@ export function Facilitator() {
       case "ai_thinking":
         // Reference-counted concurrent calls (guardrail + interject can
         // overlap). Add/remove by call_id so the indicator only clears
-        // when ALL calls have ended.
+        // when ALL calls have ended. Tier is retained so the top-bar
+        // ``LLM: <tier>`` chip can show *what* is in flight, not just
+        // *that* something is — a guardrail call layered on top of a
+        // play turn shows as ``LLM: guardrail+play`` rather than the
+        // operator having to guess from the transcript.
         setAiCalls((prev) => {
-          const next = new Set(prev);
-          if (evt.active) next.add(evt.call_id);
+          const next = new Map(prev);
+          if (evt.active) next.set(evt.call_id, evt.tier);
           else next.delete(evt.call_id);
           return next;
         });
@@ -1078,6 +1089,14 @@ export function Facilitator() {
         lastEventAt={lastEventAt}
         cost={cost ?? snapshot.cost}
         messageCount={snapshot.messages.length}
+        activeTiers={(() => {
+          // De-dupe tiers across overlapping calls and sort for a stable
+          // chip label. Empty set → idle. The chip itself decides how to
+          // render the empty case; we pass an empty array.
+          const seen = new Set<string>();
+          for (const tier of aiCalls.values()) seen.add(tier);
+          return Array.from(seen).sort();
+        })()}
       />
       <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-4 p-4 lg:min-h-0 lg:grid-cols-[280px_1fr_280px] lg:overflow-hidden">
         <aside className="flex flex-col gap-4 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
@@ -1392,6 +1411,11 @@ export function TopBar(props: {
   cost: CostSnapshot | null;
   /** ``snapshot.messages.length`` — raw message-count debug telemetry. */
   messageCount: number;
+  /** Sorted, de-duped LLM tiers currently in flight (e.g. ``["play"]``,
+   *  ``["guardrail", "play"]``). Empty array = idle. Source: every
+   *  ``ai_thinking`` event carries a ``tier``; ``Facilitator`` retains
+   *  the mapping per ``call_id``. */
+  activeTiers: string[];
 }) {
   const wsColour =
     props.wsStatus === "open"
@@ -1564,6 +1588,27 @@ export function TopBar(props: {
           >
             Last: {lastEventLabel}
           </span>
+          {/* LLM tier chip (#9). When idle the chip stays present (just
+              de-emphasised) so the bar layout doesn't reflow on every
+              call boundary; when active it goes amber + bold so the
+              operator's eye picks it up while glancing across the bar. */}
+          {props.activeTiers.length > 0 ? (
+            <span
+              className="rounded bg-amber-900/40 px-2 py-0.5 font-semibold text-amber-200"
+              role="status"
+              aria-live="polite"
+              title={`Active LLM call(s) — tier${props.activeTiers.length === 1 ? "" : "s"}: ${props.activeTiers.join(", ")}.`}
+            >
+              LLM: {props.activeTiers.join("+")}
+            </span>
+          ) : (
+            <span
+              className="rounded bg-slate-800 px-2 py-0.5 text-slate-500"
+              title="No LLM call currently in flight."
+            >
+              LLM: idle
+            </span>
+          )}
           {/* Cost: click-to-expand chip. The summary shows the dollar
               amount; the disclosure body shows the token breakdown
               (mirrors the old sidebar CostMeter, but inline). Native

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -21,7 +21,7 @@ import { SetupChat } from "../components/SetupChat";
 import { Transcript } from "../components/Transcript";
 import { ServerEvent, WsClient } from "../lib/ws";
 
-type Phase = "intro" | "setup" | "ready" | "play" | "ended";
+export type Phase = "intro" | "setup" | "ready" | "play" | "ended";
 
 interface CreatorState {
   sessionId: string;
@@ -105,6 +105,16 @@ export function Facilitator() {
   });
   const [creatorLabel, setCreatorLabel] = useState("CISO");
   const [creatorDisplayName, setCreatorDisplayName] = useState("");
+  // Issue #61: roles to invite, declared *before* the session is created
+  // so the operator doesn't have to add seats one-by-one in the lobby.
+  // These are auto-created via ``api.addRole`` immediately after the
+  // session is created. Operators can still add/remove roles dynamically
+  // from the Roles panel during setup or play.
+  const SETUP_ROLE_DEFAULTS = ["IR Lead", "Legal", "Comms"] as const;
+  const [setupRoles, setSetupRoles] = useState<string[]>([
+    ...SETUP_ROLE_DEFAULTS,
+  ]);
+  const [setupRoleDraft, setSetupRoleDraft] = useState("");
   // Dev-mode toggle on the intro page: prefills a known scenario + creator
   // identity, and on submit auto-skips the AI setup dialogue so testers
   // bypass the 5–30 s setup loop. Use only for local QA.
@@ -124,10 +134,10 @@ export function Facilitator() {
   const [cost, setCost] = useState<CostSnapshot | null>(null);
   const [godMode, setGodMode] = useState(false);
   // Page-level state for the AAR popup so a single "View AAR" button in
-  // the sidebar Controls is the only surface that opens it. Pre-fix the
-  // sidebar had a "Download AAR" that bypassed the popup AND the chat
-  // area had a duplicate "Show AAR report" button — two competing CTAs
-  // for the same task.
+  // the top SessionActionBar is the only surface that opens it. Pre-fix
+  // the sidebar had a "Download AAR" that bypassed the popup AND the
+  // chat area had a duplicate "Show AAR report" button — two competing
+  // CTAs for the same task.
   const [showAarPopup, setShowAarPopup] = useState(false);
   // role_id -> last typing-true timestamp (ms). Filtered to "currently typing"
   // by the consuming components which check freshness < 4s.
@@ -243,6 +253,46 @@ export function Facilitator() {
         creatorRoleId: created.creator_role_id,
         joinUrl: created.creator_join_url,
       });
+      // Issue #61: auto-create any pre-declared invitee roles before the
+      // operator lands on the lobby. De-duped against the creator's own
+      // label so an operator who left the suggestions list intact and
+      // *also* picked one of those labels for themselves doesn't get a
+      // duplicate seat. Dev mode skips this — it has its own SOC Analyst
+      // helper seat below.
+      if (!devMode) {
+        const creatorLabelTrim = creatorLabel.trim().toLowerCase();
+        const seen = new Set<string>([creatorLabelTrim]);
+        const labelsToAdd = setupRoles
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+          .filter((label) => {
+            const k = label.toLowerCase();
+            if (seen.has(k)) return false;
+            seen.add(k);
+            return true;
+          });
+        for (const label of labelsToAdd) {
+          setBusyMessage(`Adding role "${label}"…`);
+          try {
+            await api.addRole(created.session_id, created.creator_token, {
+              label,
+              kind: "player",
+            });
+          } catch (roleErr) {
+            console.warn("[facilitator] failed to add role", label, roleErr);
+            setError(
+              `Created the session but failed to add role "${label}": ` +
+                (roleErr instanceof Error ? roleErr.message : String(roleErr)) +
+                ". You can add it manually from the Roles panel.",
+            );
+          }
+        }
+        if (labelsToAdd.length > 0) {
+          console.info("[facilitator] pre-created roles", {
+            count: labelsToAdd.length,
+          });
+        }
+      }
       if (devMode) {
         // ``start_session`` requires ≥ 2 player roles. Dev mode auto-
         // adds a SOC Analyst seat so the operator can solo-test via the
@@ -821,6 +871,132 @@ export function Facilitator() {
               className="rounded border border-slate-700 bg-slate-900 p-2 text-sm"
             />
           </div>
+          {(() => {
+            // Helpers shared between the Add-role button and the Enter
+            // shortcut. Extracted so the trim/dedup logic lives in one
+            // place — duplicating it across the two handlers was flagged
+            // as a regression footgun in code review.
+            const addRoleLabel = (next: string) => {
+              const trimmed = next.trim();
+              if (!trimmed) return;
+              if (
+                setupRoles.some((r) => r.toLowerCase() === trimmed.toLowerCase())
+              ) {
+                setSetupRoleDraft("");
+                return;
+              }
+              setSetupRoles((cur) => [...cur, trimmed]);
+              setSetupRoleDraft("");
+            };
+            // Surface the silent dedupe-against-creator-label case: if the
+            // operator picks "IR Lead" as their own role label and leaves
+            // it in the suggestions, it'll be filtered out at create
+            // time. Tell them up front rather than letting the seat go
+            // missing without explanation.
+            const creatorLabelLower = creatorLabel.trim().toLowerCase();
+            const dedupeWithCreator = creatorLabelLower
+              ? setupRoles.find((r) => r.toLowerCase() === creatorLabelLower)
+              : undefined;
+            const defaultsMatch =
+              setupRoles.length === SETUP_ROLE_DEFAULTS.length &&
+              SETUP_ROLE_DEFAULTS.every((d, i) => setupRoles[i] === d);
+            return (
+              <fieldset className="flex flex-col gap-2 rounded border border-slate-700 bg-slate-900 p-3">
+                <legend className="px-1 text-xs uppercase tracking-widest text-slate-400">
+                  Roles to invite
+                </legend>
+                <p className="text-[11px] text-slate-400">
+                  Add the seats other participants will fill. Each role
+                  gets its own join link in the lobby — you'll copy and
+                  share the link yourself. You can also add or remove
+                  roles later from the Roles panel.
+                </p>
+                {setupRoles.length > 0 ? (
+                  <ul className="flex flex-wrap gap-1.5">
+                    {setupRoles.map((label, idx) => (
+                      <li
+                        key={`${label}-${idx}`}
+                        className="inline-flex items-center gap-1 rounded border border-slate-600 bg-slate-950 py-0.5 pl-2 pr-0.5 text-xs text-slate-200"
+                      >
+                        <span>{label}</span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setSetupRoles((cur) =>
+                              cur.filter((_, i) => i !== idx),
+                            )
+                          }
+                          aria-label={`Remove ${label}`}
+                          className="rounded px-1.5 py-0.5 text-slate-400 hover:bg-slate-800 hover:text-red-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-300"
+                          title={`Remove ${label}`}
+                        >
+                          <span aria-hidden="true">×</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-[11px] italic text-slate-500">
+                    No invitee roles yet. You'll need at least 1 invitee
+                    (you + 1 = 2 player seats) before the exercise can
+                    start.
+                  </p>
+                )}
+                {dedupeWithCreator ? (
+                  <p
+                    role="status"
+                    className="text-[11px] text-amber-300"
+                  >
+                    You're playing "{dedupeWithCreator}", so it won't be
+                    auto-added as a separate invitee.
+                  </p>
+                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  <input
+                    value={setupRoleDraft}
+                    onChange={(e) => setSetupRoleDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        addRoleLabel(setupRoleDraft);
+                      }
+                    }}
+                    placeholder="e.g. IR Lead — press Enter to add another"
+                    aria-label="New role label"
+                    className="flex-1 rounded border border-slate-700 bg-slate-950 p-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-300"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => addRoleLabel(setupRoleDraft)}
+                    disabled={!setupRoleDraft.trim()}
+                    className="rounded border border-slate-600 px-3 py-2 text-xs text-slate-200 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-300 disabled:opacity-50"
+                  >
+                    Add role
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-3 text-[11px] text-slate-400">
+                  {setupRoles.length > 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => setSetupRoles([])}
+                      className="text-slate-400 underline hover:text-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-300"
+                    >
+                      Clear all
+                    </button>
+                  ) : null}
+                  {!defaultsMatch ? (
+                    <button
+                      type="button"
+                      onClick={() => setSetupRoles([...SETUP_ROLE_DEFAULTS])}
+                      className="text-slate-400 underline hover:text-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-300"
+                    >
+                      Reset to defaults
+                    </button>
+                  ) : null}
+                </div>
+              </fieldset>
+            );
+          })()}
           <button
             type="submit"
             disabled={busy}
@@ -863,6 +1039,22 @@ export function Facilitator() {
         onToggleGodMode={() => setGodMode((g) => !g)}
         godMode={godMode}
       />
+      {/* Issue #62: pin the session controls (Start / Force-advance / End /
+          View AAR / New session) to a horizontal bar at the very top of
+          the layout so the primary CTA is always reachable on narrow
+          viewports without scrolling past the role roster. */}
+      <SessionActionBar
+        phase={phase}
+        onStart={handleStart}
+        onForceAdvance={handleForceAdvance}
+        onEnd={handleEnd}
+        onNewSession={handleNewSession}
+        onViewAar={() => setShowAarPopup(true)}
+        playerCount={playerCount}
+        hasFinalizedPlan={Boolean(snapshot.plan)}
+        aarStatus={snapshot.aar_status ?? null}
+        busy={busy}
+      />
       <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-4 p-4 lg:min-h-0 lg:grid-cols-[280px_1fr_280px] lg:overflow-hidden">
         <aside className="flex flex-col gap-4 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
           <RolesPanel
@@ -890,18 +1082,6 @@ export function Facilitator() {
           />
           <DecisionLogPanel entries={decisionLog} />
           <CostMeter cost={cost ?? snapshot.cost} />
-          <Controls
-            phase={phase}
-            onStart={handleStart}
-            onForceAdvance={handleForceAdvance}
-            onEnd={handleEnd}
-            onNewSession={handleNewSession}
-            onViewAar={() => setShowAarPopup(true)}
-            playerCount={playerCount}
-            hasFinalizedPlan={Boolean(snapshot.plan)}
-            aarStatus={snapshot.aar_status ?? null}
-            busy={busy}
-          />
         </aside>
 
         <section className="flex min-w-0 flex-col gap-3 lg:min-h-0 lg:overflow-hidden">
@@ -1339,7 +1519,15 @@ function WaitingChip({
 }
 
 
-function Controls(props: {
+/**
+ * Issue #62: horizontal action bar pinned just below the StatusBar so the
+ * primary phase-appropriate CTA (Start / Force-advance / End / View AAR /
+ * New session) is always reachable on narrow viewports. Pre-fix the same
+ * controls lived at the bottom of the left sidebar — on a 493×943
+ * viewport the Start button was below the fold, requiring a scroll past
+ * the entire role roster + activity panel to reach it.
+ */
+export function SessionActionBar(props: {
   phase: Phase;
   onStart: () => void;
   onForceAdvance: () => void;
@@ -1359,112 +1547,101 @@ function Controls(props: {
     props.playerCount >= 2;
 
   return (
-    <div className="flex min-w-0 flex-col gap-2 rounded border border-slate-700 bg-slate-900 p-3 text-sm">
-      {props.phase === "ready" || props.phase === "setup" ? (
-        <>
-          <p className="text-xs text-slate-400">
-            Players: {props.playerCount} (need ≥ 2 to start)
-          </p>
-          <button
-            onClick={props.onStart}
-            disabled={!canStart || props.busy}
-            className="rounded bg-emerald-600 px-2 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
-            title={
-              !props.hasFinalizedPlan
-                ? "Finalize the plan first"
-                : props.playerCount < 2
-                  ? "Add at least 2 player roles"
-                  : ""
-            }
-          >
-            Start session
-          </button>
-        </>
-      ) : null}
-
-      {props.phase === "play" ? (
-        <>
-          {/*
-            Single force-advance button. The User-Agent review flagged
-            two stacked buttons that landed on the same handler as
-            "reads like an unfinished refactor" — fair. We now ship one
-            primary action with a clarifying tooltip + a one-line
-            inline hint that covers both intents (nudge AI / skip
-            missing voices).
-          */}
-          <button
-            onClick={props.onForceAdvance}
-            disabled={props.busy}
-            className="rounded border border-emerald-500 bg-emerald-900/30 px-2 py-1 text-sm font-semibold text-emerald-100 hover:bg-emerald-700/40 disabled:opacity-50"
-            title="Hand the turn to the AI now. Use when conversation has stalled OR when one player is unresponsive."
-          >
-            AI: take next beat
-          </button>
-          <p className="text-[10px] leading-tight text-slate-500">
-            Marks the current player turn complete (skipping any missing
-            voices) and lets the AI run the next beat.
-          </p>
-          <button
-            onClick={props.onEnd}
-            disabled={props.busy}
-            className="rounded border border-red-500 px-2 py-1 text-sm font-semibold text-red-300 hover:bg-red-900/30 disabled:opacity-50"
-          >
-            End session
-          </button>
-        </>
-      ) : null}
-
-      {props.phase === "ended" ? (() => {
-        // Single AAR entry point. The popup contains the actual Download
-        // button; this CTA only opens the viewer. Pre-fix there were two
-        // competing buttons (sidebar "Download AAR" that bypassed the
-        // popup, plus an in-chat "Show AAR report").
-        if (props.aarStatus === "ready") {
-          return (
+    <div className="border-b border-slate-800 bg-slate-900/60 px-4 py-2">
+      <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center gap-2 text-sm">
+        {props.phase === "ready" || props.phase === "setup" ? (
+          <>
             <button
-              onClick={props.onViewAar}
-              className="rounded bg-emerald-600 px-2 py-1 text-sm font-semibold text-white hover:bg-emerald-500"
+              onClick={props.onStart}
+              disabled={!canStart || props.busy}
+              className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+              title={
+                !props.hasFinalizedPlan
+                  ? "Finalize the plan first"
+                  : props.playerCount < 2
+                    ? "Add at least 2 player roles"
+                    : ""
+              }
             >
-              View AAR
+              Start session
             </button>
-          );
-        }
-        if (props.aarStatus === "failed") {
-          return (
-            <div
-              role="status"
-              className="flex flex-col gap-1 rounded border border-red-500/60 bg-red-950/30 px-2 py-1 text-xs text-red-200"
-            >
-              <span>AAR generation failed.</span>
-              <span className="text-[11px] text-red-200/80">
-                Use Retry in the main panel, or end + restart the session.
-              </span>
-            </div>
-          );
-        }
-        return (
-          <span
-            role="status"
-            aria-live="polite"
-            className="inline-flex items-center gap-1.5 rounded bg-slate-800/80 px-2 py-1 text-xs text-slate-300"
-          >
-            <span
-              aria-hidden="true"
-              className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400"
-            />
-            AAR generating… (~30 s)
-          </span>
-        );
-      })() : null}
+            <span className="text-xs text-slate-400">
+              Players: {props.playerCount} (need ≥ 2 to start)
+            </span>
+          </>
+        ) : null}
 
-      <button
-        onClick={props.onNewSession}
-        disabled={props.busy}
-        className="mt-1 rounded border border-slate-600 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
-        title="End the current session (if any) and return to the new-session form."
-      >
-        Start a new session
-      </button>
+        {props.phase === "play" ? (
+          <>
+            <button
+              onClick={props.onForceAdvance}
+              disabled={props.busy}
+              className="rounded border border-emerald-500 bg-emerald-900/30 px-3 py-1 text-sm font-semibold text-emerald-100 hover:bg-emerald-700/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:opacity-50"
+              title="Hand the turn to the AI now. Use when conversation has stalled OR when one player is unresponsive."
+            >
+              AI: take next beat
+            </button>
+            <button
+              onClick={props.onEnd}
+              disabled={props.busy}
+              className="rounded border border-red-500 px-3 py-1 text-sm font-semibold text-red-300 hover:bg-red-900/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-300 disabled:opacity-50"
+            >
+              End session
+            </button>
+            <span className="text-[11px] leading-tight text-slate-500">
+              "Take next beat" marks the current player turn complete
+              (skipping any missing voices).
+            </span>
+          </>
+        ) : null}
+
+        {props.phase === "ended"
+          ? (() => {
+              if (props.aarStatus === "ready") {
+                return (
+                  <button
+                    onClick={props.onViewAar}
+                    className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300"
+                  >
+                    View AAR
+                  </button>
+                );
+              }
+              if (props.aarStatus === "failed") {
+                return (
+                  <span
+                    role="status"
+                    className="inline-flex items-center gap-1 rounded border border-red-500/60 bg-red-950/30 px-2 py-1 text-xs text-red-200"
+                  >
+                    AAR generation failed — use Retry in the main panel.
+                  </span>
+                );
+              }
+              return (
+                <span
+                  role="status"
+                  aria-live="polite"
+                  className="inline-flex items-center gap-1.5 rounded bg-slate-800/80 px-2 py-1 text-xs text-slate-300"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400"
+                  />
+                  AAR generating… (~30 s)
+                </span>
+              );
+            })()
+          : null}
+
+        <button
+          onClick={props.onNewSession}
+          disabled={props.busy}
+          className="ml-auto rounded border border-slate-600 px-3 py-1 text-xs text-slate-300 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-300 disabled:opacity-50"
+          title="End the current session (if any) and return to the new-session form."
+        >
+          Start a new session
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #62. Closes #61.

- **#62 — Start session button off-screen.** Moved the Start / Force-advance / End / View AAR / "Start a new session" controls out of the bottom of the left sidebar into a new horizontal `SessionActionBar` pinned just below the `StatusBar`. On the reporter's 493×943 viewport the primary CTA is now visible without scrolling past the role roster, activity panel, decision log, and cost meter.
- **#61 — Add roles during setup.** The "New tabletop exercise" intro page now has a "Roles to invite" fieldset seeded with `IR Lead / Legal / Comms`. After `createSession` returns, the frontend loops `api.addRole` for each declared label (deduped case-insensitively against the creator's own label, skipped in dev mode which already auto-adds a SOC Analyst seat). The lobby's existing `RolesPanel` still supports dynamic add / kick / remove during setup and play.

Per `CLAUDE.md`, the six-agent review pipeline was run against the diff; QA, Security, UI/UX, Product/App-Owner, User-Agent, and Prompt-Expert reviews were triaged. Findings addressed in this commit:

- **User Agent HIGH** — inline amber note when the creator's label matches an invitee chip so the dedupe doesn't fire silently.
- **User Agent HIGH** — `Clear all` and `Reset to defaults` links so operators whose org doesn't use IR Lead / Legal / Comms can wipe the seeds in one click.
- **UI/UX MEDIUM** — `focus-visible` outlines on every new button + the chip-remove `×` control; dropped the duplicate `aria-label` on the chip `<ul>`.
- **QA HIGH** — new `Facilitator.intro.test.tsx` covering `SessionActionBar` phase rendering & canStart gating, plus the intro chip flow (Add via button / Enter, case-insensitive dedup, blank-input rejection, Clear / Reset, and the creator-label collision warning). 17 tests passing.
- **QA LOW (logging-and-debuggability, must-fix per CLAUDE.md)** — refreshed the now-stale "sidebar Controls" comment.

Deferred follow-ups (MEDIUM / LOW, not blockers): per-role-failure error messages overwrite each other in the loop (only the last is shown); chip `key` is index-based; configurable role defaults.

## Test plan

- [ ] `cd frontend && npm test -- --run` — 2 files / 17 tests pass.
- [ ] `cd frontend && npm run typecheck` — clean.
- [ ] `cd frontend && npm run lint` — clean (`--max-warnings 0`).
- [ ] Manual: open the intro page on a ~500px-wide viewport, create a session, confirm `Start session` is reachable in the top bar without scrolling.
- [ ] Manual: leave the three default invitee chips, type creator label `IR Lead`, confirm the inline amber dedupe note appears.
- [ ] Manual: `Clear all` then `Reset to defaults` — chips repopulate.
- [ ] Manual: dev-mode submit still auto-adds SOC Analyst and starts the exercise.

https://claude.ai/code/session_011BwWciqUxP97mtEf5Ez22S

---
_Generated by [Claude Code](https://claude.ai/code/session_011BwWciqUxP97mtEf5Ez22S)_