### PR TITLE
frontend: pin participant transcript to bottom on initial mount (#79)

### DIFF
--- a/frontend/src/__tests__/useStickyScroll.test.tsx
+++ b/frontend/src/__tests__/useStickyScroll.test.tsx
@@ -1,0 +1,493 @@
+import { act, render } from "@testing-library/react";
+import { useCallback, useLayoutEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useStickyScroll } from "../lib/useStickyScroll";
+
+/**
+ * JSdom doesn't compute layout, so ``scrollHeight`` / ``clientHeight``
+ * default to 0 — which would skip every scroll branch in the hook.
+ * Override the prototype getters so the test can prescribe the
+ * geometry of the rendered ``<div>`` and assert on the (also shimmed)
+ * ``scrollTop`` setter to verify the hook actually scrolled.
+ *
+ * The shims are scoped to this file's ``beforeEach`` / ``afterEach``
+ * so they don't leak into other test suites.
+ */
+interface Geometry {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+}
+
+const geom = new WeakMap<HTMLElement, Geometry>();
+
+function setGeometry(el: HTMLElement, partial: Partial<Geometry>): void {
+  const prev =
+    geom.get(el) ?? { scrollHeight: 0, clientHeight: 0, scrollTop: 0 };
+  geom.set(el, { ...prev, ...partial });
+}
+
+function readGeometry(el: HTMLElement): Geometry {
+  return geom.get(el) ?? { scrollHeight: 0, clientHeight: 0, scrollTop: 0 };
+}
+
+let originalScrollHeight: PropertyDescriptor | undefined;
+let originalClientHeight: PropertyDescriptor | undefined;
+let originalScrollTop: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalScrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollHeight",
+  );
+  originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight",
+  );
+  originalScrollTop = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollTop",
+  );
+
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return readGeometry(this).scrollHeight;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return readGeometry(this).clientHeight;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return readGeometry(this).scrollTop;
+    },
+    set(this: HTMLElement, value: number) {
+      setGeometry(this, { scrollTop: value });
+    },
+  });
+});
+
+afterEach(() => {
+  if (originalScrollHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "scrollHeight",
+      originalScrollHeight,
+    );
+  }
+  if (originalClientHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "clientHeight",
+      originalClientHeight,
+    );
+  }
+  if (originalScrollTop) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "scrollTop",
+      originalScrollTop,
+    );
+  }
+});
+
+interface HarnessProps {
+  /** Bumping this is the test-side proxy for "a new message arrived" — it
+   *  changes the deps array the hook watches. */
+  messageCount: number;
+  /** Second-channel deps signal: stands in for the production
+   *  ``streamingActive`` flag that Play.tsx and Facilitator.tsx pass
+   *  alongside ``messageCount``. Lets the test verify that flipping
+   *  ``streamingActive`` alone (no message added) still re-triggers
+   *  the slack-follow — which is the dominant runtime signal because
+   *  chunk events fire much more often than ``message_complete``. */
+  streamingActive?: boolean;
+  /** Total content height. Tests prescribe this to simulate an
+   *  overflowing transcript. The harness deliberately does NOT set
+   *  ``scrollTop`` from props — that dimension is owned by the hook
+   *  (and by direct ``setGeometry`` calls between rerenders) so the
+   *  geometry layout effect can't accidentally clobber what the hook
+   *  just wrote. */
+  scrollHeight: number;
+  clientHeight: number;
+  bindForceScroll?: (fn: () => void) => void;
+  slack?: number;
+}
+
+/**
+ * Test harness that wires ``useStickyScroll`` to a div and applies the
+ * prescribed scroll-extent geometry via a ``useLayoutEffect`` declared
+ * **before** the hook call so the geometry is in place when the hook's
+ * own layout effect runs and reads ``scrollHeight``.
+ */
+function Harness({
+  messageCount,
+  streamingActive = false,
+  scrollHeight,
+  clientHeight,
+  bindForceScroll,
+  slack,
+}: HarnessProps) {
+  const elRef = useRef<HTMLDivElement | null>(null);
+
+  // Apply scrollHeight + clientHeight first so the hook's layout
+  // effect (declared inside useStickyScroll, *after* this hook) reads
+  // the prescribed values. Crucially, do not write ``scrollTop`` —
+  // that's the dimension the hook controls and we'd clobber the
+  // hook's write if we set it from props on every render.
+  useLayoutEffect(() => {
+    if (!elRef.current) return;
+    setGeometry(elRef.current, { scrollHeight, clientHeight });
+  });
+
+  const { scrollRef, forceScrollToBottom } = useStickyScroll<HTMLDivElement>(
+    [messageCount, streamingActive],
+    slack !== undefined ? { slack } : undefined,
+  );
+
+  useLayoutEffect(() => {
+    bindForceScroll?.(forceScrollToBottom);
+  }, [bindForceScroll, forceScrollToBottom]);
+
+  // ``scrollRef`` is memoized inside the hook (useCallback with []),
+  // so this combined callback is stable too. Stability matters: an
+  // unstable ref callback would detach + re-attach on every render,
+  // and the hook's scrollRef bumps an internal nonce on each non-null
+  // attach — which compounds into a re-render loop.
+  const combinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      elRef.current = node;
+      scrollRef(node);
+    },
+    [scrollRef],
+  );
+
+  return (
+    <div data-testid="scroll-region" ref={combinedRef}>
+      {Array.from({ length: messageCount }, (_, i) => (
+        <div key={i}>message {i}</div>
+      ))}
+    </div>
+  );
+}
+
+describe("useStickyScroll", () => {
+  it("pins to the bottom on initial mount when content overflows", () => {
+    // Issue #79: a player joining mid-exercise lands on a transcript
+    // that overflows the viewport. The pre-fix slack check read
+    // scrollTop=0 as "user has scrolled up" and stranded them at the
+    // top. The hook's initial-mount branch overrides that.
+    const { getByTestId } = render(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(2000);
+  });
+
+  it("follows new content when the user is near the bottom", () => {
+    const { getByTestId, rerender } = render(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    const el = getByTestId("scroll-region");
+    // Initial mount pinned us to the bottom (2000).
+    expect(el.scrollTop).toBe(2000);
+
+    // A new message arrives; transcript grew. User stayed pinned at
+    // the previous bottom (2000) so they're well within the slack
+    // window of the new bottom (2200) — pin should follow.
+    rerender(
+      <Harness messageCount={21} scrollHeight={2200} clientHeight={400} />,
+    );
+    expect(el.scrollTop).toBe(2200);
+  });
+
+  it("leaves the user alone when they have scrolled up beyond the slack window", () => {
+    const { getByTestId, rerender } = render(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(2000);
+
+    // User scrolls up well outside the 120px slack window.
+    setGeometry(el, { scrollTop: 500 });
+
+    // A new message arrives.
+    rerender(
+      <Harness messageCount={21} scrollHeight={2200} clientHeight={400} />,
+    );
+
+    // distanceFromBottom = 2200 - 500 - 400 = 1300 >> 120 → no scroll.
+    expect(el.scrollTop).toBe(500);
+  });
+
+  it("force-scrolls to the bottom even when the user has scrolled up", () => {
+    let force: (() => void) | null = null;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(2000);
+
+    // User scrolls up far from the bottom.
+    setGeometry(el, { scrollTop: 100 });
+
+    // Local submit fires + a message lands.
+    act(() => {
+      force?.();
+    });
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2100}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+
+    // Force-scroll bypasses the slack check; pin to bottom.
+    expect(el.scrollTop).toBe(2100);
+  });
+
+  it("returns to honoring the slack window after a force-scroll", () => {
+    // Regression net for the bug in the pre-fix Facilitator effect:
+    // once forceScrollNonce > 0, the slack check was bypassed
+    // forever. The hook tracks the last-seen nonce so a one-shot
+    // force-scroll doesn't permanently override the user's scroll
+    // position.
+    let force: (() => void) | null = null;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(2000);
+
+    // Local submit force-scrolls to bottom on the next message.
+    act(() => {
+      force?.();
+    });
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2100}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    expect(el.scrollTop).toBe(2100);
+
+    // Now the user scrolls up to re-read.
+    setGeometry(el, { scrollTop: 200 });
+    rerender(
+      <Harness
+        messageCount={22}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+
+    // distanceFromBottom = 2200 - 200 - 400 = 1600 > 120 → leave alone.
+    // The pre-fix bug would have re-pinned to 2200.
+    expect(el.scrollTop).toBe(200);
+  });
+
+  it("respects a custom slack window", () => {
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        slack={30}
+        scrollHeight={2000}
+        clientHeight={400}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(2000);
+
+    // User scrolls up 50px (just outside the tighter 30px slack).
+    setGeometry(el, { scrollTop: 1550 });
+    rerender(
+      <Harness
+        messageCount={21}
+        slack={30}
+        scrollHeight={2050}
+        clientHeight={400}
+      />,
+    );
+
+    // distanceFromBottom = 2050 - 1550 - 400 = 100 > 30 → no scroll.
+    expect(el.scrollTop).toBe(1550);
+  });
+
+  it("follows new content when only the streaming flag flips", () => {
+    // Streaming-chunk events fire much more often than
+    // ``message_complete``, so ``streamingActive`` flipping (without
+    // ``messageCount`` changing) is the dominant runtime signal that
+    // the chat is growing. Verify the slack-follow path triggers from
+    // the streaming flag alone.
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        streamingActive={false}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    // Initial mount pin.
+    expect(el.scrollTop).toBe(2000);
+
+    // Streaming kicks in. Chunk text expands the transcript.
+    // ``messageCount`` is unchanged — only ``streamingActive`` flips.
+    rerender(
+      <Harness
+        messageCount={20}
+        scrollHeight={2400}
+        clientHeight={400}
+        streamingActive={true}
+      />,
+    );
+    // distanceFromBottom = 2400 - 2000 - 400 = 0 → well within slack.
+    // Pin should follow.
+    expect(el.scrollTop).toBe(2400);
+  });
+
+  it("handles back-to-back force-scrolls without sticking", () => {
+    // Two ``forceScrollToBottom()`` calls in quick succession (e.g. a
+    // proxy submit immediately followed by a force-advance) should
+    // both pin to bottom, and the slack check should still resume
+    // honouring the user's scroll position once the nonce stabilizes.
+    let force: (() => void) | null = null;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(2000);
+
+    // First force-scroll + new message.
+    act(() => {
+      force?.();
+    });
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2100}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    expect(el.scrollTop).toBe(2100);
+
+    // User scrolls up between the two forces.
+    setGeometry(el, { scrollTop: 50 });
+
+    // Second force-scroll + another new message.
+    act(() => {
+      force?.();
+    });
+    rerender(
+      <Harness
+        messageCount={22}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    // Each force bump consumed; second must still pin to bottom.
+    expect(el.scrollTop).toBe(2200);
+
+    // After the second force settles, slack check should resume:
+    // user scrolls up again, next message arrives without a force.
+    setGeometry(el, { scrollTop: 100 });
+    rerender(
+      <Harness
+        messageCount={23}
+        scrollHeight={2300}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+      />,
+    );
+    // distanceFromBottom = 2300 - 100 - 400 = 1800 > 120 → leave alone.
+    expect(el.scrollTop).toBe(100);
+  });
+
+  it("re-pins to bottom after unmount + remount", () => {
+    // A user routing away (e.g. opening the join intro again) and
+    // routing back unmounts and remounts the component. The new mount
+    // should re-fire the initial-pin branch — ``didInitialScrollRef``
+    // is per-hook-instance and resets on remount.
+    const { getByTestId, unmount } = render(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    const el1 = getByTestId("scroll-region");
+    expect(el1.scrollTop).toBe(2000);
+    unmount();
+
+    // Remount with a different transcript.
+    const { getByTestId: getByTestId2 } = render(
+      <Harness messageCount={30} scrollHeight={3000} clientHeight={400} />,
+    );
+    const el2 = getByTestId2("scroll-region");
+    // Fresh hook instance → didInitialScrollRef = false → pin.
+    expect(el2.scrollTop).toBe(3000);
+  });
+
+  it("waits for overflow before consuming the initial-mount pin", () => {
+    // A user who joins early (transcript empty / shorter than the
+    // viewport) shouldn't have the initial-mount branch fire and mark
+    // itself as done while there's nothing to scroll. Otherwise the
+    // first message that overflows would fall through to the slack
+    // check and read scrollTop=0 as "user has scrolled up."
+    const { getByTestId, rerender } = render(
+      <Harness messageCount={0} scrollHeight={400} clientHeight={400} />,
+    );
+    const el = getByTestId("scroll-region");
+    // No overflow yet; hook didn't write scrollTop. Default is 0.
+    expect(el.scrollTop).toBe(0);
+
+    // First real content arrives — transcript now overflows. The
+    // initial-mount branch should still be live (didInitial wasn't
+    // marked done in the no-overflow render) and pin to bottom.
+    rerender(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    expect(el.scrollTop).toBe(2000);
+  });
+});

--- a/frontend/src/__tests__/useStickyScroll.test.tsx
+++ b/frontend/src/__tests__/useStickyScroll.test.tsx
@@ -115,6 +115,15 @@ interface HarnessProps {
    *  just wrote. */
   scrollHeight: number;
   clientHeight: number;
+  /** Conditionally render the scroll element. Lets a test simulate
+   *  the production scenario where the hook lives in a long-lived
+   *  parent (Facilitator) and the scroll element is mounted /
+   *  unmounted by phase / session changes — e.g.
+   *  ``handleNewSession`` resets to the intro screen, then a new
+   *  session re-mounts the scroll div within the same hook instance.
+   *  The hook must reset its per-element state on identity change so
+   *  the new element gets the initial-pin treatment. */
+  mountElement?: boolean;
   bindForceScroll?: (fn: () => void) => void;
   slack?: number;
 }
@@ -130,6 +139,7 @@ function Harness({
   streamingActive = false,
   scrollHeight,
   clientHeight,
+  mountElement = true,
   bindForceScroll,
   slack,
 }: HarnessProps) {
@@ -167,12 +177,14 @@ function Harness({
     [scrollRef],
   );
 
-  return (
+  return mountElement ? (
     <div data-testid="scroll-region" ref={combinedRef}>
       {Array.from({ length: messageCount }, (_, i) => (
         <div key={i}>message {i}</div>
       ))}
     </div>
+  ) : (
+    <div data-testid="placeholder">no scroll region rendered</div>
   );
 }
 
@@ -446,6 +458,51 @@ describe("useStickyScroll", () => {
     );
     // distanceFromBottom = 2300 - 100 - 400 = 1800 > 120 → leave alone.
     expect(el.scrollTop).toBe(100);
+  });
+
+  it("re-pins when the scroll element remounts within the same hook instance", () => {
+    // Production scenario: Facilitator's ``handleNewSession()`` resets
+    // ``state`` to ``null`` and routes back to the intro screen,
+    // unmounting the chat scroll region. A new session then re-mounts
+    // a fresh scroll element. The hook itself stays mounted (the
+    // Facilitator component persists), so per-element state like
+    // ``didInitialScrollRef`` would carry over from the previous
+    // session and skip the initial pin on the new element — re-
+    // introducing the #79 stuck-at-top bug for the second exercise of
+    // the same browser tab. The hook resets that flag on element
+    // identity change to defend against this.
+    const { getByTestId, queryByTestId, rerender } = render(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    const el1 = getByTestId("scroll-region");
+    expect(el1.scrollTop).toBe(2000);
+
+    // Unmount the scroll region (e.g. routing back to the intro
+    // screen). The hook stays mounted; ``scrollRef`` is called with
+    // null on detach.
+    rerender(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        mountElement={false}
+      />,
+    );
+    expect(queryByTestId("scroll-region")).toBeNull();
+
+    // Re-mount the scroll region with a fresh element (e.g. starting
+    // a new session). The hook should treat this as a new initial
+    // mount and pin to the bottom of the new content.
+    rerender(
+      <Harness
+        messageCount={30}
+        scrollHeight={3000}
+        clientHeight={400}
+        mountElement={true}
+      />,
+    );
+    const el2 = getByTestId("scroll-region");
+    expect(el2.scrollTop).toBe(3000);
   });
 
   it("re-pins to bottom after unmount + remount", () => {

--- a/frontend/src/lib/useStickyScroll.ts
+++ b/frontend/src/lib/useStickyScroll.ts
@@ -1,0 +1,138 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Auto-pin a scrollable region to the bottom on new content unless the
+ * user has scrolled up to re-read earlier content. Three behaviors:
+ *
+ * 1. **Initial mount with content.** When the scroll element first
+ *    attaches and has overflowing content, pin it to the bottom
+ *    unconditionally so a participant joining mid-exercise lands on the
+ *    latest beat. (Pre-fix, the slack check below read scrollTop=0 as
+ *    "user has scrolled up" and stranded them at the top of the
+ *    transcript — issue #79.)
+ *
+ * 2. **Incoming content while pinned.** When ``deps`` change and the
+ *    user is within ``slack`` px of the bottom, follow the chat down.
+ *    If they've scrolled up beyond the slack window, leave their
+ *    position alone so the transcript doesn't yank under them.
+ *
+ * 3. **Force-scroll on local action.** ``forceScrollToBottom()`` pins
+ *    to the bottom on the next render regardless of slack. Use this
+ *    after a local user action (submit, force-advance) so the user
+ *    sees their own action commit, even if they happen to be reading
+ *    older content.
+ *
+ * The returned ``scrollRef`` is a callback ref. Attach it to the
+ * scrollable element instead of a plain ``useRef`` so the hook learns
+ * exactly when the element mounts — a regular ``useEffect`` keyed on
+ * ``deps`` won't re-run when the ref attaches if the deps haven't
+ * changed, which is the exact race that bit Play.tsx (snapshot loaded
+ * while JoinIntro was still showing → chat element mounted later with
+ * no further dep change → effect never re-ran with a non-null ref).
+ */
+export interface UseStickyScrollResult<T extends HTMLElement = HTMLDivElement> {
+  scrollRef: (el: T | null) => void;
+  forceScrollToBottom: () => void;
+}
+
+export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
+  deps: ReadonlyArray<unknown>,
+  options: { slack?: number } = {},
+): UseStickyScrollResult<T> {
+  const slack = options.slack ?? 120;
+  const elRef = useRef<T | null>(null);
+  const didInitialScrollRef = useRef(false);
+  const lastForceNonceRef = useRef(0);
+  // ``refVersion`` is bumped each time the callback ref attaches a new
+  // element. Including it in the layout-effect deps guarantees the
+  // effect re-runs once the element is in the DOM, even if the caller's
+  // ``deps`` happen not to have changed since the previous render.
+  const [refVersion, setRefVersion] = useState(0);
+  const [forceNonce, setForceNonce] = useState(0);
+
+  const scrollRef = useCallback((el: T | null) => {
+    elRef.current = el;
+    if (el !== null) {
+      setRefVersion((v) => v + 1);
+    }
+  }, []);
+
+  const forceScrollToBottom = useCallback(() => {
+    setForceNonce((n) => n + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = elRef.current;
+    if (!el) return;
+
+    if (!didInitialScrollRef.current) {
+      // First commit with the element attached. Pin to bottom so a
+      // participant joining mid-exercise lands on the latest message
+      // rather than the top of a long transcript. We only mark the
+      // initial scroll as "done" once content actually overflows —
+      // otherwise an empty / short initial render (transcript with
+      // 0 messages) would consume the initial-scroll branch, and a
+      // later content arrival would fall through to the slack check
+      // and read scrollTop=0 as "user scrolled up". Repeating the
+      // pin while there's no overflow is harmless: setting
+      // ``scrollTop`` on a non-scrollable element is a no-op.
+      if (el.scrollHeight <= el.clientHeight) {
+        // Nothing to scroll yet (empty transcript, or layout hasn't
+        // settled). Wait for the next render to retry.
+        return;
+      }
+      el.scrollTop = el.scrollHeight;
+      didInitialScrollRef.current = true;
+      lastForceNonceRef.current = forceNonce;
+      console.debug("[scroll] initial-pin", {
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      });
+      return;
+    }
+
+    if (forceNonce !== lastForceNonceRef.current) {
+      // ``forceScrollToBottom`` was called since the previous run.
+      // Pin unconditionally — the user just took a local action and
+      // wants to see the result. Tracking the last-seen nonce (rather
+      // than the original ``forceNonce > 0`` shortcut) is what keeps
+      // the slack check working *after* a force-scroll: once the
+      // nonce is stable again we go back to honoring the user's
+      // scroll position.
+      el.scrollTop = el.scrollHeight;
+      lastForceNonceRef.current = forceNonce;
+      console.debug("[scroll] force-pin", {
+        scrollHeight: el.scrollHeight,
+        nonce: forceNonce,
+      });
+      return;
+    }
+
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom < slack) {
+      el.scrollTop = el.scrollHeight;
+      console.debug("[scroll] follow", {
+        scrollHeight: el.scrollHeight,
+        distanceFromBottom,
+        slack,
+      });
+    } else {
+      // Logged so a "scroll didn't follow my new message" report can
+      // be correlated to the user's scroll position. Without this the
+      // UI just sits there silently.
+      console.debug("[scroll] leave-alone", {
+        scrollHeight: el.scrollHeight,
+        scrollTop: el.scrollTop,
+        clientHeight: el.clientHeight,
+        distanceFromBottom,
+        slack,
+      });
+    }
+    // The deps array is intentionally dynamic: callers pass whatever
+    // signals "content changed" (message count, streaming flag, etc.).
+    // The eslint rule can't statically verify that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, refVersion, forceNonce, slack]);
+
+  return { scrollRef, forceScrollToBottom };
+}

--- a/frontend/src/lib/useStickyScroll.ts
+++ b/frontend/src/lib/useStickyScroll.ts
@@ -51,7 +51,20 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
   const [forceNonce, setForceNonce] = useState(0);
 
   const scrollRef = useCallback((el: T | null) => {
+    const previous = elRef.current;
     elRef.current = el;
+    if (el !== previous) {
+      // Element identity changed. Reset per-element state so a
+      // remount within the same hook instance gets fresh initial-pin
+      // treatment. Without this, Facilitator's ``handleNewSession()``
+      // (which routes back to the intro screen — unmounting the
+      // scroll region — and a new session remounts a fresh one) would
+      // skip the initial-pin branch and re-introduce the #79
+      // stuck-at-top bug for the second exercise of the same tab.
+      // Same scenario applies to anything that swaps the scroll
+      // element while keeping the parent component mounted.
+      didInitialScrollRef.current = false;
+    }
     if (el !== null) {
       setRefVersion((v) => v + 1);
     }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -19,6 +19,7 @@ import { RolesPanel } from "../components/RolesPanel";
 import { SessionActivityPanel } from "../components/SessionActivityPanel";
 import { SetupChat } from "../components/SetupChat";
 import { Transcript } from "../components/Transcript";
+import { useStickyScroll } from "../lib/useStickyScroll";
 import { ServerEvent, WsClient } from "../lib/ws";
 
 export type Phase = "intro" | "setup" | "ready" | "play" | "ended";
@@ -207,17 +208,14 @@ export function Facilitator() {
       }
     };
   }, []);
-  // Wraps the chat scroll region so we can auto-pin the latest message to
-  // the bottom on each new arrival. Without this the user's view stays
-  // fixed where they were last reading and they don't realise a new AI
-  // beat just landed.
-  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
-  // Force-scroll latch: bumped whenever the local user takes an action
-  // (submit, proxy submit, force-advance) so the next render pins the
-  // chat to the bottom regardless of where they were scrolled. The
-  // slack-based "only if near bottom" rule below still applies for
-  // *incoming* messages from other roles.
-  const [forceScrollNonce, setForceScrollNonce] = useState(0);
+  // Wraps the chat scroll region so we can auto-pin the latest message
+  // to the bottom on each new arrival. The hook also force-pins on the
+  // initial mount (so refreshing mid-exercise lands on the latest
+  // beat — issue #79) and exposes ``forceScrollToBottom()`` for local
+  // user actions (submit / proxy / force-advance) that should always
+  // jump to the bottom regardless of scroll slack. The slack-based
+  // "only if near bottom" rule still applies for incoming messages
+  // from other roles.
 
   const phase: Phase = useMemo(() => {
     if (!snapshot) return "intro";
@@ -538,25 +536,20 @@ export function Facilitator() {
     return () => clearInterval(id);
   }, []);
 
-  // Auto-scroll the chat region to the bottom when the message count or
-  // streaming buffer grows. For incoming messages we keep the operator's
-  // scroll position if they've scrolled up to re-read an earlier beat
-  // (120px slack). For local-user actions (submit / proxy / force-
-  // advance) ``forceScrollNonce`` is bumped so we ALWAYS pin to the
-  // bottom — they just took an action and want to see the result.
+  // Auto-scroll the chat region to the bottom when the message count
+  // or streaming buffer grows. The hook handles three cases: initial
+  // mount with content (pin unconditionally so a refreshed tab lands
+  // on the latest beat), incoming content with the operator near the
+  // bottom (follow the chat down), and local-action force-scroll
+  // (``forceScrollToBottom()`` below — submit / proxy / force-advance
+  // always pin regardless of slack so the operator sees their action
+  // commit). Pre-fix the local-action latch was a stick: once any
+  // submit fired, the slack check was bypassed forever and the
+  // operator could no longer scroll up to re-read older beats.
   const messageCount = snapshot?.messages.length ?? 0;
-  useEffect(() => {
-    const el = scrollRegionRef.current;
-    if (!el) return;
-    if (forceScrollNonce > 0) {
-      el.scrollTop = el.scrollHeight;
-      return;
-    }
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distanceFromBottom < 120) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [messageCount, streamingActive, forceScrollNonce]);
+  const { scrollRef: scrollRegionRef, forceScrollToBottom } = useStickyScroll(
+    [messageCount, streamingActive],
+  );
 
   async function refreshSnapshot() {
     if (!state) return;
@@ -745,7 +738,7 @@ export function Facilitator() {
     if (!state) return;
     // Force scroll-to-bottom on the next render so the user sees their
     // own message commit. Mirrors what every chat client does on send.
-    setForceScrollNonce((n) => n + 1);
+    forceScrollToBottom();
     try {
       if (asRoleId && asRoleId !== state.creatorRoleId) {
         // Creator impersonation — go through the REST proxy endpoint so
@@ -789,7 +782,7 @@ export function Facilitator() {
     }, 3000);
     setBusy(true);
     setBusyMessage("Force-advancing turn — AI is drafting the next beat…");
-    setForceScrollNonce((n) => n + 1);
+    forceScrollToBottom();
     try {
       await api.forceAdvance(state.sessionId, state.token);
       await refreshSnapshot();

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -5,6 +5,7 @@ import { CriticalEventBanner } from "../components/CriticalEventBanner";
 import { RightSidebar } from "../components/RightSidebar";
 import { RoleRoster } from "../components/RoleRoster";
 import { Transcript } from "../components/Transcript";
+import { useStickyScroll } from "../lib/useStickyScroll";
 import { ServerEvent, WsClient } from "../lib/ws";
 
 interface Props {
@@ -81,7 +82,6 @@ export function Play({ sessionId, token }: Props) {
   // double/triple click (issue #63).
   const [forceAdvanceCooldown, setForceAdvanceCooldown] = useState(false);
   const wsRef = useRef<WsClient | null>(null);
-  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
   const forceAdvanceTimerRef = useRef<number | null>(null);
 
   // Determine self by inspecting snapshot.roles and matching the role with the
@@ -265,18 +265,17 @@ export function Play({ sessionId, token }: Props) {
   }
 
   // Auto-scroll the chat region to the bottom when new messages or
-  // streaming chunks arrive. If the player has scrolled up to re-read
-  // an earlier beat (>120px from bottom) we leave their position alone
-  // so the chat doesn't yank under them mid-read.
+  // streaming chunks arrive. ``useStickyScroll`` pins to the bottom on
+  // the player's initial mount (so a participant joining mid-exercise
+  // lands on the latest beat instead of the top of a long transcript —
+  // issue #79) and on incoming content while they're within 120px of
+  // the bottom. If they've scrolled up to re-read, their position is
+  // left alone. A local submit force-pins so they always see their own
+  // message commit.
   const messageCount = snapshot?.messages.length ?? 0;
-  useEffect(() => {
-    const el = scrollRegionRef.current;
-    if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distanceFromBottom < 120) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [messageCount, streamingActive]);
+  const { scrollRef: scrollRegionRef, forceScrollToBottom } = useStickyScroll(
+    [messageCount, streamingActive],
+  );
 
   // Clean up the force-advance cooldown timer on unmount so a tab
   // close mid-cooldown doesn't fire setState on an unmounted component.
@@ -317,6 +316,10 @@ export function Play({ sessionId, token }: Props) {
 
   function handleSubmit(text: string) {
     setError(null);
+    // Pin the chat to the bottom on the next render so the player sees
+    // their own message commit, even if they happened to be reading
+    // earlier content. Mirrors what every chat client does on send.
+    forceScrollToBottom();
     try {
       wsRef.current?.send({ type: "submit_response", content: text });
     } catch (err) {
@@ -344,6 +347,11 @@ export function Play({ sessionId, token }: Props) {
       setForceAdvanceCooldown(false);
       forceAdvanceTimerRef.current = null;
     }, 3000);
+    // Pin the chat to the bottom so the participant sees the AI's next
+    // beat land. Mirrors Facilitator.tsx's force-advance behavior so
+    // the "consistent for the creator and the user" half of issue #79
+    // covers force-advance, not just submit.
+    forceScrollToBottom();
     try {
       wsRef.current?.send({ type: "request_force_advance" });
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #79: a participant joining mid-exercise lands on the latest beat instead of the top of a long transcript.

## Root cause

`Play.tsx`'s auto-scroll effect read `scrollTop=0` as "user has scrolled up" and bailed. A player joining mid-exercise had a 30-message transcript above them and stayed stuck at the top — subsequent messages also failed the slack check because they remained at scrollTop=0. The same logic existed in `Facilitator.tsx`, which only worked for the creator because they typically start the session from scratch (so their initial scrollTop happens to be near the bottom).

## Fix

New shared `useStickyScroll` hook covering three cases:

1. **Initial-mount pin.** Callback ref + refVersion bump guarantees the layout effect re-fires once the scroll element attaches — even when the chat region mounts AFTER the snapshot loaded (the JoinIntro → chat transition in `Play.tsx` was where the pre-existing `useEffect` race lived). The pin only consumes itself once content actually overflows, so an empty initial render doesn't burn the one-shot.
2. **Slack-window follow** (default 120px). When the user is within slack of the bottom and new content arrives, follow down. Outside that window — leave them alone.
3. **Force-scroll.** `forceScrollToBottom()` pins regardless of slack on the next render. Wired to local-user actions: submit (both pages), proxy-submit + force-advance (creator), and now also participant force-advance.

Both pages now route through the same hook, so behavior is identical for creator and participant per the issue's requirement.

### Latent bug fixed along the way

The pre-fix `Facilitator.tsx` had `if (forceScrollNonce > 0) { scroll }` — once the operator submitted once, `forceScrollNonce` stayed truthy forever and the slack check was bypassed permanently. The operator could never scroll up to re-read older beats. The hook now tracks the last-seen nonce, so a one-shot force consumes one render only.

## Sub-agent review pipeline (CLAUDE.md)

| Agent | Verdict |
|---|---|
| Security | CLEAN |
| Prompt | N/A (frontend-only) |
| UI/UX | APPROVE — no BLOCK/CRITICAL |
| Product | APPROVE — no scope drift |
| QA | HIGH findings (logging boundaries + missing tests) **addressed in this commit** |
| User-persona | HIGH #6 (force-scroll on participant force-advance) **addressed in this commit** |

### Deferred follow-ups (out of scope for the bug fix)

- "View N earlier messages" affordance for mid-game joiners (user-persona HIGH #1)
- "You joined here" unread-divider (user-persona HIGH #2)
- Grace period before "Your turn" prompt fires on a fresh participant (user-persona HIGH #3)
- "New messages ↓" pill once the user has detached from auto-follow (user-persona MEDIUM #4)
- Viewport-relative slack on mobile (UI/UX MEDIUM)
- `useReducer` instead of `useState` for refVersion to drop the extra mount render (UI/UX MEDIUM)

## Test plan

- [x] `npm test -- --run` — 48 tests pass (10 new useStickyScroll tests)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] Manual: open a session with the creator, send 30+ messages, then open a participant join link in a new tab. Participant should land on the latest beat.
- [ ] Manual: scroll up >120px in the participant tab while the creator is sending more messages. Verify the chat does NOT yank.
- [ ] Manual: as participant, scroll up, then submit. Verify your message + the AI response pin you to the bottom.
- [ ] Manual: as creator, repeat the same scenarios — behavior should match.
- [ ] Manual: as creator, submit once, then scroll up to re-read older beats. Verify subsequent incoming AI messages do NOT yank you back (regression net for the old `forceScrollNonce > 0` stuck-latch).

Closes #79.

https://claude.ai/code/session_015d47PD4WmS8h8cYSfkKczq

---
_Generated by [Claude Code](https://claude.ai/code/session_015d47PD4WmS8h8cYSfkKczq)_