### PR TITLE
frontend: hide debug-y chrome behind God Mode (#36)

### DIFF
--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { Facilitator, TopBar } from "../pages/Facilitator";
-import { api } from "../api/client";
+import { Facilitator, TopBar, SetupView, PlanView } from "../pages/Facilitator";
+import { api, type ScenarioPlan, type SessionSnapshot } from "../api/client";
 
 // The intro page renders both an `<ol>` ("What to expect") and the chip
 // list in the fieldset, so a bare `getByRole("list")` is ambiguous.
@@ -369,5 +369,193 @@ describe("TopBar (issue #62)", () => {
       ).toBeInTheDocument();
       unmount();
     }
+  });
+
+  // Issue #36: hide debug-y chips behind God Mode so a fresh creator
+  // doesn't see "ws: open · v 7a1862f" on first impression. The God Mode
+  // toggle button itself stays visible — it's the only entry to debug
+  // mode now and must remain reachable.
+  it("hides ws-pill and build-SHA chip when God Mode is off (healthy connection)", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        godMode={false}
+        wsStatus="open"
+      />,
+    );
+    // ``state: ... · phase: ...`` chip stays — it carries user-facing meaning.
+    expect(screen.getByText(/state: READY · phase: play/i)).toBeInTheDocument();
+    // Debug-y chips are hidden until God Mode is on (when connection healthy).
+    expect(screen.queryByTestId("ws-pill")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("build-sha-chip")).not.toBeInTheDocument();
+    // God Mode toggle stays reachable — it's the only entry to debug mode.
+    expect(screen.getByRole("button", { name: /God Mode/i })).toBeInTheDocument();
+  });
+
+  it("shows ws-pill and build-SHA chip when God Mode is on", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        godMode={true}
+        wsStatus="open"
+      />,
+    );
+    expect(screen.getByText(/state: READY · phase: play/i)).toBeInTheDocument();
+    expect(screen.getByTestId("ws-pill")).toHaveTextContent(/ws: open/);
+    expect(screen.getByTestId("build-sha-chip")).toHaveTextContent(/^v /);
+  });
+
+  // Resurfacing the WS pill on a degraded connection is the only "is the
+  // app stuck?" signal a non-operator creator has — without it, hiding
+  // the pill behind God Mode would leave them silently disconnected.
+  it("resurfaces ws-pill on degraded connection even when God Mode is off", () => {
+    render(
+      <TopBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        godMode={false}
+        wsStatus="closed"
+      />,
+    );
+    expect(screen.getByTestId("ws-pill")).toHaveTextContent(/ws: closed/);
+    // Build-SHA chip stays God-Mode-only — it's bug-report ergonomics, not
+    // user-facing connection health.
+    expect(screen.queryByTestId("build-sha-chip")).not.toBeInTheDocument();
+  });
+});
+
+// Issue #36: ``Skip setup (dev only)`` is gated on God Mode so first-time
+// creators see only the two real CTAs ("Send reply" and "Looks ready").
+describe("SetupView Skip-setup gating (issue #36)", () => {
+  const baseSnapshot: SessionSnapshot = {
+    id: "sess-1",
+    state: "SETUP",
+    scenario_prompt: "ransomware drill",
+    plan: null,
+    roles: [],
+    current_turn: null,
+    messages: [],
+    setup_notes: null,
+    cost: null,
+    aar_status: null,
+  };
+  const baseProps = {
+    snapshot: baseSnapshot,
+    setupReply: "",
+    setSetupReply: vi.fn(),
+    onSubmit: vi.fn(),
+    onLooksReady: vi.fn(),
+    onApprovePlan: vi.fn(),
+    onSkipSetup: vi.fn(),
+    onPickOption: vi.fn(),
+    busy: false,
+    busyMessage: null,
+  };
+
+  it("hides Skip setup (dev only) when God Mode is off", () => {
+    render(<SetupView {...baseProps} godMode={false} />);
+    expect(
+      screen.queryByRole("button", { name: /Skip setup \(dev only\)/i }),
+    ).not.toBeInTheDocument();
+    // Real CTAs still render.
+    expect(screen.getByRole("button", { name: /Send reply/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Looks ready — propose the plan/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Skip setup (dev only) when God Mode is on", () => {
+    const onSkipSetup = vi.fn();
+    render(<SetupView {...baseProps} godMode={true} onSkipSetup={onSkipSetup} />);
+    const skip = screen.getByRole("button", { name: /Skip setup \(dev only\)/i });
+    expect(skip).toBeInTheDocument();
+    fireEvent.click(skip);
+    expect(onSkipSetup).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Issue #36: spoiler toggle is now a stateful checkbox with a stable
+// label ("Show injects (facilitator mode)") instead of a button whose
+// label flipped between "Switch to participant mode" / "Switch to
+// facilitator mode".
+describe("PlanView spoiler checkbox (issue #36)", () => {
+  const planFixture: ScenarioPlan = {
+    title: "Ransomware drill",
+    executive_summary: "Tabletop for an IR exercise.",
+    key_objectives: ["Restore service"],
+    narrative_arc: [
+      { beat: 1, label: "Initial detection", expected_actors: ["IR Lead"] },
+      { beat: 2, label: "Containment", expected_actors: ["IR Lead", "Comms"] },
+    ],
+    injects: [
+      { trigger: "+5min", type: "media", summary: "Reporter calls for comment" },
+    ],
+    guardrails: [],
+    success_criteria: [],
+    out_of_scope: [],
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders the stable label regardless of state", () => {
+    render(<PlanView plan={planFixture} sessionId="s-1" />);
+    // Default: hidden (participant mode).
+    expect(screen.getByText(/Show injects \(facilitator mode\)/i)).toBeInTheDocument();
+    // Click the checkbox to flip state.
+    fireEvent.click(screen.getByTestId("plan-spoiler-checkbox"));
+    // Label is unchanged — only the checkbox state flipped.
+    expect(screen.getByText(/Show injects \(facilitator mode\)/i)).toBeInTheDocument();
+  });
+
+  it("hides narrative-arc / inject content by default and reveals on toggle", () => {
+    render(<PlanView plan={planFixture} sessionId="s-1" />);
+    // Default: spoiler hidden — the arc beat label and inject summary
+    // should NOT be in the DOM.
+    expect(screen.queryByText(/Initial detection/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Reporter calls for comment/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Participant mode\./i)).toBeInTheDocument();
+
+    // Toggle the checkbox.
+    const checkbox = screen.getByTestId("plan-spoiler-checkbox") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+
+    // Arc + inject content now visible.
+    expect(screen.getByText(/Initial detection/i)).toBeInTheDocument();
+    expect(screen.getByText(/Reporter calls for comment/i)).toBeInTheDocument();
+  });
+
+  it("persists the reveal preference to localStorage scoped per session", () => {
+    render(<PlanView plan={planFixture} sessionId="abc" />);
+    fireEvent.click(screen.getByTestId("plan-spoiler-checkbox"));
+    expect(window.localStorage.getItem("atf-plan-reveal:abc")).toBe("1");
+    fireEvent.click(screen.getByTestId("plan-spoiler-checkbox"));
+    expect(window.localStorage.getItem("atf-plan-reveal:abc")).toBe("0");
+  });
+
+  it("reads the previously-stored reveal preference on mount", () => {
+    window.localStorage.setItem("atf-plan-reveal:abc", "1");
+    render(<PlanView plan={planFixture} sessionId="abc" />);
+    const checkbox = screen.getByTestId("plan-spoiler-checkbox") as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(screen.getByText(/Initial detection/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1073,7 +1073,16 @@ export function Facilitator() {
         backendState={snapshot.state}
         wsStatus={wsStatus}
         godMode={godMode}
-        onToggleGodMode={() => setGodMode((g) => !g)}
+        onToggleGodMode={() =>
+          setGodMode((g) => {
+            const next = !g;
+            // Per CLAUDE.md logging rules — every state transition gets one
+            // line. Once #36 hid debug chips behind God Mode, "is God Mode
+            // on?" became a load-bearing question for future bug triage.
+            console.info("[facilitator] godMode toggled", { godMode: next });
+            return next;
+          })
+        }
         onStart={handleStart}
         onForceAdvance={handleForceAdvance}
         onEnd={handleEnd}
@@ -1159,6 +1168,7 @@ export function Facilitator() {
               onPickOption={(opt) => callSetup(opt, "Sending your selection to the AI…")}
               busy={busy}
               busyMessage={busyMessage}
+              godMode={godMode}
             />
           ) : null}
           {phase === "ready" ? (
@@ -1626,19 +1636,35 @@ export function TopBar(props: {
               free; the popup positions absolutely so it overlays the
               page chrome below the bar without pushing layout. */}
           <CostChip cost={props.cost} />
-          <span className={wsColour}>● ws: {props.wsStatus}</span>
+          {/* Per #36: ws-pill and build-SHA chip are operator/debug signals
+              that read as a "this is a debug overlay" first impression for
+              a fresh creator. Gate them behind God Mode so the everyday
+              chrome stays clean while operators triaging a stuck session
+              still get the connection state and the build hash for bug
+              reports. The WS pill *also* surfaces unconditionally on a
+              degraded connection (``wsStatus !== "open"``) so a non-
+              operator creator still sees when their tab loses the server
+              — the only "is the app stuck?" signal a non-debug user has.
+              The ``state: / phase:`` chip stays always-visible because
+              it carries user-facing meaning ("phase: ended" tells a
+              creator the exercise is done). */}
+          {props.godMode || props.wsStatus !== "open" ? (
+            <span className={wsColour} data-testid="ws-pill">
+              ● ws: {props.wsStatus}
+            </span>
+          ) : null}
           <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-200">
             state: {props.backendState} · phase: {props.phase}
           </span>
-          {/* Build identification — surfaced so a creator filing a bug
-              report can tell us which version they're on without opening
-              DevTools. Vite injects ``__ATF_GIT_SHA__`` at build time. */}
-          <span
-            className="rounded bg-slate-800 px-2 py-0.5 font-mono text-[10px] text-slate-400"
-            title={`Build: ${__ATF_GIT_SHA__} · ${__ATF_BUILD_TS__}`}
-          >
-            v {__ATF_GIT_SHA__}
-          </span>
+          {props.godMode ? (
+            <span
+              className="rounded bg-slate-800 px-2 py-0.5 font-mono text-[10px] text-slate-400"
+              title={`Build: ${__ATF_GIT_SHA__} · ${__ATF_BUILD_TS__}`}
+              data-testid="build-sha-chip"
+            >
+              v {__ATF_GIT_SHA__}
+            </span>
+          ) : null}
           <button
             type="button"
             onClick={props.onToggleGodMode}
@@ -1649,7 +1675,7 @@ export function TopBar(props: {
                 ? "border-purple-500 bg-purple-700/40 text-purple-100"
                 : "border-purple-700/40 text-purple-300 hover:bg-purple-900/30")
             }
-            title="Toggle full debug overlay (audit log, system prompt, etc). Creator-only."
+            title="Toggle full debug overlay (ws status, build hash, audit log, system prompt, dev shortcuts). Creator-only."
           >
             {props.godMode ? "● God Mode" : "○ God Mode"}
           </button>
@@ -1884,7 +1910,7 @@ function WaitingChip({
  * viewport the Start button was below the fold, requiring a scroll past
  * the entire role roster + activity panel to reach it.
  */
-function SetupView({
+export function SetupView({
   snapshot,
   setupReply,
   setSetupReply,
@@ -1895,6 +1921,7 @@ function SetupView({
   onPickOption,
   busy,
   busyMessage,
+  godMode,
 }: {
   snapshot: SessionSnapshot;
   setupReply: string;
@@ -1906,6 +1933,14 @@ function SetupView({
   onPickOption: (option: string) => void;
   busy: boolean;
   busyMessage: string | null;
+  /**
+   * Per #36: ``Skip setup (dev only)`` is a developer/test shortcut that
+   * read as confusing chrome to a first-time creator. Hidden behind God
+   * Mode so the setup row stays focused on the two real CTAs ("Send
+   * reply" and "Looks ready / Approve") while still being available to
+   * operators with God Mode on.
+   */
+  godMode: boolean;
 }) {
   const hasPlan = Boolean(snapshot.plan);
   const notes = snapshot.setup_notes ?? [];
@@ -1977,15 +2012,17 @@ function SetupView({
               Looks ready — propose the plan
             </button>
           )}
-          <button
-            type="button"
-            onClick={onSkipSetup}
-            disabled={busy}
-            className="ml-auto rounded border border-dashed border-slate-700 px-3 py-1 text-xs text-slate-500 opacity-70 hover:opacity-100 hover:bg-slate-800 disabled:opacity-50"
-            title="Dev/testing only: skip the AI setup dialogue and use a generic default plan."
-          >
-            Skip setup (dev only)
-          </button>
+          {godMode ? (
+            <button
+              type="button"
+              onClick={onSkipSetup}
+              disabled={busy}
+              className="ml-auto rounded border border-dashed border-slate-700 px-3 py-1 text-xs text-slate-500 opacity-70 hover:opacity-100 hover:bg-slate-800 disabled:opacity-50"
+              title="Dev/testing only: skip the AI setup dialogue and use a generic default plan."
+            >
+              Skip setup (dev only)
+            </button>
+          ) : null}
         </div>
       </form>
 
@@ -2021,7 +2058,7 @@ function PlanPreview({ plan, sessionId }: { plan: ScenarioPlan; sessionId?: stri
  * ``injects`` are spoiler-hidden behind a Reveal toggle whose state is
  * persisted in localStorage so it carries across reloads.
  */
-function PlanView({
+export function PlanView({
   plan,
   sessionId,
 }: {
@@ -2136,19 +2173,25 @@ function PlanView({
             <h4 className="text-xs uppercase tracking-widest text-amber-200">
               Narrative arc &amp; injects
             </h4>
-            <button
-              type="button"
-              onClick={toggleReveal}
-              className="rounded border border-amber-500/60 px-2 py-0.5 text-xs font-semibold text-amber-100 hover:bg-amber-900/30"
-              aria-pressed={reveal}
-              title={
-                reveal
-                  ? "Switch to participant mode — hide upcoming injects so you can play fresh."
-                  : "Switch to facilitator mode — show upcoming injects so you can pace the meeting."
-              }
+            {/* Per #36: previously a button whose label flipped between
+                "Switch to participant mode" and "Switch to facilitator
+                mode" — every read required mentally inverting the label
+                to know the current state. A native checkbox keeps the
+                label stable ("Show injects (facilitator mode)") and uses
+                the checked indicator to communicate state. */}
+            <label
+              className="inline-flex cursor-pointer select-none items-center gap-1.5 rounded border border-amber-500/60 px-2 py-0.5 text-xs font-semibold text-amber-100 hover:bg-amber-900/30"
+              title="When checked, upcoming narrative beats and injects are visible (facilitator mode). Uncheck to play through fresh alongside the team (participant mode)."
             >
-              {reveal ? "Switch to participant mode" : "Switch to facilitator mode"}
-            </button>
+              <input
+                type="checkbox"
+                className="h-3 w-3 cursor-pointer accent-amber-500"
+                checked={reveal}
+                onChange={toggleReveal}
+                data-testid="plan-spoiler-checkbox"
+              />
+              <span>Show injects (facilitator mode)</span>
+            </label>
           </header>
           {!reveal ? (
             <p className="text-xs text-amber-200/80">


### PR DESCRIPTION
## Summary

Resolves #36 — first-impression UX polish for the creator top bar and surrounding chrome. The user-persona review at Phase 2 bow-tying flagged that `state: SETUP · phase: setup · ws: open · v 7a1862f · ○ God Mode` reads as a debug overlay rather than product chrome. This change gates operator/debug signals behind the existing God Mode toggle and tightens two adjacent affordances called out in the same review.

### Changes

- **`TopBar`** (`frontend/src/pages/Facilitator.tsx`): the `● ws:` pill and the `v <SHA>` build chip now render only when `godMode` is on. The ws-pill **resurfaces unconditionally on a degraded connection** (`wsStatus !== "open"`) so non-operator creators still see when their tab loses the server — the only "is the app stuck?" signal a non-debug user has. The `state: / phase:` chip stays always-visible (carries user-facing meaning). The God Mode toggle button stays visible (sole entry to debug mode now); its tooltip was updated to enumerate what's behind it.
- **`SetupView`**: `Skip setup (dev only)` is gated on `godMode`. Backend authz on the corresponding route is unchanged — this is a UX gate only.
- **`PlanView`**: the plan-spoiler toggle was a button whose label flipped between "Switch to participant mode" / "Switch to facilitator mode" — every read required mentally inverting the label. Replaced with a native `<input type="checkbox">` wrapped in a `<label>` carrying the stable text "Show injects (facilitator mode)". State storage (`localStorage["atf-plan-reveal:<sessionId>"]`) is unchanged.
- **Logging** (per CLAUDE.md): God Mode toggle emits `[facilitator] godMode toggled { godMode }` once per flip — load-bearing for future bug triage now that the flag determines which chips render.

### Out of scope (deferred per issue framing)

- Re-running the user-agent review on the "AI: take next beat" copy — testing-shaped, not code-shaped.
- Moving the God Mode toggle into a settings menu — issue framed this as "reconsider"; removing the only entry to debug mode without building a replacement would degrade operator ergonomics. Worth filing separately if a replacement settings surface lands.
- Hiding the other telemetry chips (T#, msgs, Rationale, Tabs, Last, LLM, Cost) — those accreted after #36 was filed and were not called out. Could be a follow-up "first-run polish, round 2".

### Sub-agent review

Six reviews ran in parallel per CLAUDE.md. Verdicts:

| Agent | Verdict | Findings addressed in this PR |
|---|---|---|
| QA | Block until tests added | HIGH: SetupView Skip-setup gating untested; PlanView checkbox + localStorage untested. **Fixed**: 7 new test cases (chips on/off both ws states, Skip-setup both godMode states, checkbox flips narrative-arc visibility, localStorage round-trip per session). |
| UI/UX | Address one HIGH | HIGH: missing log on godMode toggle. **Fixed**: `console.info` line added. MEDIUM: WS pill invisible on degraded connection. **Fixed**: pill resurfaces when not `open`. LOW: redundant `aria-label` on checkbox; fragile test regex. **Fixed**: `aria-label` removed (label wrapping supplies the name); tests use `data-testid`. |
| Product | Ship | LOW only; verified Phase 2 milestone is closed. |
| User-persona | Ship | LOW: God Mode discoverability. **Partially addressed**: tooltip updated to enumerate what's behind the toggle. |
| Security | Pass | UI gating only; backend authz unchanged. |
| Prompt Expert | N/A | No prompt content in diff. |

## Test plan

- [x] `cd frontend && npm test -- --run` — 37/37 pass (added 7 cases)
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [ ] Manual smoke at 1080p / 1440p / mobile widths — top bar wraps, God Mode toggle reachable in every phase
- [ ] Manual smoke: kill the WS connection — `● ws: closed` appears even with God Mode off
- [ ] Manual smoke: toggle plan-spoiler checkbox — narrative arc + injects appear/disappear; reload preserves choice scoped to session id

Closes #36


---
_Generated by [Claude Code](https://claude.ai/code/session_012pJNprMTREzt1GTv6o7Zem)_