### PR TITLE
Surface AI work in real-time so the indicator never lies (#63)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -854,6 +854,7 @@ def register_api_routes(app: FastAPI) -> None:
                     "model": call.model,
                     "stream": call.stream,
                     "elapsed_ms": int((now - call.started_at) * 1000),
+                    "call_id": call.call_id,
                 }
                 for call in in_flight
             ],
@@ -961,6 +962,7 @@ def register_api_routes(app: FastAPI) -> None:
                     "model": call.model,
                     "stream": call.stream,
                     "elapsed_ms": int((now - call.started_at) * 1000),
+                    "call_id": call.call_id,
                 }
                 for call in in_flight
             ],

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -248,6 +248,14 @@ class Settings(BaseSettings):
     export_retention_min: int = Field(default=60, alias="EXPORT_RETENTION_MIN", ge=1)
     ws_heartbeat_s: int = Field(default=20, alias="WS_HEARTBEAT_S", ge=1)
     input_guardrail_enabled: bool = Field(default=True, alias="INPUT_GUARDRAIL_ENABLED")
+    # Reject a participant's submission as a duplicate if it matches the
+    # role's previous message body (whitespace-stripped) within this many
+    # seconds. Backstop for the no-feedback retype loop in issue #63 once
+    # the new ``ai_thinking`` indicator dissolves the underlying confusion.
+    # Set to 0 to disable.
+    duplicate_submission_window_seconds: int = Field(
+        default=30, alias="DUPLICATE_SUBMISSION_WINDOW_SECONDS", ge=0
+    )
 
     # ---- Logging -------------------------------------------------------
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = Field(

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -16,14 +16,18 @@ events depending on ``stream``.
 from __future__ import annotations
 
 import asyncio
+import secrets
 import time
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
-from typing import Any, Protocol
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
 
 from ..config import ModelTier, Settings
 from ..logging_setup import get_logger
 from .cost import estimate_usd
+
+if TYPE_CHECKING:
+    from ..ws.connection_manager import ConnectionManager
 
 _logger = get_logger("llm.client")
 
@@ -97,12 +101,21 @@ def _validate_tool_choice(tool_choice: dict[str, Any] | None) -> None:
 
 @dataclass
 class InFlightCall:
-    """One active LLM call. Used by the creator's activity panel."""
+    """One active LLM call. Used by the creator's activity panel.
+
+    ``call_id`` is a short opaque identifier so a real-time WS subscriber
+    (the participant + creator UI's "AI thinking" indicator, see
+    issue #63) can match a ``ai_thinking active=true`` event with the
+    later ``active=false`` event for the same call. Concurrent calls on
+    the same session (e.g. guardrail + interject) overlap, so the
+    indicator must reference-count rather than naively toggle.
+    """
 
     tier: str
     model: str
     stream: bool
     started_at: float  # time.monotonic() seconds
+    call_id: str = field(default_factory=lambda: secrets.token_hex(6))
 
 
 class _AnthropicCallable(Protocol):
@@ -144,6 +157,22 @@ class LLMClient:
         # session manager dispatches the AAR while a guardrail call is also
         # active; rare but possible).
         self._in_flight: dict[str, list[InFlightCall]] = {}
+        # ConnectionManager is wired in post-construction (set_connections)
+        # because the app builds the LLM client before the connection manager
+        # in some startup orderings. Until set, ``_begin_call`` / ``_end_call``
+        # skip the WS broadcast — non-fatal (the call still tracks via
+        # ``_in_flight`` for the polled ``/activity`` endpoint).
+        self._connections: ConnectionManager | None = None
+
+    def set_connections(self, connections: ConnectionManager) -> None:
+        """Wire the connection manager so begin/end-of-call events fan out
+        to participant + creator UIs as ``ai_thinking`` WS events. See
+        issue #63 (the "AI thinking" indicator was previously gated on
+        ``session.state``, which left interject / guardrail / setup-tier
+        / AAR-generation work invisible to clients).
+        """
+
+        self._connections = connections
 
     def in_flight_for(self, session_id: str) -> list[InFlightCall]:
         """Snapshot of active LLM calls for a session. Safe from any thread."""
@@ -162,6 +191,7 @@ class LLMClient:
             return None
         call = InFlightCall(tier=tier, model=model, stream=stream, started_at=time.monotonic())
         self._in_flight.setdefault(session_id, []).append(call)
+        self._broadcast_thinking(session_id, call, active=True)
         return call
 
     def _end_call(self, session_id: str | None, call: InFlightCall | None) -> None:
@@ -171,6 +201,46 @@ class LLMClient:
                 bucket.remove(call)
             if bucket is not None and not bucket:
                 self._in_flight.pop(session_id, None)
+            self._broadcast_thinking(session_id, call, active=False)
+
+    def _broadcast_thinking(
+        self, session_id: str, call: InFlightCall, *, active: bool
+    ) -> None:
+        """Fire-and-forget ``ai_thinking`` event so every connected client
+        sees the indicator the moment a call starts / stops, regardless
+        of which tier or driver path triggered it.
+
+        ``record=False`` because the event is stale on reconnect — the
+        replay buffer would otherwise show "AI was thinking" forever
+        for a call that finished an hour ago. Failures are swallowed
+        but logged: a misbehaving WS handler must NOT break the LLM
+        call (a swallowed exception here is intentional, but per
+        CLAUDE.md "Logging rules" it has to be visible in the log).
+        """
+
+        if self._connections is None:
+            return
+        event: dict[str, Any] = {
+            "type": "ai_thinking",
+            "active": active,
+            "tier": call.tier,
+            "call_id": call.call_id,
+        }
+        if active:
+            event["started_at_ms"] = int(call.started_at * 1000)
+        try:
+            asyncio.get_running_loop().create_task(
+                self._connections.broadcast(session_id, event, record=False)
+            )
+        except Exception as exc:
+            _logger.warning(
+                "ai_thinking_broadcast_failed",
+                session_id=session_id,
+                call_id=call.call_id,
+                tier=call.tier,
+                active=active,
+                error=str(exc),
+            )
 
     # ---------------------------------------------------------------- setup
     def set_transport(self, transport: _AnthropicCallable) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,6 +60,12 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     repository = InMemoryRepository(max_sessions=settings.max_sessions)
     connections = ConnectionManager()
     llm = LLMClient(settings=settings)
+    # Wire the connection manager into the LLM client so every LLM call
+    # boundary (begin / end) fans out an ``ai_thinking`` WS event. Without
+    # this, the participant + creator UIs only saw the indicator when
+    # ``session.state == AI_PROCESSING``, which left interject / guardrail /
+    # setup-tier / AAR-generation work invisible (issue #63).
+    llm.set_connections(connections)
     guardrail = InputGuardrail(llm=llm, settings=settings)
 
     tool_dispatcher = ToolDispatcher(

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -434,6 +434,37 @@ class SessionManager:
                 raise IllegalTransitionError("no current turn")
             if not can_submit(turn, role_id):
                 raise IllegalTransitionError("role cannot submit on this turn")
+            # Backstop the duplicate-submission path. The 15-second-apart
+            # duplicate visible in the issue #63 screenshot is dissolved
+            # by the new ``ai_thinking`` / ``ai_status`` indicators (the
+            # participant retyped because they had no feedback) but the
+            # belt-and-braces guard prevents a stray double-Enter from
+            # producing two visible bubbles. Compare against the most
+            # recent message — same role, identical (whitespace-stripped)
+            # body, and within the dedupe window.
+            stripped_new = content.strip()
+            window_seconds = self._settings.duplicate_submission_window_seconds
+            if window_seconds > 0 and session.messages:
+                last = session.messages[-1]
+                if (
+                    last.kind == MessageKind.PLAYER
+                    and last.role_id == role_id
+                    and last.body.strip() == stripped_new
+                    and (datetime.now(UTC) - last.ts).total_seconds() < window_seconds
+                ):
+                    self._emit(
+                        "dedupe_dropped_submission",
+                        session,
+                        role_id=role_id,
+                        content_preview=content[:120],
+                        elapsed_seconds=int(
+                            (datetime.now(UTC) - last.ts).total_seconds()
+                        ),
+                    )
+                    raise IllegalTransitionError(
+                        "You just sent the same message — wait a moment "
+                        "or change something to send again."
+                    )
             turn.submitted_role_ids.append(role_id)
             session.messages.append(
                 Message(
@@ -469,6 +500,25 @@ class SessionManager:
         return ready_to_advance
 
     async def force_advance(self, *, session_id: str, by_role_id: str) -> None:
+        # Refuse force-advance while a play-tier LLM call is mid-stream.
+        # Without this guard, every operator click spawned a fresh
+        # ``run_play_turn`` that raced the still-streaming original —
+        # the screenshot timeline in issue #63 (three "Force-advanced"
+        # SYSTEM banners followed by the AI's actual reply seconds
+        # later) is exactly that race. Non-play tiers (guardrail,
+        # setup, AAR) are NOT blocked: an operator must always be able
+        # to recover from a hung non-play call.
+        in_flight = self._llm.in_flight_for(session_id)
+        if any(c.tier == "play" for c in in_flight):
+            _logger.info(
+                "force_advance_rejected_in_flight",
+                session_id=session_id,
+                by_role_id=by_role_id,
+                in_flight_tiers=[c.tier for c in in_flight],
+            )
+            raise IllegalTransitionError(
+                "AI is still processing — wait a few seconds before forcing advance"
+            )
         async with await self._lock_for(session_id):
             session = await self._repo.get(session_id)
             turn = session.current_turn
@@ -740,6 +790,12 @@ class SessionManager:
         await self._connections.broadcast(
             session_id, {"type": "aar_status_changed", "status": "generating"}
         )
+        # Labelled AI-status breadcrumb so the operator's UI shows
+        # "AI — Drafting the after-action report" during the 30 s+
+        # generation. Without this the UI only had ``aar_status_changed``
+        # WS events, which connected clients see but reload-the-tab
+        # users miss until their snapshot polls. Issue #63 audit gap #7.
+        await self._broadcast_ai_status(session_id, phase="aar")
         _logger.info("aar_generation_start", session_id=session_id)
 
         try:
@@ -762,6 +818,7 @@ class SessionManager:
             await self._connections.broadcast(
                 session_id, {"type": "aar_status_changed", "status": "failed"}
             )
+            await self._broadcast_ai_status(session_id, phase=None)
             return
 
         async with await self._lock_for(session_id):
@@ -776,9 +833,42 @@ class SessionManager:
         await self._connections.broadcast(
             session_id, {"type": "aar_status_changed", "status": "ready"}
         )
+        await self._broadcast_ai_status(session_id, phase=None)
         _logger.info(
             "aar_generation_complete", session_id=session_id, length=len(markdown)
         )
+
+    async def _broadcast_ai_status(
+        self, session_id: str, *, phase: str | None
+    ) -> None:
+        """Manager-side helper for emitting the labelled ``ai_status``
+        breadcrumb. Symmetric with ``TurnDriver._emit_ai_status`` —
+        both broadcast to ``record=False`` so the events don't clog
+        the replay buffer. Wrapped because a misbehaving WS handler
+        must not abort the AAR pipeline.
+        """
+
+        try:
+            await self._connections.broadcast(
+                session_id,
+                {
+                    "type": "ai_status",
+                    "phase": phase,
+                    "attempt": None,
+                    "budget": None,
+                    "recovery": None,
+                    "turn_index": None,
+                    "for_role_id": None,
+                },
+                record=False,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "ai_status_broadcast_failed",
+                session_id=session_id,
+                phase=phase,
+                error=str(exc),
+            )
 
     # ---------------------------------------------------- messaging helpers
     async def append_ai_message(

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -439,32 +439,40 @@ class SessionManager:
             # by the new ``ai_thinking`` / ``ai_status`` indicators (the
             # participant retyped because they had no feedback) but the
             # belt-and-braces guard prevents a stray double-Enter from
-            # producing two visible bubbles. Compare against the most
-            # recent message — same role, identical (whitespace-stripped)
-            # body, and within the dedupe window.
+            # producing two visible bubbles.
+            #
+            # Scan backwards for the most recent ``PLAYER`` message from
+            # this same role within the dedupe window. We can't just
+            # check ``messages[-1]`` because an interject path can splice
+            # an AI reply (``run_interject`` appends ``broadcast`` /
+            # ``address_role`` outputs) between the two participant
+            # submits — and a SYSTEM banner can land in the same gap.
+            # The window itself bounds the scan, so the cost is at worst
+            # O(messages_in_last_30s).
             stripped_new = content.strip()
             window_seconds = self._settings.duplicate_submission_window_seconds
-            if window_seconds > 0 and session.messages:
-                last = session.messages[-1]
-                if (
-                    last.kind == MessageKind.PLAYER
-                    and last.role_id == role_id
-                    and last.body.strip() == stripped_new
-                    and (datetime.now(UTC) - last.ts).total_seconds() < window_seconds
-                ):
-                    self._emit(
-                        "dedupe_dropped_submission",
-                        session,
-                        role_id=role_id,
-                        content_preview=content[:120],
-                        elapsed_seconds=int(
-                            (datetime.now(UTC) - last.ts).total_seconds()
-                        ),
-                    )
-                    raise IllegalTransitionError(
-                        "You just sent the same message — wait a moment "
-                        "or change something to send again."
-                    )
+            if window_seconds > 0:
+                now = datetime.now(UTC)
+                for prior in reversed(session.messages):
+                    if (now - prior.ts).total_seconds() >= window_seconds:
+                        break
+                    if prior.kind != MessageKind.PLAYER or prior.role_id != role_id:
+                        continue
+                    if prior.body.strip() == stripped_new:
+                        self._emit(
+                            "dedupe_dropped_submission",
+                            session,
+                            role_id=role_id,
+                            content_preview=content[:120],
+                            elapsed_seconds=int((now - prior.ts).total_seconds()),
+                        )
+                        raise IllegalTransitionError(
+                            "You just sent the same message — wait a moment "
+                            "or change something to send again."
+                        )
+                    # Found the most recent same-role player message and it
+                    # didn't match — stop scanning.
+                    break
             turn.submitted_role_ids.append(role_id)
             session.messages.append(
                 Message(
@@ -508,18 +516,27 @@ class SessionManager:
         # later) is exactly that race. Non-play tiers (guardrail,
         # setup, AAR) are NOT blocked: an operator must always be able
         # to recover from a hung non-play call.
-        in_flight = self._llm.in_flight_for(session_id)
-        if any(c.tier == "play" for c in in_flight):
-            _logger.info(
-                "force_advance_rejected_in_flight",
-                session_id=session_id,
-                by_role_id=by_role_id,
-                in_flight_tiers=[c.tier for c in in_flight],
-            )
-            raise IllegalTransitionError(
-                "AI is still processing — wait a few seconds before forcing advance"
-            )
+        #
+        # The check runs *inside* the per-session lock so it's
+        # synchronized with state transitions. A play-tier call can only
+        # be started by code that holds the lock at some point (the WS
+        # / REST handlers acquire it via ``submit_response`` or earlier
+        # ``force_advance`` invocations before kicking ``run_play_turn``);
+        # checking outside the lock would let one of those start a
+        # second call between our check and the state mutation,
+        # producing the very race we're guarding against.
         async with await self._lock_for(session_id):
+            in_flight = self._llm.in_flight_for(session_id)
+            if any(c.tier == "play" for c in in_flight):
+                _logger.info(
+                    "force_advance_rejected_in_flight",
+                    session_id=session_id,
+                    by_role_id=by_role_id,
+                    in_flight_tiers=[c.tier for c in in_flight],
+                )
+                raise IllegalTransitionError(
+                    "AI is still processing — wait a few seconds before forcing advance"
+                )
             session = await self._repo.get(session_id)
             turn = session.current_turn
             if turn is None:

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -286,8 +286,11 @@ class TurnDriver:
         # Phase label for the labelled "what is the AI doing?" indicator.
         # When state is BRIEFING we expose ``phase=briefing`` so the UI
         # can render "Briefing the team" instead of a generic play
-        # status; otherwise it's a normal play turn. Cleared on every
-        # return path via ``finally``.
+        # status; otherwise it's a normal play turn. The ``finally``
+        # clause guarantees a ``phase=None`` clear on every exit path
+        # — including exceptions from the streamed LLM call, dispatcher,
+        # or apply-outcome — so the indicator can never show a stale
+        # label on the next thinking cycle.
         status_phase = "briefing" if session.state == SessionState.BRIEFING else "play"
 
         # Cumulative outcome across attempts. Holds the merged slot
@@ -306,179 +309,180 @@ class TurnDriver:
         prior_assistant_blocks: list[dict[str, Any]] | None = None
         prior_tool_results: list[dict[str, Any]] | None = None
 
-        while attempt < budget:
-            attempt += 1
-            recovery = active_directive is not None
-            # Labelled status: surface attempt N/M and the recovery kind
-            # so the operator can tell "AI is on attempt 2/3 because
-            # the first response missed a yield" from "AI is stuck"
-            # (issue #63 — the strict-retry loop was previously
-            # invisible to clients).
-            # Only the directive ``kind`` (e.g. ``"missing_yield"``) goes
-            # on the wire — NEVER the full ``user_nudge`` / ``system_addendum``
-            # text. Those carry plan-derived structure that's creator-only;
-            # broadcasting them would leak via the WS to participants.
-            await self._emit_ai_status(
-                session.id,
-                phase=status_phase,
-                attempt=attempt,
-                budget=budget,
-                recovery=active_directive.kind if active_directive else None,
-                turn_index=turn.index,
-            )
-
-            # Build messages. On a recovery pass replace the trailing
-            # kickoff/strict nudge with the directive's user_nudge,
-            # then splice the prior assistant tool_use blocks +
-            # dispatcher tool_results in as a proper Anthropic tool-
-            # loop pair.
-            messages = _play_messages(session, strict=recovery)
-            if (
-                recovery
-                and active_directive is not None
-                and active_directive.replays_prior_tool_loop
-                and prior_assistant_blocks is not None
-                and prior_tool_results is not None
-            ):
-                # Drop the trailing user nudge that ``_play_messages``
-                # appended; we'll re-insert a directive-specific one
-                # *after* the tool-loop pair.
-                if messages and messages[-1]["role"] == "user":
-                    messages.pop()
-                messages.append({"role": "assistant", "content": prior_assistant_blocks})
-                # tool_results + the directive's user_nudge in one user
-                # turn so the message sequence stays user → assistant →
-                # user (Anthropic accepts mixed tool_result + text
-                # blocks within a single user message).
-                recovery_blocks: list[dict[str, Any]] = list(prior_tool_results)
-                recovery_blocks.append(
-                    {"type": "text", "text": active_directive.user_nudge}
-                )
-                messages.append({"role": "user", "content": recovery_blocks})
-
-            system_blocks = build_play_system_blocks(session, registry=registry)
-            if active_directive is not None:
-                system_blocks.append(
-                    {"type": "text", "text": active_directive.system_addendum}
+        try:
+            while attempt < budget:
+                attempt += 1
+                recovery = active_directive is not None
+                # Labelled status: surface attempt N/M and the recovery kind
+                # so the operator can tell "AI is on attempt 2/3 because
+                # the first response missed a yield" from "AI is stuck"
+                # (issue #63 — the strict-retry loop was previously
+                # invisible to clients).
+                # Only the directive ``kind`` (e.g. ``"missing_yield"``) goes
+                # on the wire — NEVER the full ``user_nudge`` /
+                # ``system_addendum`` text. Those carry plan-derived
+                # structure that's creator-only; broadcasting them would
+                # leak via the WS to participants.
+                await self._emit_ai_status(
+                    session.id,
+                    phase=status_phase,
+                    attempt=attempt,
+                    budget=budget,
+                    recovery=active_directive.kind if active_directive else None,
+                    turn_index=turn.index,
                 )
 
-            # Tool surface. Recovery narrows to the directive's
-            # allowlist and pins tool_choice; first attempt exposes
-            # the full palette + extensions.
-            if active_directive is not None:
-                tools = [
-                    t
-                    for t in PLAY_TOOLS
-                    if t["name"] in active_directive.tools_allowlist
-                ]
-                tool_choice = active_directive.tool_choice
-            else:
-                tools = PLAY_TOOLS + dispatcher_extension_specs(registry)
-                tool_choice = None
+                # Build messages. On a recovery pass replace the trailing
+                # kickoff/strict nudge with the directive's user_nudge,
+                # then splice the prior assistant tool_use blocks +
+                # dispatcher tool_results in as a proper Anthropic tool-
+                # loop pair.
+                messages = _play_messages(session, strict=recovery)
+                if (
+                    recovery
+                    and active_directive is not None
+                    and active_directive.replays_prior_tool_loop
+                    and prior_assistant_blocks is not None
+                    and prior_tool_results is not None
+                ):
+                    # Drop the trailing user nudge that ``_play_messages``
+                    # appended; we'll re-insert a directive-specific one
+                    # *after* the tool-loop pair.
+                    if messages and messages[-1]["role"] == "user":
+                        messages.pop()
+                    messages.append({"role": "assistant", "content": prior_assistant_blocks})
+                    # tool_results + the directive's user_nudge in one user
+                    # turn so the message sequence stays user → assistant →
+                    # user (Anthropic accepts mixed tool_result + text
+                    # blocks within a single user message).
+                    recovery_blocks: list[dict[str, Any]] = list(prior_tool_results)
+                    recovery_blocks.append(
+                        {"type": "text", "text": active_directive.user_nudge}
+                    )
+                    messages.append({"role": "user", "content": recovery_blocks})
 
-            result = await self._streamed_play_call(
-                session=session,
-                turn=turn,
-                tier="play",
-                system_blocks=system_blocks,
-                messages=messages,
-                tools=tools,
-                tool_choice=tool_choice,
-            )
-            await self._apply_cost(session.id, result)
-            self._check_truncation(
-                session_id=session.id, tier="play", result=result, turn_id=turn.id
-            )
+                system_blocks = build_play_system_blocks(session, registry=registry)
+                if active_directive is not None:
+                    system_blocks.append(
+                        {"type": "text", "text": active_directive.system_addendum}
+                    )
 
-            tool_uses = _tool_uses(result)
-            outcome = await dispatcher.dispatch(
-                session=session,
-                tool_uses=tool_uses,
-                turn_id=turn.id,
-                critical_inject_allowed_cb=lambda: critical_inject_allowed(
-                    session,
-                    max_per_5_turns=settings.max_critical_injects_per_5_turns,
-                ),
-            )
+                # Tool surface. Recovery narrows to the directive's
+                # allowlist and pins tool_choice; first attempt exposes
+                # the full palette + extensions.
+                if active_directive is not None:
+                    tools = [
+                        t
+                        for t in PLAY_TOOLS
+                        if t["name"] in active_directive.tools_allowlist
+                    ]
+                    tool_choice = active_directive.tool_choice
+                else:
+                    tools = PLAY_TOOLS + dispatcher_extension_specs(registry)
+                    tool_choice = None
 
-            # Merge into the cumulative outcome — this is what the
-            # validator inspects.
-            _merge_outcomes(cumulative, outcome)
+                result = await self._streamed_play_call(
+                    session=session,
+                    turn=turn,
+                    tier="play",
+                    system_blocks=system_blocks,
+                    messages=messages,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                )
+                await self._apply_cost(session.id, result)
+                self._check_truncation(
+                    session_id=session.id, tier="play", result=result, turn_id=turn.id
+                )
 
-            # Validate cumulative state against the contract.
-            validation = validate(
-                session=session,
-                cumulative_slots=cumulative.slots,
-                contract=contract,
-                soft_drive_carve_out_enabled=settings.llm_recovery_drive_soft_on_open_question,
-            )
+                tool_uses = _tool_uses(result)
+                outcome = await dispatcher.dispatch(
+                    session=session,
+                    tool_uses=tool_uses,
+                    turn_id=turn.id,
+                    critical_inject_allowed_cb=lambda: critical_inject_allowed(
+                        session,
+                        max_per_5_turns=settings.max_critical_injects_per_5_turns,
+                    ),
+                )
 
-            _logger.info(
-                "turn_validation",
-                session_id=session.id,
-                turn_index=turn.index,
-                attempt=attempt,
-                slots=sorted(s.value for s in cumulative.slots),
-                violations=[d.kind for d in validation.violations],
-                warnings=validation.warnings,
-                ok=validation.ok,
-            )
+                # Merge into the cumulative outcome — this is what the
+                # validator inspects.
+                _merge_outcomes(cumulative, outcome)
 
-            if validation.ok:
-                # Persist + advance state.
+                # Validate cumulative state against the contract.
+                validation = validate(
+                    session=session,
+                    cumulative_slots=cumulative.slots,
+                    contract=contract,
+                    soft_drive_carve_out_enabled=settings.llm_recovery_drive_soft_on_open_question,
+                )
+
+                _logger.info(
+                    "turn_validation",
+                    session_id=session.id,
+                    turn_index=turn.index,
+                    attempt=attempt,
+                    slots=sorted(s.value for s in cumulative.slots),
+                    violations=[d.kind for d in validation.violations],
+                    warnings=validation.warnings,
+                    ok=validation.ok,
+                )
+
+                if validation.ok:
+                    # Persist + advance state.
+                    await self._apply_play_outcome(
+                        session,
+                        turn,
+                        cumulative,
+                        result_text=_all_text(result),
+                    )
+                    return session
+
+                # Not ok — pick the highest-priority directive and run
+                # another attempt (sequential calls, per the plan: DRIVE
+                # before YIELD).
+                if attempt >= budget:
+                    break
+
+                ordered = order_directives(validation.violations)
+                active_directive = ordered[0]
+                turn.retried_with_strict = True
+                prior_assistant_blocks = result.content
+                prior_tool_results = list(outcome.tool_results)
+                _logger.info(
+                    "turn_recovery_directive",
+                    session_id=session.id,
+                    turn_index=turn.index,
+                    attempt=attempt,
+                    kind=active_directive.kind,
+                    tools=sorted(active_directive.tools_allowlist),
+                )
+
+            # Budget exhausted with violations remaining. If a YIELD did
+            # land at some point we can still apply the outcome — players
+            # at least see the partial work. If no YIELD ever fired the
+            # turn is errored.
+            if Slot.YIELD in cumulative.slots or Slot.TERMINATE in cumulative.slots:
                 await self._apply_play_outcome(
-                    session,
-                    turn,
-                    cumulative,
-                    result_text=_all_text(result),
+                    session, turn, cumulative, result_text=""
                 )
-                await self._emit_ai_status(session.id, phase=None)
                 return session
 
-            # Not ok — pick the highest-priority directive and run
-            # another attempt (sequential calls, per the plan: DRIVE
-            # before YIELD).
-            if attempt >= budget:
-                break
-
-            ordered = order_directives(validation.violations)
-            active_directive = ordered[0]
-            turn.retried_with_strict = True
-            prior_assistant_blocks = result.content
-            prior_tool_results = list(outcome.tool_results)
-            _logger.info(
-                "turn_recovery_directive",
-                session_id=session.id,
-                turn_index=turn.index,
-                attempt=attempt,
-                kind=active_directive.kind,
-                tools=sorted(active_directive.tools_allowlist),
+            turn.status = "errored"
+            turn.error_reason = "model did not yield via a tool call"
+            await self._manager.connections().broadcast(
+                session.id,
+                {
+                    "type": "error",
+                    "scope": "turn",
+                    "message": "AI failed to yield. Use force-advance or retry.",
+                    "turn_index": turn.index,
+                },
             )
-
-        # Budget exhausted with violations remaining. If a YIELD did
-        # land at some point we can still apply the outcome — players
-        # at least see the partial work. If no YIELD ever fired the
-        # turn is errored.
-        if Slot.YIELD in cumulative.slots or Slot.TERMINATE in cumulative.slots:
-            await self._apply_play_outcome(
-                session, turn, cumulative, result_text=""
-            )
-            await self._emit_ai_status(session.id, phase=None)
             return session
-
-        turn.status = "errored"
-        turn.error_reason = "model did not yield via a tool call"
-        await self._manager.connections().broadcast(
-            session.id,
-            {
-                "type": "error",
-                "scope": "turn",
-                "message": "AI failed to yield. Use force-advance or retry.",
-                "turn_index": turn.index,
-            },
-        )
-        await self._emit_ai_status(session.id, phase=None)
-        return session
+        finally:
+            await self._emit_ai_status(session.id, phase=None)
 
     async def run_interject(
         self, *, session: Session, turn: Turn, for_role_id: str | None = None
@@ -531,7 +535,10 @@ class TurnDriver:
         # participant + everyone else knows the AI received the question
         # and is composing an answer (issue #63 — without this the entire
         # interject path was invisible because it doesn't change
-        # ``session.state``). Cleared in the finally below.
+        # ``session.state``). The ``finally`` clause guarantees the
+        # ``phase=None`` clear even if the streamed LLM call, dispatcher,
+        # or persist raises — without try/finally a stale "Replying to X"
+        # would otherwise be displayed on the next thinking cycle.
         await self._emit_ai_status(
             session.id,
             phase="interject",
@@ -539,57 +546,59 @@ class TurnDriver:
             for_role_id=for_role_id,
         )
 
-        messages = _play_messages(session, strict=False)
-        system_blocks = build_play_system_blocks(session, registry=registry)
-        system_blocks.append({"type": "text", "text": INTERJECT_NOTE})
+        try:
+            messages = _play_messages(session, strict=False)
+            system_blocks = build_play_system_blocks(session, registry=registry)
+            system_blocks.append({"type": "text", "text": INTERJECT_NOTE})
 
-        # Narrow tools to non-yielding narration only. ``set_active_roles``
-        # / ``end_session`` are the two yielding/terminal calls; excluding
-        # them guarantees the interject can't accidentally advance the
-        # turn or end the session.
-        allowed = {"broadcast", "address_role", "mark_timeline_point"}
-        tools = [t for t in PLAY_TOOLS if t["name"] in allowed]
-        tool_choice: dict[str, Any] = {"type": "any"}
+            # Narrow tools to non-yielding narration only. ``set_active_roles``
+            # / ``end_session`` are the two yielding/terminal calls; excluding
+            # them guarantees the interject can't accidentally advance the
+            # turn or end the session.
+            allowed = {"broadcast", "address_role", "mark_timeline_point"}
+            tools = [t for t in PLAY_TOOLS if t["name"] in allowed]
+            tool_choice: dict[str, Any] = {"type": "any"}
 
-        result = await self._streamed_play_call(
-            session=session,
-            turn=turn,
-            tier="play",
-            system_blocks=system_blocks,
-            messages=messages,
-            tools=tools,
-            tool_choice=tool_choice,
-        )
-        await self._apply_cost(session.id, result)
-
-        tool_uses = _tool_uses(result)
-        outcome = await dispatcher.dispatch(
-            session=session,
-            tool_uses=tool_uses,
-            turn_id=turn.id,
-            critical_inject_allowed_cb=lambda: critical_inject_allowed(
-                session,
-                max_per_5_turns=self._manager.settings().max_critical_injects_per_5_turns,
-            ),
-        )
-        # Persist appended messages but do NOT touch turn state — the
-        # interject is purely additive content.
-        for msg in outcome.appended_messages:
-            session.messages.append(msg)
-            await self._manager.connections().broadcast(
-                session.id,
-                {
-                    "type": "message_complete",
-                    "kind": msg.kind.value,
-                    "body": msg.body,
-                    "tool_name": msg.tool_name,
-                    "tool_args": msg.tool_args,
-                    "turn_id": turn.id,
-                },
+            result = await self._streamed_play_call(
+                session=session,
+                turn=turn,
+                tier="play",
+                system_blocks=system_blocks,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
             )
-        await self._manager._repo.save(session)
-        await self._emit_ai_status(session.id, phase=None)
-        return session
+            await self._apply_cost(session.id, result)
+
+            tool_uses = _tool_uses(result)
+            outcome = await dispatcher.dispatch(
+                session=session,
+                tool_uses=tool_uses,
+                turn_id=turn.id,
+                critical_inject_allowed_cb=lambda: critical_inject_allowed(
+                    session,
+                    max_per_5_turns=self._manager.settings().max_critical_injects_per_5_turns,
+                ),
+            )
+            # Persist appended messages but do NOT touch turn state — the
+            # interject is purely additive content.
+            for msg in outcome.appended_messages:
+                session.messages.append(msg)
+                await self._manager.connections().broadcast(
+                    session.id,
+                    {
+                        "type": "message_complete",
+                        "kind": msg.kind.value,
+                        "body": msg.body,
+                        "tool_name": msg.tool_name,
+                        "tool_args": msg.tool_args,
+                        "turn_id": turn.id,
+                    },
+                )
+            await self._manager._repo.save(session)
+            return session
+        finally:
+            await self._emit_ai_status(session.id, phase=None)
 
     # ------------------------------------------------- internals
     async def _streamed_play_call(

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -61,6 +61,49 @@ class TurnDriver:
     def __init__(self, *, manager: SessionManager) -> None:
         self._manager = manager
 
+    async def _emit_ai_status(
+        self,
+        session_id: str,
+        *,
+        phase: str | None,
+        attempt: int | None = None,
+        budget: int | None = None,
+        recovery: str | None = None,
+        turn_index: int | None = None,
+        for_role_id: str | None = None,
+    ) -> None:
+        """Broadcast a labelled "what is the AI doing?" breadcrumb.
+
+        ``ai_thinking`` (emitted from the LLM-call boundary) answers
+        "is anything running"; ``ai_status`` (this method) answers
+        "what should the human see?". Failure to emit must NOT break
+        the turn — wrap and log.
+
+        ``record=False`` because the breadcrumb is stale on reconnect.
+        """
+
+        try:
+            await self._manager.connections().broadcast(
+                session_id,
+                {
+                    "type": "ai_status",
+                    "phase": phase,
+                    "attempt": attempt,
+                    "budget": budget,
+                    "recovery": recovery,
+                    "turn_index": turn_index,
+                    "for_role_id": for_role_id,
+                },
+                record=False,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "ai_status_broadcast_failed",
+                session_id=session_id,
+                phase=phase,
+                error=str(exc),
+            )
+
     def _check_truncation(
         self,
         *,
@@ -124,62 +167,71 @@ class TurnDriver:
             note_count=len(session.setup_notes),
             has_plan=session.plan is not None,
         )
+        # Light up the labelled indicator so the creator sees "AI —
+        # Designing the scenario" while the setup tier is at work.
+        # The ``finally`` clause clears it on every return path; the
+        # ``ai_thinking`` events from the LLM-call boundary handle the
+        # binary "is something running" signal.
+        await self._emit_ai_status(session.id, phase="setup")
 
-        # Safety cap on chained setup tool calls — operator-tunable via
-        # ``MAX_SETUP_TURNS``. Lifting it lets a model that wants to
-        # ``ask_setup_question`` → ``propose_scenario_plan`` → ``finalize_setup``
-        # in one cycle do so without a premature break.
-        for _ in range(self._manager.settings().max_setup_turns):
-            messages = _setup_messages(session)
-            result = await llm.acomplete(
-                tier="setup",
-                system_blocks=build_setup_system_blocks(session),
-                messages=messages,
-                # Pin ``tool_choice`` to "any" so the model MUST emit a
-                # setup tool call. Eliminates the bare-text leak path
-                # entirely — the only way the setup tier can produce
-                # text without a tool is if the SDK contract is
-                # violated, in which case we discard below.
-                tool_choice=tool_choice_for("setup"),
-                tools=SETUP_TOOLS,
-                # Per-tier default from settings.max_tokens_for(tier) — call passes None.
-                session_id=session.id,
-            )
-            await self._apply_cost(session.id, result)
-            self._check_truncation(session_id=session.id, tier="setup", result=result)
+        try:
+            # Safety cap on chained setup tool calls — operator-tunable via
+            # ``MAX_SETUP_TURNS``. Lifting it lets a model that wants to
+            # ``ask_setup_question`` → ``propose_scenario_plan`` →
+            # ``finalize_setup`` in one cycle do so without a premature break.
+            for _ in range(self._manager.settings().max_setup_turns):
+                messages = _setup_messages(session)
+                result = await llm.acomplete(
+                    tier="setup",
+                    system_blocks=build_setup_system_blocks(session),
+                    messages=messages,
+                    # Pin ``tool_choice`` to "any" so the model MUST emit a
+                    # setup tool call. Eliminates the bare-text leak path
+                    # entirely — the only way the setup tier can produce
+                    # text without a tool is if the SDK contract is
+                    # violated, in which case we discard below.
+                    tool_choice=tool_choice_for("setup"),
+                    tools=SETUP_TOOLS,
+                    # Per-tier default from settings.max_tokens_for(tier) — call passes None.
+                    session_id=session.id,
+                )
+                await self._apply_cost(session.id, result)
+                self._check_truncation(session_id=session.id, tier="setup", result=result)
 
-            tool_uses = _tool_uses(result)
-            if not tool_uses:
-                # Bare text from the setup tier should be impossible:
-                # ``tool_choice={"type":"any"}`` forces a tool call.
-                # If we land here anyway (SDK contract violation, mock
-                # in tests, or a future refactor that drops the pin),
-                # discard the text rather than persist it — the
-                # transcript belongs to the play tier and we don't
-                # want setup-style assistant prose leaking into the
-                # play history. Log loudly so the regression is
-                # visible.
-                text = _all_text(result)
-                if text:
-                    _logger.warning(
-                        "setup_tier_bare_text_discarded",
-                        session_id=session.id,
-                        chars=len(text),
-                    )
-                return session
+                tool_uses = _tool_uses(result)
+                if not tool_uses:
+                    # Bare text from the setup tier should be impossible:
+                    # ``tool_choice={"type":"any"}`` forces a tool call.
+                    # If we land here anyway (SDK contract violation, mock
+                    # in tests, or a future refactor that drops the pin),
+                    # discard the text rather than persist it — the
+                    # transcript belongs to the play tier and we don't
+                    # want setup-style assistant prose leaking into the
+                    # play history. Log loudly so the regression is
+                    # visible.
+                    text = _all_text(result)
+                    if text:
+                        _logger.warning(
+                            "setup_tier_bare_text_discarded",
+                            session_id=session.id,
+                            chars=len(text),
+                        )
+                    return session
 
-            outcome = await dispatcher.dispatch(
-                session=session,
-                tool_uses=tool_uses,
-                turn_id=None,
-                critical_inject_allowed_cb=lambda: True,
-            )
-            await self._apply_setup_outcome(session, outcome)
-            # All three setup tools (ask_setup_question / propose / finalize)
-            # set ``had_yielding_call`` — that's our single yield signal.
-            if outcome.had_yielding_call:
-                return session
-        return session
+                outcome = await dispatcher.dispatch(
+                    session=session,
+                    tool_uses=tool_uses,
+                    turn_id=None,
+                    critical_inject_allowed_cb=lambda: True,
+                )
+                await self._apply_setup_outcome(session, outcome)
+                # All three setup tools (ask_setup_question / propose / finalize)
+                # set ``had_yielding_call`` — that's our single yield signal.
+                if outcome.had_yielding_call:
+                    return session
+            return session
+        finally:
+            await self._emit_ai_status(session.id, phase=None)
 
     async def run_play_turn(self, *, session: Session, turn: Turn) -> Session:
         """Drive one play-tier turn end-to-end via the turn validator.
@@ -231,6 +283,13 @@ class TurnDriver:
         budget = 1 + settings.llm_strict_retry_max
         attempt = 0
 
+        # Phase label for the labelled "what is the AI doing?" indicator.
+        # When state is BRIEFING we expose ``phase=briefing`` so the UI
+        # can render "Briefing the team" instead of a generic play
+        # status; otherwise it's a normal play turn. Cleared on every
+        # return path via ``finally``.
+        status_phase = "briefing" if session.state == SessionState.BRIEFING else "play"
+
         # Cumulative outcome across attempts. Holds the merged slot
         # set + appended messages + tool_results so the validator sees
         # everything that fired this turn, not just the latest attempt.
@@ -250,6 +309,23 @@ class TurnDriver:
         while attempt < budget:
             attempt += 1
             recovery = active_directive is not None
+            # Labelled status: surface attempt N/M and the recovery kind
+            # so the operator can tell "AI is on attempt 2/3 because
+            # the first response missed a yield" from "AI is stuck"
+            # (issue #63 — the strict-retry loop was previously
+            # invisible to clients).
+            # Only the directive ``kind`` (e.g. ``"missing_yield"``) goes
+            # on the wire — NEVER the full ``user_nudge`` / ``system_addendum``
+            # text. Those carry plan-derived structure that's creator-only;
+            # broadcasting them would leak via the WS to participants.
+            await self._emit_ai_status(
+                session.id,
+                phase=status_phase,
+                attempt=attempt,
+                budget=budget,
+                recovery=active_directive.kind if active_directive else None,
+                turn_index=turn.index,
+            )
 
             # Build messages. On a recovery pass replace the trailing
             # kickoff/strict nudge with the directive's user_nudge,
@@ -356,6 +432,7 @@ class TurnDriver:
                     cumulative,
                     result_text=_all_text(result),
                 )
+                await self._emit_ai_status(session.id, phase=None)
                 return session
 
             # Not ok — pick the highest-priority directive and run
@@ -386,6 +463,7 @@ class TurnDriver:
             await self._apply_play_outcome(
                 session, turn, cumulative, result_text=""
             )
+            await self._emit_ai_status(session.id, phase=None)
             return session
 
         turn.status = "errored"
@@ -399,9 +477,12 @@ class TurnDriver:
                 "turn_index": turn.index,
             },
         )
+        await self._emit_ai_status(session.id, phase=None)
         return session
 
-    async def run_interject(self, *, session: Session, turn: Turn) -> Session:
+    async def run_interject(
+        self, *, session: Session, turn: Turn, for_role_id: str | None = None
+    ) -> Session:
         """Side-channel AI response that does NOT advance the turn.
 
         Triggered when a player asks the facilitator a direct question
@@ -444,6 +525,18 @@ class TurnDriver:
             "interject_start",
             session_id=session.id,
             turn_index=turn.index,
+            for_role_id=for_role_id,
+        )
+        # Light up the labelled "Replying to {role}" status so the asking
+        # participant + everyone else knows the AI received the question
+        # and is composing an answer (issue #63 — without this the entire
+        # interject path was invisible because it doesn't change
+        # ``session.state``). Cleared in the finally below.
+        await self._emit_ai_status(
+            session.id,
+            phase="interject",
+            turn_index=turn.index,
+            for_role_id=for_role_id,
         )
 
         messages = _play_messages(session, strict=False)
@@ -495,6 +588,7 @@ class TurnDriver:
                 },
             )
         await self._manager._repo.save(session)
+        await self._emit_ai_status(session.id, phase=None)
         return session
 
     # ------------------------------------------------- internals

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -418,7 +418,7 @@ async def _client_pump(
                     turn = session.current_turn
                     if turn is not None:
                         await TurnDriver(manager=manager).run_interject(
-                            session=session, turn=turn
+                            session=session, turn=turn, for_role_id=role_id
                         )
             elif event_type == "request_force_advance":
                 try:

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -34,6 +34,12 @@ def _e2e_env(monkeypatch) -> None:
     monkeypatch.setenv("SESSION_SECRET", "x" * 32)
     monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
     monkeypatch.setenv("EXTENSIONS_TOOLS_JSON", _TOOLS_JSON)
+    # The 2-role / 12-role drivers in this file submit the same body
+    # ("Acknowledged, taking action.") every turn for every active
+    # role. The new same-body dedupe guard (issue #63) would reject
+    # the repeat in real sessions, but the e2e drive loop relies on
+    # the repetition to walk the state machine. Disable the window.
+    monkeypatch.setenv("DUPLICATE_SUBMISSION_WINDOW_SECONDS", "0")
     reset_settings_cache()
 
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -1,0 +1,197 @@
+"""Tests for the LLM client's ``ai_thinking`` boundary broadcasts.
+
+The session UI's "AI is thinking" indicator was previously gated on
+``session.state``, leaving interject / guardrail / setup / AAR work
+invisible to clients. Issue #63 fixed that by promoting the LLM-call
+boundary tracker to a real-time WS broadcast — these tests pin the
+contract: every call begins with ``ai_thinking active=True`` and ends
+with ``active=False`` (matching ``call_id``), on success **and** on
+exception.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from app.config import Settings
+from app.llm.client import LLMClient
+from tests.mock_anthropic import MockAnthropic, response, text_block
+
+
+class _RecordingConnections:
+    """Minimal ``ConnectionManager`` stand-in. Captures every broadcast
+    call so tests can assert on the event stream.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any], bool]] = []
+
+    async def broadcast(
+        self, session_id: str, event: dict[str, Any], *, record: bool = True
+    ) -> None:
+        self.events.append((session_id, event, record))
+
+    def ai_thinking_events(self) -> list[dict[str, Any]]:
+        return [evt for _, evt, _ in self.events if evt.get("type") == "ai_thinking"]
+
+
+@pytest.fixture
+def settings(monkeypatch) -> Settings:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "x")
+    monkeypatch.setenv("ANTHROPIC_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("ANTHROPIC_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("ANTHROPIC_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("ANTHROPIC_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    return Settings()
+
+
+async def _drain() -> None:
+    """Yield to the loop so fire-and-forget broadcast tasks complete."""
+
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_acomplete_emits_paired_thinking_events(settings: Settings) -> None:
+    llm = LLMClient(settings=settings)
+    conns = _RecordingConnections()
+    llm.set_connections(conns)
+    mock = MockAnthropic({"play": [response(text_block("ok"))]})
+    llm.set_transport(mock.messages)
+
+    await llm.acomplete(
+        tier="play",
+        system_blocks=[{"type": "text", "text": "sys"}],
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess-1",
+    )
+    await _drain()
+
+    events = conns.ai_thinking_events()
+    assert len(events) == 2, events
+    start, stop = events
+    assert start["active"] is True
+    assert stop["active"] is False
+    assert start["call_id"] == stop["call_id"]
+    assert start["tier"] == "play"
+    # Ephemeral broadcast — record=False so a reconnect doesn't replay
+    # a stale "thinking" event for a call that finished long ago.
+    assert all(record is False for _, evt, record in conns.events if evt.get("type") == "ai_thinking")
+
+
+@pytest.mark.asyncio
+async def test_acomplete_emits_stop_event_on_exception(settings: Settings) -> None:
+    """``CancelledError`` / generic exceptions in the LLM call must not
+    leave the indicator pinned. The ``finally`` block in ``acomplete``
+    is what guarantees the stop event."""
+
+    llm = LLMClient(settings=settings)
+    conns = _RecordingConnections()
+    llm.set_connections(conns)
+
+    class _Boom:
+        async def create(self, **kwargs: Any) -> Any:
+            raise RuntimeError("upstream blew up")
+
+        def stream(self, **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+    llm.set_transport(_Boom())
+
+    with pytest.raises(RuntimeError):
+        await llm.acomplete(
+            tier="play",
+            system_blocks=[{"type": "text", "text": "sys"}],
+            messages=[{"role": "user", "content": "hi"}],
+            session_id="sess-2",
+        )
+    await _drain()
+
+    events = conns.ai_thinking_events()
+    assert [e["active"] for e in events] == [True, False]
+    assert events[0]["call_id"] == events[1]["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_astream_emits_paired_thinking_events(settings: Settings) -> None:
+    llm = LLMClient(settings=settings)
+    conns = _RecordingConnections()
+    llm.set_connections(conns)
+    mock = MockAnthropic({"play": [response(text_block("streamed"))]})
+    llm.set_transport(mock.messages)
+
+    final: dict[str, Any] = {}
+    async for event in llm.astream(
+        tier="play",
+        system_blocks=[{"type": "text", "text": "sys"}],
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess-3",
+    ):
+        if event.get("type") == "complete":
+            final["result"] = event["result"]
+    await _drain()
+
+    assert "result" in final
+    events = conns.ai_thinking_events()
+    assert [e["active"] for e in events] == [True, False]
+    assert events[0]["call_id"] == events[1]["call_id"]
+    assert events[0]["tier"] == "play"
+
+
+@pytest.mark.asyncio
+async def test_no_broadcast_without_session_id(settings: Settings) -> None:
+    """Calls without a ``session_id`` (e.g. one-off probes) should not
+    emit per-session ``ai_thinking`` events — there's no UI to update."""
+
+    llm = LLMClient(settings=settings)
+    conns = _RecordingConnections()
+    llm.set_connections(conns)
+    mock = MockAnthropic({"play": [response(text_block("ok"))]})
+    llm.set_transport(mock.messages)
+
+    await llm.acomplete(
+        tier="play",
+        system_blocks=[{"type": "text", "text": "sys"}],
+        messages=[{"role": "user", "content": "hi"}],
+        session_id=None,
+    )
+    await _drain()
+
+    assert conns.ai_thinking_events() == []
+
+
+@pytest.mark.asyncio
+async def test_call_id_appears_in_in_flight(settings: Settings) -> None:
+    """The activity endpoint serialises ``InFlightCall`` and now exposes
+    ``call_id`` so the operator UI can cross-reference an entry with the
+    matching WS event stream."""
+
+    llm = LLMClient(settings=settings)
+
+    class _SlowMessages:
+        async def create(self, **kwargs: Any) -> Any:
+            # While this awaits, the in_flight tracker should have one entry.
+            in_flight = llm.in_flight_for("sess-4")
+            assert len(in_flight) == 1
+            assert in_flight[0].call_id  # non-empty
+            assert isinstance(in_flight[0].call_id, str)
+            from tests.mock_anthropic import _ContentBlock, _Response
+
+            return _Response(content=[_ContentBlock(type="text", text="ok")])
+
+        def stream(self, **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+    llm.set_transport(_SlowMessages())
+    await llm.acomplete(
+        tier="play",
+        system_blocks=[{"type": "text", "text": "sys"}],
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess-4",
+    )

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -1,0 +1,276 @@
+"""Targeted tests for SessionManager guards added in issue #63:
+
+* ``force_advance`` rejects with ``IllegalTransitionError`` while a
+  play-tier LLM call is in flight (defense-in-depth — the new
+  ``ai_thinking`` indicator is the primary fix; this stops the
+  triple-banner cascade visible in the screenshot timeline if an
+  impatient operator double-clicks anyway).
+* ``submit_response`` rejects an exact same-body resubmission within
+  the dedupe window (backstop for the no-feedback retype loop).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.llm.client import InFlightCall
+from app.main import create_app
+from app.sessions.turn_engine import IllegalTransitionError
+from tests.mock_anthropic import MockAnthropic, setup_then_play_script
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("ANTHROPIC_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("ANTHROPIC_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("ANTHROPIC_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    reset_settings_cache()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as c:
+        c.app.state.llm.set_transport(MockAnthropic({}).messages)
+        yield c
+
+
+def _seat_two(client: TestClient) -> dict[str, Any]:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Ransomware via vendor portal",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+        },
+    )
+    assert resp.status_code == 200
+    created = resp.json()
+    sid = created["session_id"]
+    creator_token = created["creator_token"]
+    creator_role_id = created["creator_role_id"]
+    r = client.post(
+        f"/api/sessions/{sid}/roles?token={creator_token}",
+        json={"label": "Player_1", "display_name": "P1"},
+    )
+    assert r.status_code == 200
+    other = r.json()
+    return {
+        "sid": sid,
+        "creator_token": creator_token,
+        "creator_role_id": creator_role_id,
+        "other_token": other["token"],
+        "other_role_id": other["role_id"],
+    }
+
+
+def _drive_to_play(client: TestClient, seats: dict[str, Any]) -> None:
+    role_ids = [seats["creator_role_id"], seats["other_role_id"]]
+    scripts = setup_then_play_script(role_ids=role_ids, extension_tool="")
+    client.app.state.llm.set_transport(MockAnthropic(scripts).messages)
+    client.post(f"/api/sessions/{seats['sid']}/setup/skip?token={seats['creator_token']}")
+    client.post(f"/api/sessions/{seats['sid']}/start?token={seats['creator_token']}")
+
+
+# --------------------------------------------------- force_advance gate
+def test_force_advance_rejects_while_play_tier_call_in_flight(client: TestClient) -> None:
+    """Issue #63: force-advance must NOT race a still-streaming play
+    LLM call. We simulate "play call in flight" by injecting an
+    ``InFlightCall`` directly into the LLM client's tracker."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(f"/api/sessions/{seats['sid']}?token={seats['creator_token']}").json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+
+    # Inject a fake play-tier call into _in_flight to simulate "AI is
+    # mid-stream right now".
+    llm = client.app.state.llm
+    fake = InFlightCall(
+        tier="play", model="mock-play", stream=True, started_at=time.monotonic()
+    )
+    llm._in_flight.setdefault(seats["sid"], []).append(fake)
+    try:
+        r = client.post(
+            f"/api/sessions/{seats['sid']}/force-advance?token={seats['creator_token']}"
+        )
+        # The route layer surfaces IllegalTransitionError as an HTTP 4xx.
+        assert r.status_code in (400, 409, 422), r.text
+        assert "still processing" in r.text.lower()
+    finally:
+        llm._in_flight[seats["sid"]].remove(fake)
+        if not llm._in_flight[seats["sid"]]:
+            llm._in_flight.pop(seats["sid"], None)
+
+
+def test_force_advance_allowed_with_only_non_play_calls_in_flight(
+    client: TestClient,
+) -> None:
+    """A guardrail / setup / AAR call in flight must NOT block force-advance —
+    the operator needs to be able to recover from a hung non-play call."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(f"/api/sessions/{seats['sid']}?token={seats['creator_token']}").json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+
+    llm = client.app.state.llm
+    fake = InFlightCall(
+        tier="guardrail",
+        model="mock-guardrail",
+        stream=False,
+        started_at=time.monotonic(),
+    )
+    llm._in_flight.setdefault(seats["sid"], []).append(fake)
+    try:
+        r = client.post(
+            f"/api/sessions/{seats['sid']}/force-advance?token={seats['creator_token']}"
+        )
+        assert r.status_code == 200, r.text
+    finally:
+        bucket = llm._in_flight.get(seats["sid"], [])
+        if fake in bucket:
+            bucket.remove(fake)
+        if seats["sid"] in llm._in_flight and not llm._in_flight[seats["sid"]]:
+            llm._in_flight.pop(seats["sid"], None)
+
+
+# ---------------------------------------------------- duplicate dedupe
+def _active_role(client: TestClient, seats: dict[str, Any]) -> tuple[str, str]:
+    """Return ``(role_id, token)`` for whichever seated role is in the
+    current turn's active set. ``setup_then_play_script`` opens the
+    play turn with ``set_active_roles=[role_ids[0]]`` (the creator),
+    but we read the snapshot rather than hardcoding so a future script
+    tweak doesn't silently skip these tests."""
+
+    snap = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['creator_token']}"
+    ).json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+    active = snap["current_turn"]["active_role_ids"]
+    role_to_token = {
+        seats["creator_role_id"]: seats["creator_token"],
+        seats["other_role_id"]: seats["other_token"],
+    }
+    for rid in active:
+        if rid in role_to_token:
+            return rid, role_to_token[rid]
+    pytest.skip("no seated role in active set")
+
+
+async def _force_two_active(client: TestClient, seats: dict[str, Any]) -> None:
+    """Make both seated roles active on the current turn so the first
+    submission doesn't auto-advance state out of AWAITING_PLAYERS — we
+    need the second submit to reach the dedupe guard rather than fail
+    at the prior "session is not awaiting player input" check."""
+
+    manager = client.app.state.manager
+    sid = seats["sid"]
+    async with await manager._lock_for(sid):
+        session = await manager._repo.get(sid)
+        turn = session.current_turn
+        assert turn is not None
+        turn.active_role_ids = [seats["creator_role_id"], seats["other_role_id"]]
+        turn.submitted_role_ids = []
+        await manager._repo.save(session)
+
+
+async def _allow_resubmit(client: TestClient, role_id: str, sid: str) -> None:
+    """Clear ``submitted_role_ids`` so the role can submit again on the
+    current turn — simulates the screenshot scenario where the engine
+    advanced to a new turn that re-added the role to the active set
+    (so the dedupe guard, not ``can_submit``, is what catches the
+    identical body)."""
+
+    manager = client.app.state.manager
+    async with await manager._lock_for(sid):
+        session = await manager._repo.get(sid)
+        turn = session.current_turn
+        assert turn is not None
+        if role_id in turn.submitted_role_ids:
+            turn.submitted_role_ids.remove(role_id)
+        await manager._repo.save(session)
+
+
+@pytest.mark.asyncio
+async def test_submit_response_rejects_same_body_within_window(
+    client: TestClient,
+) -> None:
+    """A second submission with identical body from the same role within
+    ``DUPLICATE_SUBMISSION_WINDOW_SECONDS`` must be rejected. Backstop
+    for the screenshot bug — the user retyped because they had no
+    feedback; once they do, this guard prevents the residual stray
+    double-Enter from producing two visible bubbles."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['creator_token']}"
+    ).json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+    await _force_two_active(client, seats)
+
+    manager = client.app.state.manager
+    body = "I'm looking at the service account auth logs, what do I see"
+    # First submit lands. With both roles active, the turn does NOT
+    # auto-advance, so the state stays AWAITING_PLAYERS.
+    await manager.submit_response(
+        session_id=seats["sid"],
+        role_id=seats["other_role_id"],
+        content=body,
+    )
+    # Re-allow this role to submit (simulates a new turn opening with
+    # the same role active again; without this the prior ``can_submit``
+    # gate fires before the dedupe check).
+    await _allow_resubmit(client, seats["other_role_id"], seats["sid"])
+    with pytest.raises(IllegalTransitionError) as excinfo:
+        await manager.submit_response(
+            session_id=seats["sid"],
+            role_id=seats["other_role_id"],
+            content=body,
+        )
+    assert "same message" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_submit_response_allows_distinct_bodies(client: TestClient) -> None:
+    """Different bodies from the same role are not duplicates — and a
+    bare repeat from a *different* role is also not a duplicate (the
+    dedupe guard only inspects same-role same-body)."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['creator_token']}"
+    ).json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+    await _force_two_active(client, seats)
+
+    manager = client.app.state.manager
+    await manager.submit_response(
+        session_id=seats["sid"],
+        role_id=seats["other_role_id"],
+        content="first body",
+    )
+    await _allow_resubmit(client, seats["other_role_id"], seats["sid"])
+    # Distinct body from same role — must NOT be flagged duplicate.
+    await manager.submit_response(
+        session_id=seats["sid"],
+        role_id=seats["other_role_id"],
+        content="different body",
+    )

--- a/backend/tests/test_turn_driver.py
+++ b/backend/tests/test_turn_driver.py
@@ -1,0 +1,192 @@
+"""Tests for the labelled ``ai_status`` breadcrumbs emitted by the
+turn driver (issue #63 — without these, the operator could not tell
+"AI is on recovery pass 2/3" from "AI is stuck", and the entire
+``run_interject`` path was invisible to clients because state stays
+``AWAITING_PLAYERS`` throughout)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.main import create_app
+from tests.mock_anthropic import MockAnthropic, setup_then_play_script
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("ANTHROPIC_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("ANTHROPIC_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("ANTHROPIC_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    reset_settings_cache()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as c:
+        c.app.state.llm.set_transport(MockAnthropic({}).messages)
+        yield c
+
+
+def _seat_two(client: TestClient) -> dict[str, Any]:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Ransomware via vendor portal",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+        },
+    )
+    created = resp.json()
+    sid = created["session_id"]
+    creator_token = created["creator_token"]
+    creator_role_id = created["creator_role_id"]
+    r = client.post(
+        f"/api/sessions/{sid}/roles?token={creator_token}",
+        json={"label": "Player_1", "display_name": "P1"},
+    )
+    other = r.json()
+    return {
+        "sid": sid,
+        "creator_token": creator_token,
+        "creator_role_id": creator_role_id,
+        "other_token": other["token"],
+        "other_role_id": other["role_id"],
+    }
+
+
+def _drive_to_play(client: TestClient, seats: dict[str, Any]) -> None:
+    role_ids = [seats["creator_role_id"], seats["other_role_id"]]
+    scripts = setup_then_play_script(role_ids=role_ids, extension_tool="")
+    client.app.state.llm.set_transport(MockAnthropic(scripts).messages)
+    client.post(f"/api/sessions/{seats['sid']}/setup/skip?token={seats['creator_token']}")
+    client.post(f"/api/sessions/{seats['sid']}/start?token={seats['creator_token']}")
+
+
+class _RecordingConnections:
+    def __init__(self, real: Any) -> None:
+        self._real = real
+        self.events: list[dict[str, Any]] = []
+
+    async def broadcast(
+        self, session_id: str, event: dict[str, Any], *, record: bool = True
+    ) -> None:
+        self.events.append({**event, "_session_id": session_id, "_record": record})
+        await self._real.broadcast(session_id, event, record=record)
+
+    async def send_to_role(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.send_to_role(*args, **kwargs)
+
+    async def shutdown(self) -> Any:
+        return await self._real.shutdown()
+
+    async def connected_role_ids(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.connected_role_ids(*args, **kwargs)
+
+    async def role_has_other_connections(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.role_has_other_connections(*args, **kwargs)
+
+    async def register(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.register(*args, **kwargs)
+
+    async def unregister(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.unregister(*args, **kwargs)
+
+    async def stream(self, *args: Any, **kwargs: Any) -> Any:
+        return self._real.stream(*args, **kwargs)
+
+
+def _wrap_connections(client: TestClient) -> _RecordingConnections:
+    real = client.app.state.connections
+    rec = _RecordingConnections(real)
+    client.app.state.connections = rec
+    # The manager and LLM client cache references to the original; rewire.
+    client.app.state.manager._connections = rec
+    client.app.state.llm.set_connections(rec)
+    return rec
+
+
+def _ai_statuses(rec: _RecordingConnections) -> list[dict[str, Any]]:
+    return [e for e in rec.events if e.get("type") == "ai_status"]
+
+
+def test_run_play_turn_emits_ai_status_with_phase_play(client: TestClient) -> None:
+    """The play-tier turn driver must light the labelled status during
+    its LLM call so the operator sees something more specific than
+    just "thinking"."""
+
+    rec = _wrap_connections(client)
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    statuses = _ai_statuses(rec)
+    # We expect at least: phase=briefing or phase=play (start) and a
+    # final phase=null (cleanup). The exact count depends on the
+    # scripted recovery path — we just assert the structure.
+    phases = [e["phase"] for e in statuses]
+    assert any(p in ("play", "briefing") for p in phases), phases
+    # Cleanup emits a null phase before returning.
+    assert phases[-1] is None, phases
+
+
+@pytest.mark.asyncio
+async def test_run_interject_emits_phase_interject(client: TestClient) -> None:
+    """The interject path was the primary screenshot bug: a participant
+    asks a question, the AI is busy, but state stays AWAITING_PLAYERS
+    so the indicator was dark. Now ``run_interject`` must emit
+    ``phase=interject`` before the LLM call and ``phase=None`` on exit.
+    """
+
+    from app.sessions.turn_driver import TurnDriver
+
+    rec = _wrap_connections(client)
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    sid = seats["sid"]
+    snap = client.get(f"/api/sessions/{sid}?token={seats['creator_token']}").json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+
+    manager = client.app.state.manager
+    rec.events.clear()
+    session = await manager.get_session(sid)
+    turn = session.current_turn
+    assert turn is not None
+    await TurnDriver(manager=manager).run_interject(
+        session=session, turn=turn, for_role_id=seats["other_role_id"]
+    )
+
+    statuses = _ai_statuses(rec)
+    phases = [(e["phase"], e.get("for_role_id")) for e in statuses]
+    assert any(p == "interject" for p, _ in phases), phases
+    interject_emit = next(e for e in statuses if e["phase"] == "interject")
+    assert interject_emit["for_role_id"] == seats["other_role_id"]
+    assert phases[-1][0] is None, phases
+
+
+def test_ai_status_events_are_not_recorded_in_replay_buffer(client: TestClient) -> None:
+    """``ai_status`` and ``ai_thinking`` are stale on reconnect and
+    must NOT clog the bounded replay buffer. Verify the
+    ``_record`` flag is False on every emit."""
+
+    rec = _wrap_connections(client)
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    statuses = _ai_statuses(rec)
+    assert statuses, "expected at least one ai_status event during play turn"
+    for evt in statuses:
+        assert evt["_record"] is False, evt
+    thinkings = [e for e in rec.events if e.get("type") == "ai_thinking"]
+    for evt in thinkings:
+        assert evt["_record"] is False, evt

--- a/frontend/src/__tests__/Transcript.test.tsx
+++ b/frontend/src/__tests__/Transcript.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RoleView } from "../api/client";
+import { Transcript } from "../components/Transcript";
+
+const ROLES: RoleView[] = [
+  {
+    id: "r1",
+    label: "CISO",
+    display_name: "Alex",
+    kind: "player",
+    token_version: 0,
+    is_creator: true,
+  },
+];
+
+describe("Transcript", () => {
+  it("renders the default 'AI Facilitator is typing…' indicator when aiThinking and no label", () => {
+    render(<Transcript messages={[]} roles={ROLES} aiThinking />);
+    expect(
+      screen.getByText(/AI Facilitator is typing/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the labelled status when aiStatusLabel is provided", () => {
+    // Issue #63: the operator must be able to tell "thinking" from
+    // "stuck" during the play-tier strict-retry loop. The label is
+    // appended to the indicator so a recovery pass shows up as
+    // "AI Facilitator — Recovery pass 2/3 (missing yield)" instead of
+    // just the generic typing string.
+    render(
+      <Transcript
+        messages={[]}
+        roles={ROLES}
+        aiThinking
+        aiStatusLabel="Recovery pass 2/3 (missing yield)"
+      />,
+    );
+    expect(
+      screen.getByText(/AI Facilitator — Recovery pass 2\/3 \(missing yield\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render the indicator when aiThinking is false", () => {
+    render(
+      <Transcript
+        messages={[]}
+        roles={ROLES}
+        aiThinking={false}
+        aiStatusLabel="Replying to SOC Analyst"
+      />,
+    );
+    expect(screen.queryByText(/AI Facilitator/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the indicator while streamingText is non-empty", () => {
+    // Streaming text takes precedence — the bubble renders the partial
+    // response, so a separate "thinking" indicator would be redundant.
+    render(
+      <Transcript
+        messages={[]}
+        roles={ROLES}
+        aiThinking
+        aiStatusLabel="Recovery pass 2/3"
+        streamingText="The AI has started replying…"
+      />,
+    );
+    expect(
+      screen.queryByText(/AI Facilitator — Recovery/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/The AI has started replying/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SessionActivityPanel.tsx
+++ b/frontend/src/components/SessionActivityPanel.tsx
@@ -183,7 +183,8 @@ export function SessionActivityPanel({
                   type="button"
                   onClick={onForceAdvance}
                   disabled={busy}
-                  className="self-start rounded border border-amber-500 px-2 py-0.5 text-xs font-semibold text-amber-200 hover:bg-amber-900/30 disabled:opacity-50"
+                  aria-disabled={busy}
+                  className="self-start rounded border border-amber-500 px-2 py-0.5 text-xs font-semibold text-amber-200 hover:bg-amber-900/30 disabled:cursor-not-allowed disabled:opacity-50"
                   title="Skip the stuck AI turn and let the engine advance."
                 >
                   Force-advance turn

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -9,11 +9,23 @@ interface Props {
   roles: RoleView[];
   streamingText?: string;
   /**
-   * True when the backend is in AI_PROCESSING (or equivalent) but no streaming
-   * chunks have arrived yet. Renders an inline "AI is thinking…" bubble so a
-   * scrolled participant doesn't have to look at the StatusBar.
+   * True when the backend is doing AI work (any tier — play, interject,
+   * setup, briefing, AAR, guardrail) but no streaming chunks have arrived
+   * yet. Renders an inline "AI is thinking…" bubble so a scrolled
+   * participant doesn't have to look at the StatusBar. Driven primarily
+   * by ``ai_thinking`` WS events from the LLM-call boundary, with a
+   * ``state``-based fallback for reconnect.
    */
   aiThinking?: boolean;
+  /**
+   * Optional human-readable label appended to the thinking indicator,
+   * e.g. ``"Recovery pass 2/3 (missing yield)"`` or
+   * ``"Replying to SOC Analyst"``. Lets the operator distinguish
+   * "thinking" from "stuck" during the play-tier strict-retry loop and
+   * surfaces what the AI is doing during otherwise opaque side-channel
+   * paths like ``run_interject``.
+   */
+  aiStatusLabel?: string;
   /** role_ids of human players currently typing (excluding the local user). */
   typingRoleIds?: string[];
 }
@@ -99,7 +111,14 @@ function MarkdownBody({ body }: { body: string }) {
   );
 }
 
-export function Transcript({ messages, roles, streamingText, aiThinking, typingRoleIds }: Props) {
+export function Transcript({
+  messages,
+  roles,
+  streamingText,
+  aiThinking,
+  aiStatusLabel,
+  typingRoleIds,
+}: Props) {
   const roleById = new Map(roles.map((r) => [r.id, r]));
   const typing = (typingRoleIds ?? []).flatMap((id) => {
     const r = roleById.get(id);
@@ -180,7 +199,14 @@ export function Transcript({ messages, roles, streamingText, aiThinking, typingR
           <p className="whitespace-pre-wrap text-sm leading-relaxed">{streamingText}</p>
         </article>
       ) : aiThinking ? (
-        <ChatIndicator label="AI Facilitator is typing…" tone="ai" />
+        <ChatIndicator
+          label={
+            aiStatusLabel
+              ? `AI Facilitator — ${aiStatusLabel}`
+              : "AI Facilitator is typing…"
+          }
+          tone="ai"
+        />
       ) : null}
       {typingLabel ? <ChatIndicator label={typingLabel} tone="player" /> : null}
     </div>

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -20,6 +20,35 @@ export type ServerEvent =
   | { type: "plan_finalized_announcement" }
   | { type: "plan_edited"; field: string }
   | { type: "aar_status_changed"; status: "pending" | "generating" | "ready" | "failed" }
+  // Real-time AI-thinking indicator. Emitted by the LLM client at every
+  // call boundary (begin / end), regardless of tier — so interject /
+  // guardrail / setup-tier / AAR-generation work all show the indicator
+  // without each driver path having to remember to emit. ``call_id`` is a
+  // stable opaque token so a UI that sees concurrent calls (e.g. guardrail
+  // overlapping a play turn) can reference-count rather than naively
+  // toggle on/off. ``record=False`` server-side, so the events do NOT
+  // replay on reconnect (they would be stale by then).
+  | {
+      type: "ai_thinking";
+      active: boolean;
+      tier: string;
+      call_id: string;
+      started_at_ms?: number;
+    }
+  // Labelled "what is the AI doing right now?" status, emitted by the
+  // turn-driver at known points (play attempt N/M, recovery directive
+  // active, interject for role X, briefing, AAR). ``ai_thinking`` answers
+  // "is anything running"; ``ai_status`` answers "what should the human
+  // see?". A null phase clears the label.
+  | {
+      type: "ai_status";
+      phase: "play" | "interject" | "setup" | "briefing" | "aar" | null;
+      attempt?: number;
+      budget?: number;
+      recovery?: string | null;
+      turn_index?: number | null;
+      for_role_id?: string | null;
+    }
   | { type: "typing"; role_id: string; typing: boolean }
   | { type: "presence"; role_id: string; active: boolean }
   | { type: "presence_snapshot"; role_ids: string[] }
@@ -132,6 +161,17 @@ export class WsClient {
             break;
           case "aar_status_changed":
             safe.status = parsed.status;
+            break;
+          case "ai_thinking":
+            safe.active = parsed.active;
+            safe.tier = parsed.tier;
+            safe.call_id = parsed.call_id;
+            break;
+          case "ai_status":
+            safe.phase = parsed.phase;
+            safe.attempt = parsed.attempt;
+            safe.budget = parsed.budget;
+            safe.recovery = parsed.recovery;
             break;
           case "typing":
             safe.role_id = parsed.role_id;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -137,6 +137,24 @@ export function Facilitator() {
   // creator needs to know which invites have actually been opened
   // before kicking off the exercise.
   const [presence, setPresence] = useState<Set<string>>(() => new Set());
+  // Real-time AI-thinking tracking — same shape as Play.tsx. ``aiCalls``
+  // collects in-flight LLM ``call_id``s from ``ai_thinking`` boundary
+  // events; ``aiStatus`` carries the labelled phase/attempt/recovery
+  // breadcrumb the turn-driver emits at known points. Together they let
+  // the operator distinguish "thinking" from "stuck" during the
+  // strict-retry loop and see interject / setup / AAR work that doesn't
+  // change ``session.state`` (issue #63).
+  const [aiCalls, setAiCalls] = useState<Set<string>>(() => new Set());
+  const [aiStatus, setAiStatus] = useState<{
+    phase: "play" | "interject" | "setup" | "briefing" | "aar";
+    attempt?: number;
+    budget?: number;
+    recovery?: string | null;
+    forRoleId?: string | null;
+  } | null>(null);
+  // 3-second client-side cooldown on force-advance — paired with the
+  // backend in-flight gate in ``manager.force_advance``. See issue #63.
+  const [forceAdvanceCooldown, setForceAdvanceCooldown] = useState(false);
   // Live AI decision rationale stream (issue #55). Entries arrive via
   // ``decision_logged`` events as the AI calls
   // ``record_decision_rationale``; on snapshot refresh we replace the
@@ -144,6 +162,15 @@ export function Facilitator() {
   // WebSocket frame was missed during reconnect.
   const [decisionLog, setDecisionLog] = useState<DecisionLogEntry[]>([]);
   const wsRef = useRef<WsClient | null>(null);
+  const forceAdvanceTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (forceAdvanceTimerRef.current !== null) {
+        window.clearTimeout(forceAdvanceTimerRef.current);
+        forceAdvanceTimerRef.current = null;
+      }
+    };
+  }, []);
   // Wraps the chat scroll region so we can auto-pin the latest message to
   // the bottom on each new arrival. Without this the user's view stays
   // fixed where they were last reading and they don't realise a new AI
@@ -270,11 +297,56 @@ export function Facilitator() {
         refreshSnapshot();
         break;
       case "state_changed":
+        refreshSnapshot();
+        // Reconnect safety-net: ``ai_thinking`` events are
+        // ``record=False`` so a reconnect during an LLM call wouldn't
+        // replay the matching ``active=false`` event. ``state_changed``
+        // IS recorded in the replay buffer, so this is the anchor
+        // point that guarantees ``aiCalls`` and ``aiStatus`` reset
+        // when the engine actually moves to a non-busy state.
+        if (evt.state !== "AI_PROCESSING" && evt.state !== "BRIEFING") {
+          setAiStatus(null);
+          setAiCalls(new Set());
+        }
+        break;
       case "turn_changed":
       case "plan_proposed":
       case "plan_finalized":
       case "plan_edited":
         refreshSnapshot();
+        break;
+      case "ai_thinking":
+        // Reference-counted concurrent calls (guardrail + interject can
+        // overlap). Add/remove by call_id so the indicator only clears
+        // when ALL calls have ended.
+        setAiCalls((prev) => {
+          const next = new Set(prev);
+          if (evt.active) next.add(evt.call_id);
+          else next.delete(evt.call_id);
+          return next;
+        });
+        console.debug(
+          "[facilitator] ai_thinking",
+          evt.active ? "add" : "remove",
+          { tier: evt.tier, call_id: evt.call_id },
+        );
+        break;
+      case "ai_status":
+        if (evt.phase === null) {
+          setAiStatus(null);
+        } else {
+          setAiStatus({
+            phase: evt.phase,
+            attempt: evt.attempt,
+            budget: evt.budget,
+            recovery: evt.recovery,
+            forRoleId: evt.for_role_id ?? null,
+          });
+        }
+        console.debug("[facilitator] ai_status", {
+          phase: evt.phase,
+          recovery: evt.recovery,
+        });
         break;
       case "critical_event":
         setCriticalBanner({ severity: evt.severity, headline: evt.headline, body: evt.body });
@@ -592,6 +664,21 @@ export function Facilitator() {
 
   async function handleForceAdvance() {
     if (!state) return;
+    // Client-side cooldown: prevents the triple-banner cascade visible
+    // in the issue #63 screenshot when a frustrated operator double- or
+    // triple-clicks. The backend gate in ``manager.force_advance``
+    // (refuses while a play-tier LLM call is in flight) is the
+    // authoritative protection; this is just a UX courtesy so a healthy
+    // session doesn't dispatch three rapid requests.
+    if (forceAdvanceCooldown) {
+      console.warn("[facilitator] force-advance suppressed (cooldown)");
+      return;
+    }
+    setForceAdvanceCooldown(true);
+    forceAdvanceTimerRef.current = window.setTimeout(() => {
+      setForceAdvanceCooldown(false);
+      forceAdvanceTimerRef.current = null;
+    }, 3000);
     setBusy(true);
     setBusyMessage("Force-advancing turn — AI is drafting the next beat…");
     setForceScrollNonce((n) => n + 1);
@@ -799,7 +886,7 @@ export function Facilitator() {
             creatorToken={state.token}
             roles={snapshot.roles}
             onForceAdvance={handleForceAdvance}
-            busy={busy}
+            busy={busy || forceAdvanceCooldown}
           />
           <DecisionLogPanel entries={decisionLog} />
           <CostMeter cost={cost ?? snapshot.cost} />
@@ -881,10 +968,11 @@ export function Facilitator() {
                   <button
                     type="button"
                     onClick={handleForceAdvance}
-                    disabled={busy}
-                    className="rounded border border-emerald-500 bg-emerald-900/30 px-3 py-1 text-xs font-semibold text-emerald-100 hover:bg-emerald-700/40 disabled:opacity-50"
+                    disabled={busy || forceAdvanceCooldown}
+                    aria-disabled={busy || forceAdvanceCooldown}
+                    className="rounded border border-emerald-500 bg-emerald-900/30 px-3 py-1 text-xs font-semibold text-emerald-100 hover:bg-emerald-700/40 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    AI: take next beat
+                    {forceAdvanceCooldown ? "AI: take next beat (cooling down)" : "AI: take next beat"}
                   </button>
                 </div>
               ) : null}
@@ -893,16 +981,44 @@ export function Facilitator() {
                 roles={snapshot.roles}
                 streamingText={streamingText}
                 aiThinking={
-                  phase === "play" &&
+                  // Authoritative: any LLM call boundary in flight for
+                  // this session lights the indicator (issue #63 — without
+                  // this, interject / guardrail / setup / AAR work was
+                  // invisible to the operator). State-based predicate
+                  // remains as a reconnect-time safety net.
                   !streamingText &&
-                  // Don't spin the indicator if the turn errored — the
-                  // AI is no longer working; the activity panel surfaces
-                  // the error and the operator can force-advance.
                   snapshot.current_turn?.status !== "errored" &&
-                  (snapshot.state === "AI_PROCESSING" ||
-                    snapshot.state === "BRIEFING" ||
-                    snapshot.current_turn?.status === "processing")
+                  (aiCalls.size > 0 ||
+                    (phase === "play" &&
+                      (snapshot.state === "AI_PROCESSING" ||
+                        snapshot.state === "BRIEFING" ||
+                        snapshot.current_turn?.status === "processing")))
                 }
+                aiStatusLabel={(() => {
+                  // Operator surface — keep the engineering detail
+                  // (``missing_yield`` / ``missing_drive``) so a CISO
+                  // running the exercise can correlate the indicator
+                  // with the activity panel + audit feed. Participant
+                  // copy in Play.tsx hides the jargon.
+                  if (!aiStatus) return undefined;
+                  if (aiStatus.phase === "play" && aiStatus.recovery) {
+                    const a = aiStatus.attempt ?? "?";
+                    const b = aiStatus.budget ?? "?";
+                    const kind = aiStatus.recovery.replace(/_/g, " ");
+                    return `Recovery pass ${a}/${b} (${kind})`;
+                  }
+                  if (aiStatus.phase === "interject") {
+                    const role = snapshot.roles.find(
+                      (r) => r.id === aiStatus.forRoleId,
+                    );
+                    return `Replying to ${role?.label ?? "a participant"}`;
+                  }
+                  if (aiStatus.phase === "briefing") return "Briefing the team";
+                  if (aiStatus.phase === "setup") return "Preparing the scenario";
+                  if (aiStatus.phase === "aar")
+                    return "Drafting the after-action report";
+                  return undefined;
+                })()}
                 typingRoleIds={Object.keys(typing).filter(
                   (rid) => rid !== state.creatorRoleId,
                 )}

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -50,8 +50,28 @@ export function Play({ sessionId, token }: Props) {
   // issue #52. Used to render the green online dot in RoleRoster so the
   // creator can tell at a glance who has actually opened their join link.
   const [presence, setPresence] = useState<Set<string>>(() => new Set());
+  // Real-time "AI is thinking" tracking. Set of in-flight LLM call_ids
+  // collected from ``ai_thinking`` WS events. The set's non-emptiness is
+  // the authoritative "is the engine working right now" boolean — used
+  // alongside the existing state-based heuristic so the indicator lights
+  // up even during interject / guardrail / setup / AAR (issue #63).
+  const [aiCalls, setAiCalls] = useState<Set<string>>(() => new Set());
+  // Labelled status from the turn driver, e.g. recovery pass 2/3.
+  // ``phase: null`` (or null state itself) clears the label.
+  const [aiStatus, setAiStatus] = useState<{
+    phase: "play" | "interject" | "setup" | "briefing" | "aar";
+    attempt?: number;
+    budget?: number;
+    recovery?: string | null;
+    forRoleId?: string | null;
+  } | null>(null);
+  // 3-second client-side cooldown on force-advance — paired with the
+  // backend in-flight gate. Prevents the triple-banner cascade from a
+  // double/triple click (issue #63).
+  const [forceAdvanceCooldown, setForceAdvanceCooldown] = useState(false);
   const wsRef = useRef<WsClient | null>(null);
   const scrollRegionRef = useRef<HTMLDivElement | null>(null);
+  const forceAdvanceTimerRef = useRef<number | null>(null);
 
   // Determine self by inspecting snapshot.roles and matching the role with the
   // missing display_name (server doesn't echo our token; we use the snapshot
@@ -96,6 +116,17 @@ export function Play({ sessionId, token }: Props) {
       case "state_changed":
         console.info("[play] state changed", evt);
         refreshSnapshot();
+        // Clear the labelled status AND the in-flight call set when
+        // leaving a busy state. ``ai_thinking`` events use
+        // ``record=False``, so a reconnect during an LLM call won't
+        // replay the matching ``active=false`` event — without this
+        // safety net, ``aiCalls`` could be left non-empty forever and
+        // pin the indicator on. ``state_changed`` IS recorded in the
+        // replay buffer, so it's the right place to anchor the reset.
+        if (evt.state !== "AI_PROCESSING" && evt.state !== "BRIEFING") {
+          setAiStatus(null);
+          setAiCalls(new Set());
+        }
         break;
       case "turn_changed":
         console.info("[play] turn changed", evt);
@@ -128,6 +159,36 @@ export function Play({ sessionId, token }: Props) {
         break;
       case "presence_snapshot":
         setPresence(new Set(evt.role_ids));
+        break;
+      case "ai_thinking":
+        // Reference-counted indicator. Concurrent LLM calls (guardrail
+        // + interject) overlap by design, so we add/remove call_ids
+        // rather than toggling a single boolean.
+        setAiCalls((prev) => {
+          const next = new Set(prev);
+          if (evt.active) next.add(evt.call_id);
+          else next.delete(evt.call_id);
+          return next;
+        });
+        console.debug(
+          "[play] ai_thinking",
+          evt.active ? "add" : "remove",
+          { tier: evt.tier, call_id: evt.call_id },
+        );
+        break;
+      case "ai_status":
+        if (evt.phase === null) {
+          setAiStatus(null);
+        } else {
+          setAiStatus({
+            phase: evt.phase,
+            attempt: evt.attempt,
+            budget: evt.budget,
+            recovery: evt.recovery,
+            forRoleId: evt.for_role_id ?? null,
+          });
+        }
+        console.debug("[play] ai_status", { phase: evt.phase, recovery: evt.recovery });
         break;
       case "typing":
         setTyping((prev) => {
@@ -178,6 +239,17 @@ export function Play({ sessionId, token }: Props) {
     }
   }, [messageCount, streamingText]);
 
+  // Clean up the force-advance cooldown timer on unmount so a tab
+  // close mid-cooldown doesn't fire setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (forceAdvanceTimerRef.current !== null) {
+        window.clearTimeout(forceAdvanceTimerRef.current);
+        forceAdvanceTimerRef.current = null;
+      }
+    };
+  }, []);
+
   // Expire stale typing entries.
   useEffect(() => {
     const id = setInterval(() => {
@@ -222,7 +294,23 @@ export function Play({ sessionId, token }: Props) {
   }
 
   function handleForceAdvance() {
-    wsRef.current?.send({ type: "request_force_advance" });
+    if (forceAdvanceCooldown) {
+      console.warn("[play] force-advance suppressed (cooldown)");
+      return;
+    }
+    setForceAdvanceCooldown(true);
+    // Tracked in a ref so a tab-close mid-cooldown doesn't try to
+    // setState on an unmounted component.
+    forceAdvanceTimerRef.current = window.setTimeout(() => {
+      setForceAdvanceCooldown(false);
+      forceAdvanceTimerRef.current = null;
+    }, 3000);
+    try {
+      wsRef.current?.send({ type: "request_force_advance" });
+    } catch (err) {
+      console.warn("[play] force-advance send failed", err);
+      setError(err instanceof Error ? err.message : String(err));
+    }
   }
 
   function handleEnd() {
@@ -244,6 +332,52 @@ export function Play({ sessionId, token }: Props) {
     );
   }
 
+  // Build the displayed indicator from BOTH the LLM-call boundary
+  // (``aiCalls``, authoritative) and the legacy state-based heuristic
+  // below. The state-based fallback handles reconnects (``ai_thinking``
+  // events are ``record=False``, so they don't replay) and any future
+  // driver path that forgets to round-trip through the LLM client.
+  const stateBasedAiThinking =
+    snapshot.state !== "ENDED" &&
+    !streamingText &&
+    snapshot.current_turn?.status !== "errored" &&
+    (snapshot.state === "AI_PROCESSING" ||
+      snapshot.state === "BRIEFING" ||
+      snapshot.current_turn?.status === "processing");
+  const showAiThinking = aiCalls.size > 0 || stateBasedAiThinking;
+  // Compose a human-readable label from the most recent ``ai_status``
+  // event. Falls back to "AI thinking…" when the engine hasn't told us
+  // anything more specific. Participant-facing copy: we deliberately
+  // hide the engineering jargon (``missing_yield`` / ``missing_drive``)
+  // from non-operator viewers — they read as "the AI is broken" rather
+  // than "the AI is normalising its tool call". The full breadcrumb
+  // stays visible to the operator in Facilitator.tsx.
+  const aiStatusLabel = (() => {
+    if (!showAiThinking) return undefined;
+    if (!aiStatus) return undefined;
+    if (aiStatus.phase === "play" && aiStatus.recovery) {
+      // Surface "Retrying" only on attempt ≥ 2 — the first attempt
+      // hasn't actually retried anything yet.
+      const a = aiStatus.attempt ?? 1;
+      const b = aiStatus.budget ?? 1;
+      if (a >= 2) return `Retrying (${a}/${b})`;
+      return undefined;
+    }
+    if (aiStatus.phase === "interject") {
+      // "Replying to <self>" is uncanny — render "Composing a reply"
+      // when the AI is responding to the local participant.
+      if (aiStatus.forRoleId && aiStatus.forRoleId === selfRoleId) {
+        return "Composing a reply";
+      }
+      const role = snapshot?.roles.find((r) => r.id === aiStatus.forRoleId);
+      if (!role) return "Composing a reply";
+      return `Replying to ${role.label}`;
+    }
+    if (aiStatus.phase === "briefing") return "Briefing the team";
+    if (aiStatus.phase === "setup") return "Preparing the scenario";
+    if (aiStatus.phase === "aar") return "Drafting the after-action report";
+    return undefined;
+  })();
   const activeRoleIds = snapshot.current_turn?.active_role_ids ?? [];
   const submittedRoleIds = snapshot.current_turn?.submitted_role_ids ?? [];
   const iAmActive = selfRoleId !== null && activeRoleIds.includes(selfRoleId);
@@ -333,9 +467,13 @@ export function Play({ sessionId, token }: Props) {
           <div className="flex flex-col gap-2 rounded border border-slate-700 bg-slate-900 p-2 text-xs">
             <button
               onClick={handleForceAdvance}
-              className="rounded border border-amber-500 px-2 py-1 font-semibold text-amber-200 hover:bg-amber-900/30"
+              disabled={forceAdvanceCooldown}
+              aria-disabled={forceAdvanceCooldown}
+              className="rounded border border-amber-500 px-2 py-1 font-semibold text-amber-200 hover:bg-amber-900/30 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Force-advance turn
+              {forceAdvanceCooldown
+                ? "Force-advance turn (cooling down)"
+                : "Force-advance turn"}
             </button>
             <button
               onClick={handleEnd}
@@ -363,14 +501,8 @@ export function Play({ sessionId, token }: Props) {
               messages={snapshot.messages}
               roles={snapshot.roles}
               streamingText={streamingText}
-              aiThinking={
-                snapshot.state !== "ENDED" &&
-                !streamingText &&
-                snapshot.current_turn?.status !== "errored" &&
-                (snapshot.state === "AI_PROCESSING" ||
-                  snapshot.state === "BRIEFING" ||
-                  snapshot.current_turn?.status === "processing")
-              }
+              aiThinking={showAiThinking}
+              aiStatusLabel={aiStatusLabel}
               typingRoleIds={Object.keys(typing).filter((rid) => rid !== selfRoleId)}
             />
           </div>


### PR DESCRIPTION
## Summary

Issue #63 — a participant asked a question mid-turn and the UI showed no "AI is thinking" feedback because the indicator was gated on `session.state`, which `run_interject` deliberately leaves at `AWAITING_PLAYERS`. The participant retyped, the operator force-advanced three times, and the AI's reply landed seconds later — all in a window where the engine was working but the UI was telling no one.

The fix touches every code path that does AI work for a session, so we don't ship a per-symptom patch that leaves the next operator hitting the next gap.

### Four-part fix

1. **`LLMClient` boundary broadcast** — `_begin_call` / `_end_call` now emit `ai_thinking` WS events at every LLM-call boundary (play, setup, interject, guardrail, AAR, briefing). `record=False` so reconnects don't replay stale indicators. New `call_id` on `InFlightCall` lets the frontend reference-count concurrent calls (guardrail can overlap interject).

2. **Labelled `ai_status` breadcrumbs from `TurnDriver`** at known points: `play attempt N/M (recovery=missing_yield)`, `interject for_role_id=…`, `setup`, `briefing`, `aar`. Operator-facing copy in Facilitator includes the directive kind; participant-facing copy in Play hides the engineering jargon ("Retrying (2/3)" instead of "Recovery pass 2/3 (missing yield)") and renders "Composing a reply" rather than third-personing the asker's own role.

3. **Defense in depth — force-advance gate.** `SessionManager.force_advance` refuses with `IllegalTransitionError` while a play-tier LLM call is in flight, eliminating the duplicate-banner cascade. Frontend adds a 3-second cooldown with `cursor-not-allowed` + `aria-disabled` on every force-advance button (Play sidebar, Facilitator chat banner, SessionActivityPanel).

4. **Backstop — duplicate-submission dedupe.** `SessionManager.submit_response` rejects an exact same-body resubmission from the same role within `DUPLICATE_SUBMISSION_WINDOW_SECONDS` (default 30, configurable). Audit-logged. The error message reads "You just sent the same message — wait a moment or change something to send again." rather than the opaque "duplicate of your previous submission".

Plus a reconnect safety net: `state_changed` to a non-busy state clears `aiCalls` + `aiStatus` on both Play and Facilitator, since `ai_thinking active=false` won't replay through the buffer.

### Per-flow audit (closes every gap, not just the screenshot one)

| Flow | Before | After |
|---|---|---|
| Setup-tier LLM call | indicator dark | lit via `ai_thinking` + `phase=setup` |
| Briefing | OK (state=BRIEFING) | OK + labelled |
| Play turn (normal) | OK | OK + labelled with attempt/budget |
| Play turn (recovery loop) | OK on indicator, no label | "Retrying (2/3)" / operator sees "Recovery pass 2/3 (missing yield)" |
| Interject (the screenshot bug) | dark | lit + "Replying to X" / "Composing a reply" |
| Force-advance | races in-flight calls | refused with friendly error; 3s client cooldown |
| Guardrail classify | dark | lit via `ai_thinking` |
| AAR generation | dark for HTTP pollers | lit via `ai_thinking` + `phase=aar` |
| Duplicate participant submit | two visible bubbles | rejected with friendly error |

## Test plan

- [x] `cd backend && pytest -q` — 219 pass, 1 skip
- [x] `cd backend && ruff check . && mypy app` — clean
- [x] `cd frontend && npm test -- --run` — 5 pass
- [x] `cd frontend && npm run lint && npm run typecheck` — clean
- [x] Six sub-agent reviews (QA, Security, Product, UI/UX, User Agent, Prompt Expert) — all CRITICAL/BLOCK/HIGH and logging findings addressed in this commit
- [ ] Manual smoke: `docker compose up --build`; participant asks a question mid-turn → confirm indicator lights immediately; force-advance during in-flight LLM call → confirm inline error, no SYSTEM banner; submit identical body twice → confirm second is rejected
- [ ] Code review

Closes #63

https://claude.ai/code/session_01LaoXYGgt7fMnW7M9KGVrPw

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaoXYGgt7fMnW7M9KGVrPw)_