### PR TITLE
backend: rework AAR markdown layout + add unit + live regression nets

### DIFF
--- a/backend/app/llm/export.py
+++ b/backend/app/llm/export.py
@@ -285,18 +285,52 @@ def _render_markdown(
     return "\n".join(lines)
 
 
-def _render_bullets(items: list[str]) -> list[str]:
+def _render_bullets(items: Any) -> list[str]:
     """Render a list of report items as markdown bullets.
 
     A single-line item becomes ``- {item}``. A multi-line item keeps its
     first line on the bullet and indents continuation lines by two spaces
     so CommonMark / GFM treat them as a continuation of the same list
     item instead of breaking out into a sibling paragraph.
+
+    The input is **defensively coerced**. The AAR ``finalize_report``
+    tool schema declares each list field as ``array of string``, but the
+    model occasionally emits a lone string (when there's only one item)
+    or a non-string scalar (e.g. ``null``, an int) inside the array. The
+    AAR pipeline is operator-critical — a TypeError here would surface
+    to the user as a 500 on the export endpoint and block the entire
+    download. Coerce defensively, log when we had to.
     """
 
+    if items is None:
+        return []
+    # A lone string instead of a list — wrap it.
+    if isinstance(items, str):
+        items = [items]
+    # Anything that isn't iterable at this point means schema drift —
+    # log and bail out with an empty list rather than propagating a
+    # TypeError from the for-loop.
+    try:
+        iterator = iter(items)
+    except TypeError:
+        _logger.warning(
+            "aar_render_bullets_unexpected_type",
+            value_type=type(items).__name__,
+            value_preview=str(items)[:120],
+        )
+        return []
+
     out: list[str] = []
-    for raw in items:
-        cleaned = (raw or "").strip()
+    for raw in iterator:
+        if raw is None:
+            continue
+        # Coerce non-strings (numbers, bools) into their str repr; the
+        # alternative is a hard crash in ``.strip()``. The AAR will read
+        # slightly oddly with a bare number as a bullet, but at least it
+        # ships.
+        if not isinstance(raw, str):
+            raw = str(raw)
+        cleaned = raw.strip()
         if not cleaned:
             continue
         first, *rest = cleaned.split("\n")
@@ -315,16 +349,28 @@ def _render_bullets(items: list[str]) -> list[str]:
     return out
 
 
-def _flatten_table_cell(text: str) -> str:
+def _flatten_table_cell(text: Any) -> str:
     """Make ``text`` safe to drop into a GFM table cell.
 
     GFM tables use unescaped ``|`` as a column separator and treat raw
     newlines as a row terminator. Rationales coming back from the model
     occasionally contain either, which silently corrupts the score table.
     Fold whitespace and escape pipes.
+
+    The input is **defensively coerced** (per Copilot review on PR #85):
+    although the ``finalize_report`` tool schema declares ``rationale``
+    as a string, the model occasionally emits ``null`` or a non-string
+    scalar. ``(text or "–").split()`` raises on those — the AAR is
+    operator-critical so we can't afford a hard crash here. Coerce to
+    ``str(text)`` for non-None / non-string inputs and keep the
+    "–" placeholder for the empty/None case.
     """
 
-    flat = " ".join((text or "–").split())
+    if text is None or text == "":
+        return "–"
+    if not isinstance(text, str):
+        text = str(text)
+    flat = " ".join(text.split()) or "–"
     return flat.replace("|", "\\|")
 
 

--- a/backend/app/llm/export.py
+++ b/backend/app/llm/export.py
@@ -8,6 +8,7 @@ trusting freeform model output.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from ..auth.audit import AuditEvent, AuditLog
@@ -30,30 +31,43 @@ _logger = get_logger("llm.export")
 CREATOR_ONLY_BEGIN = "<!-- BEGIN_CREATOR_ONLY -->"
 CREATOR_ONLY_END = "<!-- END_CREATOR_ONLY -->"
 
+# Anchor the strip pattern to a whole line. Without anchoring, a player
+# message that happened to contain the literal marker string (e.g. a
+# CISO pasting a copy of the AAR template into chat) would surface in
+# the verbatim transcript appendix as ``> <!-- BEGIN_CREATOR_ONLY -->``
+# — substring matching would then suppress the rest of the player-
+# facing report (DoS, not a leak). The line-anchored regex only matches
+# markers the renderer itself emitted at column 0 of their own line.
+_CREATOR_ONLY_BLOCK_RE = re.compile(
+    r"^"
+    + re.escape(CREATOR_ONLY_BEGIN)
+    + r"\s*$"
+    + r".*?"
+    + r"^"
+    + re.escape(CREATOR_ONLY_END)
+    + r"\s*$"
+    + r"\n?",
+    re.DOTALL | re.MULTILINE,
+)
+_CREATOR_ONLY_DANGLING_BEGIN_RE = re.compile(
+    r"^" + re.escape(CREATOR_ONLY_BEGIN) + r"\s*$.*",
+    re.DOTALL | re.MULTILINE,
+)
+
 
 def strip_creator_only(markdown: str) -> str:
     """Remove every ``CREATOR_ONLY_BEGIN`` … ``CREATOR_ONLY_END`` block
-    from ``markdown``. Non-greedy, multi-block, tolerant of leading or
-    trailing whitespace around each marker."""
+    from ``markdown``. Line-anchored: only markers occupying their own
+    line are matched, so a player message body that happens to contain
+    the literal sentinel string (now visible in the verbatim transcript
+    appendix per issue #83) doesn't trigger spurious stripping."""
 
-    out: list[str] = []
-    cursor = 0
-    while True:
-        start = markdown.find(CREATOR_ONLY_BEGIN, cursor)
-        if start == -1:
-            out.append(markdown[cursor:])
-            break
-        out.append(markdown[cursor:start])
-        end = markdown.find(CREATOR_ONLY_END, start)
-        if end == -1:
-            # Unterminated marker — drop the rest defensively. Better to
-            # truncate than leak.
-            break
-        cursor = end + len(CREATOR_ONLY_END)
-        # Skip trailing newline so we don't leave a blank gap.
-        if cursor < len(markdown) and markdown[cursor] == "\n":
-            cursor += 1
-    return "".join(out)
+    stripped = _CREATOR_ONLY_BLOCK_RE.sub("", markdown)
+    # Unterminated BEGIN: drop everything from the marker line onwards.
+    # Better to truncate than risk leaking creator-only content into a
+    # player download.
+    stripped = _CREATOR_ONLY_DANGLING_BEGIN_RE.sub("", stripped)
+    return stripped
 
 
 class AARGenerator:
@@ -107,8 +121,20 @@ def _extract_report(content: list[dict[str, Any]]) -> dict[str, Any]:
         if block.get("type") == "tool_use" and block.get("name") == "finalize_report":
             return dict(block.get("input") or {})
     # Fallback: synthesize a minimal report from any text the model produced.
+    # The model SHOULD have called ``finalize_report`` (Block 1 of the AAR
+    # system prompt makes this an explicit instruction). Reaching this branch
+    # means a prompt regression, an Anthropic-side change, or a malformed
+    # response — log loudly so the on-call operator finds the cause from
+    # production logs alone rather than from a "the AAR looks empty" ticket.
     text = "".join(
         block.get("text", "") for block in content if block.get("type") == "text"
+    )
+    block_types = [block.get("type") for block in content]
+    _logger.warning(
+        "aar_finalize_report_missing",
+        text_preview=text[:200],
+        block_types=block_types,
+        block_count=len(content),
     )
     return {
         "executive_summary": text[:500] or "(no structured report returned)",
@@ -147,29 +173,27 @@ def _render_markdown(
     lines.append(report.get("executive_summary", "").strip() or "_(none)_")
     lines.append("")
 
-    lines.append("## Full transcript")
-    for msg in session.messages:
-        lines.append(_format_transcript_line(session, msg))
-    lines.append("")
-
     lines.append("## After-action narrative")
     lines.append(report.get("narrative", "").strip() or "_(none)_")
     lines.append("")
 
+    # Bullet-list sections from the structured report. Items can carry their
+    # own markdown (bold, links, sub-bullets); the formatter preserves
+    # multi-line content by indenting continuation lines under the parent
+    # bullet so renderers don't reflow them into a sibling paragraph (issue
+    # #83 — the original `- {item}` form broke any item that contained a
+    # newline because the second line escaped the list).
     if report.get("what_went_well"):
         lines.append("### What went well")
-        for item in report["what_went_well"]:
-            lines.append(f"- {item}")
+        lines.extend(_render_bullets(report["what_went_well"]))
         lines.append("")
     if report.get("gaps"):
         lines.append("### Gaps")
-        for item in report["gaps"]:
-            lines.append(f"- {item}")
+        lines.extend(_render_bullets(report["gaps"]))
         lines.append("")
     if report.get("recommendations"):
         lines.append("### Recommendations")
-        for item in report["recommendations"]:
-            lines.append(f"- {item}")
+        lines.extend(_render_bullets(report["recommendations"]))
         lines.append("")
 
     lines.append("## Per-role scores")
@@ -179,10 +203,14 @@ def _render_markdown(
     by_role: dict[str, dict[str, Any]] = {s.get("role_id", ""): s for s in scores}
     for role in sorted(session.roles, key=lambda r: r.label):
         row = by_role.get(role.id) or {}
+        # Cell-internal newlines / pipes break GFM tables — fold them so the
+        # row stays on one line and any pipe in the rationale doesn't open a
+        # phantom column.
+        rationale = _flatten_table_cell(row.get("rationale", "–"))
         lines.append(
             f"| {role.label} | {row.get('decision_quality', '–')} | "
             f"{row.get('communication', '–')} | {row.get('speed', '–')} | "
-            f"{row.get('rationale', '–')} |"
+            f"{rationale} |"
         )
     lines.append("")
 
@@ -217,13 +245,28 @@ def _render_markdown(
         lines.append("_(no audit events captured)_")
     lines.append("")
 
-    # Appendix D is creator-only (the AI's debug rationale leaks
+    # Appendix D — full transcript. Issue #83: the transcript used to live
+    # near the top of the report (right after the executive summary), which
+    # buried the analytic content under a wall of dialogue and made the AAR
+    # unreadable on real sessions. Pushed it to the appendix so the
+    # narrative / scores / recommendations come first; the rich per-message
+    # rendering (timestamp + role header + blockquoted body) preserves any
+    # markdown the AI emitted rather than collapsing it onto one line.
+    lines.append("## Appendix D — Full transcript")
+    if session.messages:
+        for msg in session.messages:
+            lines.extend(_format_transcript_entry(session, msg))
+    else:
+        lines.append("_(no messages recorded)_")
+    lines.append("")
+
+    # Appendix E is creator-only (the AI's debug rationale leaks
     # narrative reasoning that players shouldn't see). Wrapped in
     # sentinel HTML comments so the export endpoint strips this section
     # for non-creator downloads. Markdown viewers ignore HTML comments,
     # so the creator's copy renders normally.
     lines.append(CREATOR_ONLY_BEGIN)
-    lines.append("## Appendix D — AI decision rationale log _(facilitator only)_")
+    lines.append("## Appendix E — AI decision rationale log _(facilitator only)_")
     if session.decision_log:
         for entry in session.decision_log:
             ts = entry.ts.isoformat()
@@ -242,15 +285,80 @@ def _render_markdown(
     return "\n".join(lines)
 
 
-def _format_transcript_line(session: Session, msg: Message) -> str:
+def _render_bullets(items: list[str]) -> list[str]:
+    """Render a list of report items as markdown bullets.
+
+    A single-line item becomes ``- {item}``. A multi-line item keeps its
+    first line on the bullet and indents continuation lines by two spaces
+    so CommonMark / GFM treat them as a continuation of the same list
+    item instead of breaking out into a sibling paragraph.
+    """
+
+    out: list[str] = []
+    for raw in items:
+        cleaned = (raw or "").strip()
+        if not cleaned:
+            continue
+        first, *rest = cleaned.split("\n")
+        out.append(f"- {first}")
+        for line in rest:
+            # Drop blank continuation lines entirely — emitting an empty
+            # line would force CommonMark into "loose list" mode, which
+            # wraps every ``<li>`` in ``<p>`` and produces visibly ragged
+            # bullet spacing in the AAR popup. Dropping the blank still
+            # keeps the next non-blank line indented under the parent
+            # bullet, so the multi-line markdown structure (sub-bullets,
+            # continuation prose) survives in tight-list rendering.
+            if not line.strip():
+                continue
+            out.append(f"  {line}")
+    return out
+
+
+def _flatten_table_cell(text: str) -> str:
+    """Make ``text`` safe to drop into a GFM table cell.
+
+    GFM tables use unescaped ``|`` as a column separator and treat raw
+    newlines as a row terminator. Rationales coming back from the model
+    occasionally contain either, which silently corrupts the score table.
+    Fold whitespace and escape pipes.
+    """
+
+    flat = " ".join((text or "–").split())
+    return flat.replace("|", "\\|")
+
+
+def _format_transcript_entry(session: Session, msg: Message) -> list[str]:
+    """Render one transcript entry as a header + blockquoted body.
+
+    Issue #83: the previous ``- _ts_ — **Role**: body`` form collapsed
+    newlines into spaces and made any markdown the AI emitted (lists,
+    code fences, tables in ``share_data``, etc.) unreadable. The new
+    form puts the metadata on its own line and quotes every line of the
+    body so multi-line markdown survives.
+    """
+
     role = session.role_by_id(msg.role_id) if msg.role_id else None
-    actor = (
-        f"**{role.label}** ({role.display_name})"
-        if role
-        else "**AI Facilitator**"
-        if msg.kind.value.startswith("ai")
-        else "**System**"
-    )
+    if role:
+        actor = f"**{role.label}**"
+        if role.display_name:
+            actor += f" ({role.display_name})"
+    elif msg.kind.value.startswith("ai"):
+        actor = "**AI Facilitator**"
+    else:
+        actor = "**System**"
+
     tag = f" _[{msg.tool_name}]_" if msg.tool_name else ""
-    body = msg.body.replace("\n", " ").strip()
-    return f"- _{msg.ts.isoformat()}_ — {actor}{tag}: {body}"
+    header = f"**{msg.ts.isoformat()}** — {actor}{tag}"
+    body = (msg.body or "").rstrip()
+    if not body:
+        body = "_(empty)_"
+
+    out: list[str] = [header, ""]
+    for line in body.split("\n"):
+        # Blockquote-prefix every line, including blanks, so a paragraph
+        # break inside the body doesn't terminate the quote (which would
+        # otherwise let the next line escape into a top-level paragraph).
+        out.append(f"> {line}" if line else ">")
+    out.append("")
+    return out

--- a/backend/tests/live/test_aar_generation.py
+++ b/backend/tests/live/test_aar_generation.py
@@ -1,0 +1,463 @@
+"""Live-API regression suite for the AAR generation pipeline.
+
+Each test hits the real Anthropic API and asserts that the AAR generator
+produces a structured ``finalize_report`` tool call with the fields the
+markdown renderer relies on. Skipped unless ``ANTHROPIC_API_KEY`` is set.
+Cost: ~$0.05 per run (one Opus call per test, ~5K input + ~1.5K output).
+
+Why this exists
+---------------
+
+Issue #83 surfaced two failure modes the unit-test layer can't catch:
+
+1. **Schema drift** — if the AAR system prompt or the ``finalize_report``
+   tool description changes such that the model omits a required field
+   (e.g. ``per_role_scores``) or returns the wrong shape, the deterministic
+   markdown renderer falls back to "(no structured report returned)" and
+   the operator sees a degraded AAR. Mocked fixtures don't catch this; only
+   the real model does.
+
+2. **Markdown emission inside list items** — the ``what_went_well`` /
+   ``gaps`` / ``recommendations`` bullets must render properly even when
+   the model emits markdown (bold, sub-bullets) inside individual entries.
+   The renderer fix in this branch indents continuation lines so multi-line
+   items don't break the parent bullet; this suite confirms the model
+   actually exercises that path.
+
+These tests run against the same prompt + tool surface production uses, so
+they regress on prompt edits, tool-schema edits, and any
+``Settings.model_for("aar")`` change.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.auth.audit import AuditLog
+from app.config import get_settings
+from app.llm.client import LLMClient
+from app.llm.export import AARGenerator, _extract_report
+from app.llm.prompts import build_aar_system_blocks
+from app.llm.tools import AAR_TOOL
+from app.sessions.models import (
+    Message,
+    MessageKind,
+    Role,
+    ScenarioBeat,
+    ScenarioInject,
+    ScenarioPlan,
+    Session,
+    SessionState,
+    SetupNote,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.live]
+
+
+# ---------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def aar_session() -> Session:
+    """A short but complete tabletop transcript with two roles, three
+    beats of dialogue and one critical inject. The AAR generator should
+    produce a structured report with per-role scores, gaps, and
+    recommendations grounded in the transcript."""
+
+    ciso = Role(id="role-ciso", label="CISO", display_name="Alex", is_creator=True)
+    soc = Role(id="role-soc", label="SOC Analyst", display_name="Bo")
+    plan = ScenarioPlan(
+        title="Ransomware via vendor portal",
+        executive_summary="03:14 Wednesday. Ransomware on finance laptops.",
+        key_objectives=[
+            "Confirm scope before containment",
+            "Decide regulator-notification clock",
+            "Stage Comms draft for legal review",
+        ],
+        narrative_arc=[
+            ScenarioBeat(beat=1, label="Detection & triage", expected_actors=["SOC"]),
+            ScenarioBeat(
+                beat=2, label="Containment & comms", expected_actors=["CISO", "SOC"]
+            ),
+        ],
+        injects=[
+            ScenarioInject(
+                trigger="after beat 1",
+                type="critical",
+                summary="Reporter calls about leaked Slack screenshot.",
+            ),
+        ],
+        guardrails=["stay in scope", "no real exploit code"],
+        success_criteria=["containment before beat 3", "regulator clock decided"],
+        out_of_scope=["live exploitation", "specific CVE PoCs"],
+    )
+    s = Session(
+        scenario_prompt="Ransomware via vendor portal",
+        state=SessionState.ENDED,
+        roles=[ciso, soc],
+        creator_role_id=ciso.id,
+        plan=plan,
+    )
+    s.setup_notes.append(
+        SetupNote(speaker="creator", topic="scope", content="Finance org, 50 people."),
+    )
+    s.messages.extend(
+        [
+            Message(
+                kind=MessageKind.AI_TEXT,
+                tool_name="broadcast",
+                body=(
+                    "**Beat 1 — Detection.** Defender just lit up on three "
+                    "finance laptops. **CISO** — first call: isolate or "
+                    "monitor for scope?"
+                ),
+            ),
+            Message(
+                kind=MessageKind.PLAYER,
+                role_id=ciso.id,
+                body="Isolate now. Pull IR Lead in. Start the regulator clock.",
+            ),
+            Message(
+                kind=MessageKind.AI_TEXT,
+                tool_name="broadcast",
+                body=(
+                    "Acknowledged — isolation in progress. **SOC** — what "
+                    "does the alert queue actually show?"
+                ),
+            ),
+            Message(
+                kind=MessageKind.PLAYER,
+                role_id=soc.id,
+                body=(
+                    "Three FIN-* hosts with Defender alert + lateral SMB "
+                    "attempts to FIN-08. Pulling Defender logs now."
+                ),
+            ),
+            Message(
+                kind=MessageKind.CRITICAL_INJECT,
+                tool_name="inject_critical_event",
+                body="Reporter calls about leaked Slack screenshot.",
+            ),
+            Message(
+                kind=MessageKind.PLAYER,
+                role_id=ciso.id,
+                body=(
+                    "No comment to press. Have Comms draft a holding "
+                    "statement with Legal."
+                ),
+            ),
+        ]
+    )
+    return s
+
+
+@pytest.fixture
+def aar_audit() -> AuditLog:
+    """Empty audit log — the AAR pipeline accepts this and the model
+    grounds its output in the transcript instead. The audit log is
+    additive context; not having it shouldn't break the generation."""
+
+    return AuditLog()
+
+
+@pytest.fixture
+def aar_client() -> LLMClient:
+    """Production-shaped LLMClient pointed at the live API."""
+
+    settings = get_settings()
+    # The client's own factory; same path the SessionManager uses.
+    client = LLMClient(settings=settings)
+    return client
+
+
+# ---------------------------------------------------------------- tests
+
+
+async def test_aar_generator_emits_finalize_report(
+    aar_session: Session, aar_audit: AuditLog, aar_client: LLMClient
+) -> None:
+    """End-to-end: AARGenerator on a small transcript produces a markdown
+    string that includes every required section. Routing-level check —
+    the goal is to verify the model still picks ``finalize_report`` (not
+    a freeform text reply) under the current prompt."""
+
+    gen = AARGenerator(llm=aar_client, audit=aar_audit)
+    md = await gen.generate(aar_session)
+
+    # Required sections (sanity — empty model output would not include them).
+    for section in (
+        "## Executive summary",
+        "## After-action narrative",
+        "## Per-role scores",
+        "## Overall session score",
+        "## Appendix A — Setup conversation",
+        "## Appendix D — Full transcript",
+    ):
+        assert section in md, f"missing section in AAR: {section}"
+
+    # Issue #83: transcript appendix sits after the analytic sections.
+    assert md.index("## Per-role scores") < md.index("## Appendix D — Full transcript")
+
+    # The fallback string is a sign the model didn't emit finalize_report.
+    assert "(no structured report returned)" not in md, (
+        "model failed to emit finalize_report; markdown contains the "
+        "fallback synthesis text. Likely cause: AAR system prompt drift "
+        "or tool-description regression."
+    )
+
+    # Issue #83 fix #2: every transcript entry renders as
+    # ``header + > body``. Confirm the blockquote prefix actually made
+    # it through the live round-trip — a future regression that flipped
+    # ``_format_transcript_entry`` back to a flat one-liner would still
+    # leave the section heading in place but lose the markdown-preserving
+    # blockquote structure. Catch it here.
+    transcript_section = md.split("## Appendix D — Full transcript", 1)[1]
+    assert any(line.startswith("> ") for line in transcript_section.splitlines()), (
+        "transcript appendix has no blockquote-prefixed lines — the "
+        "renderer regressed to the pre-#83 flat one-liner format."
+    )
+
+
+async def test_aar_report_includes_per_role_scores_for_seated_roles(
+    aar_session: Session, aar_audit: AuditLog, aar_client: LLMClient
+) -> None:
+    """Each seated role must appear in ``per_role_scores`` with all four
+    sub-fields populated. The renderer falls back to ``–`` for missing
+    role rows, which is operator-confusing — catch model omissions here."""
+
+    raw = await aar_client.acomplete(
+        tier="aar",
+        system_blocks=build_aar_system_blocks(aar_session),
+        messages=[
+            {
+                "role": "user",
+                "content": _build_user_payload(aar_session, aar_audit),
+            }
+        ],
+        tools=[AAR_TOOL],
+        session_id=aar_session.id,
+    )
+    report = _extract_report(raw.content)
+
+    assert report.get("per_role_scores"), (
+        f"finalize_report missing per_role_scores: {list(report.keys())}"
+    )
+    seated_ids = {r.id for r in aar_session.roles}
+    scored_ids = {row.get("role_id") for row in report["per_role_scores"]}
+    missing = seated_ids - scored_ids
+    assert not missing, (
+        f"model omitted per_role_scores for roles: {missing}; "
+        f"reported: {scored_ids}"
+    )
+
+    for row in report["per_role_scores"]:
+        for field in ("decision_quality", "communication", "speed", "rationale"):
+            assert field in row, (
+                f"per_role_scores entry for {row.get('role_id')} missing "
+                f"{field}: {row}"
+            )
+        # Numeric fields must fall in the rubric range 1–5.
+        for field in ("decision_quality", "communication", "speed"):
+            value = row[field]
+            assert isinstance(value, int) and 1 <= value <= 5, (
+                f"{row.get('role_id')}.{field} = {value!r}; expected int 1–5"
+            )
+        assert isinstance(row["rationale"], str) and row["rationale"].strip(), (
+            f"{row.get('role_id')}.rationale must be a non-empty string"
+        )
+
+
+async def test_aar_report_overall_score_in_range(
+    aar_session: Session, aar_audit: AuditLog, aar_client: LLMClient
+) -> None:
+    """Overall score must be an integer 1–5 with a non-empty rationale."""
+
+    raw = await aar_client.acomplete(
+        tier="aar",
+        system_blocks=build_aar_system_blocks(aar_session),
+        messages=[
+            {
+                "role": "user",
+                "content": _build_user_payload(aar_session, aar_audit),
+            }
+        ],
+        tools=[AAR_TOOL],
+        session_id=aar_session.id,
+    )
+    report = _extract_report(raw.content)
+
+    score = report.get("overall_score")
+    assert isinstance(score, int) and 1 <= score <= 5, (
+        f"overall_score = {score!r}; expected int 1–5"
+    )
+    rationale = report.get("overall_rationale", "")
+    assert isinstance(rationale, str) and rationale.strip(), (
+        f"overall_rationale missing or empty: {rationale!r}"
+    )
+
+
+async def test_aar_report_grounds_recommendations_in_transcript(
+    aar_session: Session, aar_audit: AuditLog, aar_client: LLMClient
+) -> None:
+    """The model should produce at least one recommendation that touches
+    a topic actually present in the transcript (containment, regulator
+    notification, comms / press, vendor accounts, etc.). Soft-grounding
+    check — at least one keyword from the seeded narrative should appear
+    somewhere in the recommendations OR in the gaps list. If neither
+    contains a single transcript-anchored keyword, the model is producing
+    generic boilerplate and the AAR is failing its core job."""
+
+    raw = await aar_client.acomplete(
+        tier="aar",
+        system_blocks=build_aar_system_blocks(aar_session),
+        messages=[
+            {
+                "role": "user",
+                "content": _build_user_payload(aar_session, aar_audit),
+            }
+        ],
+        tools=[AAR_TOOL],
+        session_id=aar_session.id,
+    )
+    report = _extract_report(raw.content)
+
+    recs = report.get("recommendations") or []
+    gaps = report.get("gaps") or []
+    assert recs, "model produced no recommendations"
+    # Search both gaps and recs — gaps name "what was missing" and recs
+    # name "what to do about it"; either is a valid place to anchor a
+    # transcript-grounded observation. The model also frequently uses
+    # the narrative section for these anchors.
+    narrative = report.get("narrative") or ""
+    blob = (" ".join(recs) + " " + " ".join(gaps) + " " + narrative).lower()
+    # Substrings (not whole words) so "communications", "communicate",
+    # "comms", "regulatory", "regulator" all hit a single check, and the
+    # model's preferred phrasing doesn't trip the test.
+    keywords = (
+        "regulat",  # regulator / regulatory
+        "comm",  # comms / communication / communicate
+        "press",
+        "media",
+        "reporter",
+        "containment",
+        "contain",
+        "isolat",  # isolation / isolate
+        "vendor",
+        "legal",
+        "draft",
+        "playbook",
+        "ransom",
+        "defender",
+        "slack",
+        "screenshot",
+    )
+    hits = [k for k in keywords if k in blob]
+    assert hits, (
+        "neither recommendations nor gaps reference any topic from the "
+        "seeded transcript — model may be producing generic boilerplate. "
+        f"recommendations: {recs}\ngaps: {gaps}"
+    )
+
+
+async def test_aar_report_what_went_well_and_gaps_non_empty(
+    aar_session: Session, aar_audit: AuditLog, aar_client: LLMClient
+) -> None:
+    """Both the strengths and the gaps list must be populated for the
+    AAR to feel balanced. The system prompt explicitly asks for 3–7 items
+    per list; assert at least one in each."""
+
+    raw = await aar_client.acomplete(
+        tier="aar",
+        system_blocks=build_aar_system_blocks(aar_session),
+        messages=[
+            {
+                "role": "user",
+                "content": _build_user_payload(aar_session, aar_audit),
+            }
+        ],
+        tools=[AAR_TOOL],
+        session_id=aar_session.id,
+    )
+    report = _extract_report(raw.content)
+
+    well = report.get("what_went_well") or []
+    gaps = report.get("gaps") or []
+    # Issue #83 in practice: the live model occasionally emits a
+    # whitespace-only entry (observed on 2026-04-30: ``'\n'`` slipped
+    # through Opus output). The renderer's ``_render_bullets`` drops
+    # those silently — so the user-visible AAR is fine, but the test
+    # bar is "at least one non-empty item per list", not "every item is
+    # non-empty". This both avoids flakiness and proves the renderer is
+    # tolerant of the variance.
+    well_clean = [item for item in well if isinstance(item, str) and item.strip()]
+    gaps_clean = [item for item in gaps if isinstance(item, str) and item.strip()]
+    assert well_clean, (
+        "what_went_well has no non-empty items — AAR feels one-sided. "
+        f"Raw: {well!r}"
+    )
+    assert gaps_clean, (
+        "gaps has no non-empty items — AAR feels one-sided. "
+        f"Raw: {gaps!r}"
+    )
+
+
+async def test_aar_report_no_temperature_param_for_opus(
+    aar_session: Session, aar_audit: AuditLog, aar_client: LLMClient
+) -> None:
+    """Defensive guard: the AAR tier defaults to Opus 4.x which rejects
+    the ``temperature`` param. The client strips it before the API call;
+    if a future caller re-introduces it, the live API will 400. This
+    test simply runs an end-to-end AAR and asserts no API error — a
+    return without exception means the strip is still in place."""
+
+    gen = AARGenerator(llm=aar_client, audit=aar_audit)
+    md = await gen.generate(aar_session)
+    # If the call had errored on a temperature rejection, generate() would
+    # have raised. A non-empty markdown body is enough confirmation here.
+    assert md.startswith("# "), (
+        f"AAR markdown does not begin with a heading; first 80 chars: "
+        f"{md[:80]!r}"
+    )
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _build_user_payload(session: Session, audit: AuditLog) -> str:
+    """Mirror :func:`app.llm.export._user_payload` for the lower-level
+    tests that bypass the AARGenerator wrapper. Kept inline rather than
+    importing the underscore-private helper so a future signature change
+    doesn't require touching multiple files in lockstep."""
+
+    import json
+
+    transcript = "\n".join(
+        f"[{m.kind.value}] role={m.role_id or 'AI'}: {m.body}" for m in session.messages
+    )
+    setup = "\n".join(
+        f"[{n.speaker}] {n.topic or '-'}: {n.content}" for n in session.setup_notes
+    )
+    audit_lines = "\n".join(
+        json.dumps({"kind": e.kind, "ts": e.ts.isoformat(), "payload": e.payload})
+        for e in audit.dump(session.id)
+    )
+    return (
+        "Session transcript:\n"
+        f"{transcript}\n\n"
+        "Setup conversation:\n"
+        f"{setup}\n\n"
+        "Audit log (JSONL):\n"
+        f"{audit_lines}\n\n"
+        "Call finalize_report with your structured report."
+    )
+
+
+# Suite-level guard — the directory-level conftest skips when the API key is
+# missing, but defending in depth here gives a clearer error if someone runs
+# the file directly with ``pytest tests/live/test_aar_generation.py``.
+if not os.environ.get("ANTHROPIC_API_KEY"):  # pragma: no cover - import-time guard
+    pytestmark.append(
+        pytest.mark.skip(reason="live-API tests require ANTHROPIC_API_KEY")
+    )

--- a/backend/tests/test_aar_export.py
+++ b/backend/tests/test_aar_export.py
@@ -1,0 +1,640 @@
+"""Unit tests for the AAR markdown rendering pipeline.
+
+The :func:`app.llm.export._render_markdown` helper builds the operator-facing
+markdown report from the structured ``finalize_report`` payload. Issue #83
+flagged two formatting bugs:
+
+* the "what went well" / "gaps" / "recommendations" bullets dropped any
+  multi-line markdown the model emitted because the renderer treated each
+  item as a single line,
+* the full transcript lived near the top of the report and used a flattened
+  ``- _ts_ — **Role**: body`` form that collapsed newlines into spaces, so
+  any markdown the AI emitted (lists, code fences, tables) became unreadable.
+
+These tests pin the new behavior:
+
+* multi-line bullet items keep their continuation lines indented under the
+  parent bullet,
+* the transcript renders as ``header + blockquoted body`` so multi-line
+  markdown survives,
+* the transcript appendix lives at the bottom of the report (after the
+  per-role scores) and the analytic sections come first,
+* the creator-only block is wrapped in sentinel comments and gets stripped
+  cleanly by :func:`strip_creator_only`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from app.auth.audit import AuditEvent
+from app.llm.export import (
+    CREATOR_ONLY_BEGIN,
+    CREATOR_ONLY_END,
+    _flatten_table_cell,
+    _format_transcript_entry,
+    _render_bullets,
+    _render_markdown,
+    strip_creator_only,
+)
+from app.sessions.models import (
+    DecisionLogEntry,
+    Message,
+    MessageKind,
+    Role,
+    ScenarioBeat,
+    ScenarioInject,
+    ScenarioPlan,
+    Session,
+    SessionState,
+    SetupNote,
+)
+
+# ---------------------------------------------------------------- fixtures
+
+
+def _ts(seconds: int = 0) -> datetime:
+    """Build a deterministic UTC timestamp ``seconds`` past 10:00:00 on
+    2026-04-30. Tests use small ints (0–~120) so we keep the formula
+    inside the minute/hour bounds explicitly."""
+
+    minute, second = divmod(seconds, 60)
+    return datetime(2026, 4, 30, 10, minute, second, tzinfo=UTC)
+
+
+@pytest.fixture
+def ciso() -> Role:
+    return Role(
+        id="role-ciso",
+        label="CISO",
+        display_name="Alex",
+        is_creator=True,
+    )
+
+
+@pytest.fixture
+def soc() -> Role:
+    return Role(id="role-soc", label="SOC Analyst", display_name="Bo")
+
+
+@pytest.fixture
+def session_with_messages(ciso: Role, soc: Role) -> Session:
+    plan = ScenarioPlan(
+        title="Ransomware via vendor portal",
+        executive_summary="03:14 Wednesday. Ransomware on finance laptops.",
+        key_objectives=["Confirm scope", "Contain"],
+        narrative_arc=[
+            ScenarioBeat(beat=1, label="Detection & triage", expected_actors=["SOC"]),
+        ],
+        injects=[
+            ScenarioInject(
+                trigger="after beat 1",
+                type="critical",
+                summary="Slack screenshot leaked.",
+            ),
+        ],
+        guardrails=["stay in scope"],
+        success_criteria=["containment before beat 3"],
+        out_of_scope=["real exploit code"],
+    )
+    s = Session(
+        scenario_prompt="Ransomware via vendor portal",
+        state=SessionState.ENDED,
+        roles=[ciso, soc],
+        creator_role_id=ciso.id,
+        plan=plan,
+        ended_at=_ts(60),
+    )
+    s.created_at = _ts(0)
+    s.messages.extend(
+        [
+            Message(
+                kind=MessageKind.AI_TEXT,
+                tool_name="broadcast",
+                ts=_ts(1),
+                body=(
+                    "**Briefing**\n\n"
+                    "- Beat 1: detection\n"
+                    "- Beat 2: containment\n\n"
+                    "_Who acts first?_"
+                ),
+            ),
+            Message(
+                kind=MessageKind.PLAYER,
+                role_id=ciso.id,
+                ts=_ts(2),
+                body="Isolate immediately.\n\nPull IR Lead in.",
+            ),
+            Message(
+                kind=MessageKind.AI_TEXT,
+                tool_name="share_data",
+                ts=_ts(3),
+                body=(
+                    "Defender alert queue — 03:14 UTC\n\n"
+                    "```\n"
+                    "ALERT-001  Critical  FIN-04\n"
+                    "ALERT-002  High      FIN-12\n"
+                    "```"
+                ),
+            ),
+        ]
+    )
+    s.setup_notes.append(
+        SetupNote(speaker="creator", topic="scope", content="finance only", ts=_ts(0))
+    )
+    s.decision_log.append(
+        DecisionLogEntry(
+            ts=_ts(2),
+            turn_index=1,
+            rationale="CISO answered fast — push briefing forward.",
+        )
+    )
+    return s
+
+
+@pytest.fixture
+def report() -> dict[str, Any]:
+    return {
+        "executive_summary": "Team contained ransomware in 23 minutes.",
+        "narrative": "Para 1.\n\nPara 2.",
+        "what_went_well": [
+            "**Quick containment** within 3 minutes",
+            # Multi-line item — must render as a single bullet with indented
+            # continuation lines, not split into two paragraphs.
+            "Strong cross-role comms\n  - CISO drove decisions\n  - SOC fed telemetry",
+            "  ",  # whitespace-only items are dropped
+        ],
+        "gaps": [
+            "Delayed regulator clock",
+            "No comms draft staged",
+        ],
+        "recommendations": [
+            "Pre-draft regulator notification template",
+        ],
+        "per_role_scores": [
+            {
+                "role_id": "role-ciso",
+                "decision_quality": 4,
+                "communication": 4,
+                "speed": 5,
+                # Pipe + newline in the rationale — must be flattened so the
+                # GFM table doesn't break.
+                "rationale": "Decisive call early\nfollowed up | clearly",
+            },
+            {
+                "role_id": "role-soc",
+                "decision_quality": 3,
+                "communication": 4,
+                "speed": 4,
+                "rationale": "Reliable telemetry feed.",
+            },
+        ],
+        "overall_score": 4,
+        "overall_rationale": "Solid response with documentation gaps.",
+    }
+
+
+# ---------------------------------------------------------------- _render_bullets
+
+
+def test_render_bullets_single_line() -> None:
+    out = _render_bullets(["Quick containment", "Clear comms"])
+    assert out == ["- Quick containment", "- Clear comms"]
+
+
+def test_render_bullets_preserves_multiline_continuation() -> None:
+    """A multi-line item keeps the first line on the bullet and indents the
+    rest with two spaces so the bullet doesn't break."""
+
+    out = _render_bullets(["**Header**\n  - sub-bullet 1\n  - sub-bullet 2"])
+    assert out == [
+        "- **Header**",
+        "    - sub-bullet 1",
+        "    - sub-bullet 2",
+    ]
+
+
+def test_render_bullets_drops_blank_items() -> None:
+    out = _render_bullets(["", "   ", "real item", "\n\n"])
+    assert out == ["- real item"]
+
+
+def test_render_bullets_drops_blank_continuation_lines() -> None:
+    """Blank continuation lines inside a bullet are dropped, not preserved.
+
+    Preserving them flips CommonMark into "loose list" mode, which wraps
+    every ``<li>`` in a ``<p>`` and produces visibly uneven bullet spacing
+    in the AAR popup (UI/UX review finding). Dropping blanks keeps the
+    list tight while still letting non-blank continuation lines stay
+    indented under the parent bullet.
+    """
+
+    out = _render_bullets(["first\n\nsecond"])
+    assert out == ["- first", "  second"]
+
+
+# ---------------------------------------------------------------- _flatten_table_cell
+
+
+def test_flatten_table_cell_handles_pipes_and_newlines() -> None:
+    out = _flatten_table_cell("split | here\nand\twrap")
+    assert "\n" not in out
+    assert "\\|" in out
+    assert out == "split \\| here and wrap"
+
+
+def test_flatten_table_cell_falls_back_for_empty() -> None:
+    assert _flatten_table_cell("") == "–"
+    assert _flatten_table_cell(None) == "–"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------- _format_transcript_entry
+
+
+def test_transcript_entry_blockquotes_multiline_body(
+    session_with_messages: Session,
+) -> None:
+    """Multi-line message body must render as a series of blockquote lines
+    so markdown blocks (bold, lists, code fences) stay intact."""
+
+    msg = session_with_messages.messages[0]  # AI broadcast with markdown body
+    out = _format_transcript_entry(session_with_messages, msg)
+
+    # Header line carries timestamp + actor + tool tag.
+    assert out[0].startswith("**2026-04-30T10:00:01")
+    assert "AI Facilitator" in out[0]
+    assert "_[broadcast]_" in out[0]
+
+    # Body lines are blockquoted.
+    body_lines = [line for line in out[2:] if line.strip()]
+    assert all(line.startswith(">") for line in body_lines), out
+    # The blank line between paragraphs is preserved as a bare ``>``.
+    assert ">" in out
+    # The original markdown survives.
+    assert any("**Briefing**" in line for line in out)
+    assert any("- Beat 1" in line for line in out)
+
+
+def test_transcript_entry_renders_player_with_display_name(
+    session_with_messages: Session,
+) -> None:
+    msg = session_with_messages.messages[1]  # CISO player message
+    out = _format_transcript_entry(session_with_messages, msg)
+    assert "**CISO**" in out[0]
+    assert "(Alex)" in out[0]
+
+
+def test_transcript_entry_handles_empty_body(
+    session_with_messages: Session,
+) -> None:
+    """An empty-body message renders an explicit ``_(empty)_`` placeholder
+    inside the blockquote rather than a stray header with no content."""
+
+    blank = Message(
+        kind=MessageKind.SYSTEM,
+        ts=_ts(99),
+        body="",
+    )
+    out = _format_transcript_entry(session_with_messages, blank)
+    assert any("_(empty)_" in line for line in out)
+
+
+# ---------------------------------------------------------------- _render_markdown
+
+
+def test_render_markdown_section_order(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    """Issue #83: the transcript appendix must come AFTER the analytic
+    sections (executive summary, narrative, what-went-well, scores)."""
+
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+
+    # All headlines must be present once.
+    for header in (
+        "## Executive summary",
+        "## After-action narrative",
+        "### What went well",
+        "### Gaps",
+        "### Recommendations",
+        "## Per-role scores",
+        "## Overall session score",
+        "## Appendix A — Setup conversation",
+        "## Appendix B — Frozen scenario plan",
+        "## Appendix C — Audit log",
+        "## Appendix D — Full transcript",
+    ):
+        assert header in md, f"missing header: {header}"
+
+    # Strict ordering check.
+    headers_in_order = [
+        "## Executive summary",
+        "## After-action narrative",
+        "### What went well",
+        "## Per-role scores",
+        "## Appendix A — Setup conversation",
+        "## Appendix D — Full transcript",
+    ]
+    positions = [md.index(h) for h in headers_in_order]
+    assert positions == sorted(positions), (
+        "section order regressed: "
+        f"{list(zip(headers_in_order, positions, strict=True))}"
+    )
+
+
+def test_render_markdown_what_went_well_preserves_markdown(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    """The bold prefix and the multi-line sub-bullets must survive into the
+    output instead of being collapsed onto a single line."""
+
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    assert "- **Quick containment** within 3 minutes" in md
+    # Multi-line item: continuation lines stay indented under the bullet.
+    assert "- Strong cross-role comms" in md
+    assert "    - CISO drove decisions" in md
+    assert "    - SOC fed telemetry" in md
+
+
+def test_render_markdown_drops_whitespace_only_bullets(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    # Whitespace-only "  " entry from the fixture should not produce an
+    # empty bullet.
+    assert "\n- \n" not in md
+    assert "\n-  \n" not in md
+
+
+def test_render_markdown_per_role_scores_handles_pipe_in_rationale(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    """A pipe character in the rationale used to break the GFM table layout.
+    The flattener must escape the pipe and fold any newlines."""
+
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    table_section = md.split("## Per-role scores", 1)[1].split("##", 1)[0]
+    # The rationale row must be a single line with the pipe escaped.
+    assert "Decisive call early followed up \\| clearly" in table_section
+    # And there's no naked newline inside the rationale row.
+    rationale_row = next(
+        line for line in table_section.splitlines() if "CISO" in line
+    )
+    # Five-column row → six unescaped pipes (one before each cell + one
+    # after the last). The ``\|`` inside the rationale doesn't count as a
+    # column separator. Validate by counting only ``|`` chars NOT preceded
+    # by a backslash.
+    import re
+
+    column_pipes = re.findall(r"(?<!\\)\|", rationale_row)
+    assert len(column_pipes) == 6, (
+        f"row column-pipe count regressed; row was: {rationale_row!r}"
+    )
+
+
+def test_render_markdown_transcript_lives_in_appendix_d(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    """Transcript content must appear under Appendix D — Full transcript,
+    not inline in the main report."""
+
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    transcript_idx = md.index("## Appendix D — Full transcript")
+    scores_idx = md.index("## Per-role scores")
+    assert scores_idx < transcript_idx, (
+        "Per-role scores must come BEFORE the transcript appendix"
+    )
+    # Transcript content exists under the heading.
+    after = md[transcript_idx:]
+    assert "**2026-04-30T10:00:01" in after
+    assert "_[broadcast]_" in after
+    assert "**Briefing**" in after
+
+
+def test_render_markdown_creator_only_block_is_wrapped(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    assert CREATOR_ONLY_BEGIN in md
+    assert CREATOR_ONLY_END in md
+    begin = md.index(CREATOR_ONLY_BEGIN)
+    end = md.index(CREATOR_ONLY_END)
+    assert begin < end
+    assert "Appendix E — AI decision rationale log" in md[begin:end]
+    assert "CISO answered fast" in md[begin:end]
+
+
+def test_render_markdown_with_audit_events(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    audit = [
+        AuditEvent(
+            session_id=session_with_messages.id,
+            kind="state_change",
+            ts=_ts(0),
+            payload={"from": "READY", "to": "BRIEFING"},
+        ),
+    ]
+    md = _render_markdown(session_with_messages, report, audit_events=audit)
+    audit_section = md.split("## Appendix C — Audit log", 1)[1].split("##", 1)[0]
+    assert "```jsonl" in audit_section
+    assert "state_change" in audit_section
+
+
+def test_render_markdown_handles_empty_session(ciso: Role) -> None:
+    """A session that ends with no plan / no messages still produces a
+    well-formed report — every required heading present, no exceptions."""
+
+    s = Session(
+        scenario_prompt="Empty",
+        state=SessionState.ENDED,
+        roles=[ciso],
+        creator_role_id=ciso.id,
+    )
+    md = _render_markdown(
+        s,
+        {
+            "executive_summary": "",
+            "narrative": "",
+            "what_went_well": [],
+            "gaps": [],
+            "recommendations": [],
+            "per_role_scores": [],
+            "overall_score": 0,
+            "overall_rationale": "",
+        },
+        audit_events=[],
+    )
+    # Empty fields render as fallback markers, not crashes.
+    assert "_(none)_" in md
+    assert "_(no setup notes recorded)_" in md
+    assert "_(no plan was finalized)_" in md
+    assert "_(no audit events captured)_" in md
+    assert "_(no messages recorded)_" in md
+    assert "_(no rationale entries recorded)_" in md
+    # Headings still in order.
+    assert "## Appendix D — Full transcript" in md
+
+
+# ---------------------------------------------------------------- strip_creator_only
+
+
+def test_strip_creator_only_removes_block(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    stripped = strip_creator_only(md)
+    assert CREATOR_ONLY_BEGIN not in stripped
+    assert CREATOR_ONLY_END not in stripped
+    assert "Appendix E — AI decision rationale log" not in stripped
+    assert "CISO answered fast" not in stripped
+    # Non-creator content survives.
+    assert "## Executive summary" in stripped
+    assert "## Appendix D — Full transcript" in stripped
+
+
+def test_strip_creator_only_handles_unterminated_marker() -> None:
+    """A missing END marker must not leak the rest of the document — the
+    renderer drops everything after the dangling BEGIN."""
+
+    md = (
+        f"safe content\n{CREATOR_ONLY_BEGIN}\nsecret rationale\nthen abrupt eof"
+    )
+    stripped = strip_creator_only(md)
+    assert "safe content" in stripped
+    assert "secret" not in stripped
+    assert CREATOR_ONLY_BEGIN not in stripped
+
+
+def test_strip_creator_only_idempotent(
+    session_with_messages: Session, report: dict[str, Any]
+) -> None:
+    md = _render_markdown(session_with_messages, report, audit_events=[])
+    once = strip_creator_only(md)
+    twice = strip_creator_only(once)
+    assert once == twice
+
+
+def test_strip_creator_only_ignores_marker_inside_blockquote(ciso: Role) -> None:
+    """Security review finding: a player-typed marker string (now visible
+    on its own line under the ``> `` blockquote in the transcript appendix
+    per issue #83) used to trigger the substring-based stripper and silently
+    drop subsequent transcript content from non-creator downloads.
+
+    The line-anchored regex must match ONLY markers at column 0 (i.e. the
+    sentinel ones the renderer itself emits). A player message containing
+    the literal marker remains visible in the player download.
+    """
+
+    s = Session(
+        scenario_prompt="hostile player",
+        state=SessionState.ENDED,
+        roles=[ciso],
+        creator_role_id=ciso.id,
+    )
+    s.messages.append(
+        Message(
+            kind=MessageKind.PLAYER,
+            role_id=ciso.id,
+            ts=_ts(1),
+            body=(
+                "Look, the rationale appendix template is "
+                f"{CREATOR_ONLY_BEGIN}\nsecret\n{CREATOR_ONLY_END} — "
+                "shouldn't that be standardized?"
+            ),
+        )
+    )
+    md = _render_markdown(
+        s,
+        {
+            "executive_summary": "exec",
+            "narrative": "narr",
+            "what_went_well": [],
+            "gaps": [],
+            "recommendations": [],
+            "per_role_scores": [],
+            "overall_score": 1,
+            "overall_rationale": "x",
+        },
+        audit_events=[],
+    )
+    stripped = strip_creator_only(md)
+
+    # The rendered transcript still contains the player's message body
+    # (the marker shows up under a ``> `` blockquote prefix).
+    assert "shouldn't that be standardized?" in stripped, (
+        "player message should survive the strip — the marker only "
+        "matches at column 0 of its own line, not inside a quoted body"
+    )
+    # And the legitimate creator-only appendix is still removed.
+    assert "Appendix E — AI decision rationale log" not in stripped
+
+
+def test_format_transcript_entry_actor_for_critical_inject(
+    session_with_messages: Session,
+) -> None:
+    """A CRITICAL_INJECT message with no ``role_id`` and a
+    non-``ai``-prefixed kind value falls through to ``**System**`` —
+    pin this so a future kind-enum reshuffle (e.g. renaming the prefix)
+    catches in CI rather than silently mislabeling banner injects."""
+
+    inject = Message(
+        kind=MessageKind.CRITICAL_INJECT,
+        ts=_ts(5),
+        body="Reporter calls about leaked screenshot.",
+        tool_name="inject_critical_event",
+    )
+    out = _format_transcript_entry(session_with_messages, inject)
+    assert "**System**" in out[0], out[0]
+    assert "_[inject_critical_event]_" in out[0]
+
+
+def test_format_transcript_entry_ai_message_without_tool_name(
+    session_with_messages: Session,
+) -> None:
+    """An AI message with no ``tool_name`` (e.g. raw text content emitted
+    alongside tool calls) renders without the ``_[...]_`` tag — guards
+    against accidentally interpolating ``None`` into the header."""
+
+    raw_ai = Message(
+        kind=MessageKind.AI_TEXT,
+        ts=_ts(6),
+        body="thinking aloud",
+    )
+    out = _format_transcript_entry(session_with_messages, raw_ai)
+    assert "**AI Facilitator**" in out[0]
+    assert "_[" not in out[0], (
+        f"unexpected tool-name tag rendered for tool_name=None: {out[0]!r}"
+    )
+
+
+def test_render_markdown_logs_when_finalize_report_missing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``_extract_report`` synthesizes a fallback when the model didn't
+    call ``finalize_report``. The fallback path used to be silent — the
+    operator only learned about it from a "the AAR looks empty" ticket.
+    Confirm the warn-level log line fires so production logs catch the
+    regression. ``structlog`` writes to stdout via ``PrintLoggerFactory``,
+    so we capture via ``capsys`` rather than the python-logging ``caplog``.
+    """
+
+    from app.llm.export import _extract_report
+
+    fallback = _extract_report(
+        [
+            {"type": "text", "text": "free-form reply, no tool call"},
+        ]
+    )
+    # Sanity: fallback shape preserved.
+    assert fallback["overall_score"] == 0
+
+    captured = capsys.readouterr()
+    log_blob = captured.out + captured.err
+    assert "aar_finalize_report_missing" in log_blob, (
+        "expected an `aar_finalize_report_missing` warning when the "
+        f"fallback path fires; saw stdout: {captured.out!r}, stderr: {captured.err!r}"
+    )

--- a/backend/tests/test_aar_export.py
+++ b/backend/tests/test_aar_export.py
@@ -236,6 +236,56 @@ def test_render_bullets_drops_blank_continuation_lines() -> None:
     assert out == ["- first", "  second"]
 
 
+def test_render_bullets_coerces_non_string_items() -> None:
+    """Per Copilot review on PR #85: the AAR tool input is forwarded
+    raw, so the model can emit non-strings (``null``, numbers, bools)
+    inside what's declared as ``array of string``. The renderer must
+    coerce instead of crashing — the AAR pipeline is operator-critical.
+    """
+
+    out = _render_bullets(["string item", 42, None, True, "tail item"])
+    # ``None`` is dropped (whitespace-only-equivalent); the others are
+    # coerced via ``str()`` into bullets.
+    assert out == ["- string item", "- 42", "- True", "- tail item"]
+
+
+def test_render_bullets_handles_lone_string() -> None:
+    """The model occasionally emits a lone string for a single-item
+    array. Wrap it as a single-bullet list rather than iterating
+    characters."""
+
+    out = _render_bullets("the only item")
+    assert out == ["- the only item"]
+
+
+def test_render_bullets_handles_none_and_non_iterable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``None`` returns empty. A non-iterable scalar (e.g. an int from
+    severe schema drift) logs a warning and returns empty rather than
+    propagating a ``TypeError``."""
+
+    assert _render_bullets(None) == []
+    capsys.readouterr()  # discard
+    assert _render_bullets(7) == []
+    log_blob = capsys.readouterr().out
+    assert "aar_render_bullets_unexpected_type" in log_blob
+
+
+def test_flatten_table_cell_coerces_non_string() -> None:
+    """Per Copilot review on PR #85: a non-string rationale (``null``,
+    a number) used to crash ``(text or "–").split()``. Coerce."""
+
+    assert _flatten_table_cell(None) == "–"
+    assert _flatten_table_cell("") == "–"
+    assert _flatten_table_cell(0) == "0"
+    assert _flatten_table_cell(4.5) == "4.5"
+    # Whitespace-only after coercion → fall back to "–".
+    assert _flatten_table_cell("   ") == "–"
+    # Pipe in coerced value still gets escaped.
+    assert _flatten_table_cell("a | b") == "a \\| b"
+
+
 # ---------------------------------------------------------------- _flatten_table_cell
 
 
@@ -248,7 +298,7 @@ def test_flatten_table_cell_handles_pipes_and_newlines() -> None:
 
 def test_flatten_table_cell_falls_back_for_empty() -> None:
     assert _flatten_table_cell("") == "–"
-    assert _flatten_table_cell(None) == "–"  # type: ignore[arg-type]
+    assert _flatten_table_cell(None) == "–"
 
 
 # ---------------------------------------------------------------- _format_transcript_entry

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -218,14 +218,22 @@ def test_e2e_2_role(client: TestClient) -> None:
         "After-Action Report",
         "Header",
         "Executive summary",
-        "Full transcript",
+        "After-action narrative",
         "Per-role scores",
         "Overall session score",
         "Appendix A — Setup conversation",
         "Appendix B — Frozen scenario plan",
         "Appendix C — Audit log",
+        "Appendix D — Full transcript",
     ):
         assert section in md, f"missing section: {section}"
+
+    # Issue #83: the transcript must come AFTER the analytic content so
+    # the report is readable. Verify the appendix transcript header
+    # appears after the per-role scores table.
+    assert md.index("Per-role scores") < md.index(
+        "Appendix D — Full transcript"
+    ), "transcript appendix must be below the analytic sections"
 
     # Roster-size adaptation: small strategy
     snap = client.get(

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -294,13 +294,19 @@ All via env, documented in `docs/configuration.md`. Names:
 
 ### End-of-session export
 
-Triggered by `end_session` (AI-initiated or participant-initiated). The export pipeline (`llm/export.py`) runs **one final Claude call** with the full transcript and audit log to produce a single markdown document containing:
+Triggered by `end_session` (AI-initiated or participant-initiated). The export pipeline (`llm/export.py`) runs **one final Claude call** with the full transcript and audit log to produce a single markdown document. The renderer pins this section order so the analytic content surfaces first and the long-tail dialogue lives in the appendix (issue #83):
 
 1. **Header** — scenario brief, roster, start/end timestamps.
-2. **Full transcript** — chronological, role+display-name tagged, AI turns clearly delineated.
-3. **After-action report** — narrative summary, key decisions, what went well, gaps, recommendations.
-4. **Per-role scores** — 1–5 across `decision_quality`, `communication`, `speed`, with one-sentence rationale each.
-5. **Overall session score** — single 1–5 with rationale.
+2. **Executive summary** — 2–4 sentences with the headline outcome.
+3. **After-action narrative** — chronological prose anchored to beats and pivotal decisions, with verbatim quotes.
+4. **What went well / Gaps / Recommendations** — bulleted; bullets carry their own markdown (sub-bullets, bold) and the renderer indents continuation lines so multi-line items stay attached to the parent bullet.
+5. **Per-role scores** — 1–5 across `decision_quality`, `communication`, `speed`, with one-sentence rationale each. Pipes / newlines in the rationale are escaped/folded so the GFM table doesn't break.
+6. **Overall session score** — single 1–5 with rationale.
+7. **Appendix A — Setup conversation.**
+8. **Appendix B — Frozen scenario plan** (JSON).
+9. **Appendix C — Audit log** (JSONL).
+10. **Appendix D — Full transcript** — chronological, role+display-name tagged, AI turns clearly delineated. Each entry renders as `**ts** — **Role** _[tool]_` header + blockquoted body so multi-line markdown the AI emitted (lists, code fences in `share_data`, bold) survives.
+11. **Appendix E — AI decision rationale log** — *creator-only*, wrapped in `<!-- BEGIN_CREATOR_ONLY --> … <!-- END_CREATOR_ONLY -->` sentinel comments. The export route strips this section for non-creator downloads.
 
 Returned via `GET /api/sessions/{id}/export.md` (Content-Disposition: attachment) and also offered as a "Download report" button in the UI when state = `ENDED`. Session memory is GC'd after the export is fetched (or after a configurable retention window, `EXPORT_RETENTION_MIN`, default 60).
 


### PR DESCRIPTION
## Summary

Fixes the AAR formatting bugs reported in #83 and lands a regression net of 24 unit tests + 6 live-API tests.

**Layout change** (`backend/app/llm/export.py`):
- Multi-line items in `what went well` / `gaps` / `recommendations` now keep their continuation lines indented under the parent bullet (the old `- {item}` form let any newline escape into a sibling paragraph and break the list).
- The full transcript moves from inline (right under the executive summary) to **Appendix D**, so the analytic content surfaces first.
- Each transcript entry renders as `**timestamp** — **Role** _[tool]_` header + a blockquoted body, so multi-line markdown the AI emits (lists, code fences in `share_data`, bold) survives instead of getting collapsed onto one line.
- Per-role-score rationale cells now have pipes / newlines escaped (a stray `|` used to silently shatter the GFM table).

**Hardening** (caught in review):
- `_extract_report` fallback now logs `aar_finalize_report_missing` (warn) so an operator finds the cause in stdout instead of from a "the AAR looks empty" ticket.
- `strip_creator_only` is line-anchored — a player-typed marker now visible verbatim under the `> ` blockquote in Appendix D can't trigger spurious stripping of the player's AAR download.
- `_render_bullets` drops blank continuation lines so the list stays tight (loose lists wrap each `<li>` in `<p>` and produce ragged spacing in the popup).

**Tests:**
- `backend/tests/test_aar_export.py` (new) — 24 unit tests covering bullet rendering, transcript entry rendering, table-cell escaping, section ordering, creator-only stripping (incl. marker-DoS guard), fallback logging.
- `backend/tests/live/test_aar_generation.py` (new) — 6 live-API tests against `ANTHROPIC_MODEL_AAR` (auto-skipped without `ANTHROPIC_API_KEY`) verifying `finalize_report` routing, per-role-score schema for every seated role, overall-score range, recommendations grounded in transcript topics, non-empty what-went-well + gaps after whitespace filtering, no `temperature`-param leak for Opus.
- `backend/tests/test_e2e_session.py` — updated section list + ordering assertion.

**Docs:** `docs/PLAN.md` § "End-of-session export" updated to describe the new section order (the previous wording listed transcript inline + a single "After-action report" bucket).

**Reviewed by all six sub-agents** (QA, security, UI/UX, product, user, prompt-expert). All HIGH / MEDIUM findings addressed in this commit. Deferred to follow-ups: prompt-tightening (transcript-appendix awareness, narrative length cap, audience hint), UI/UX visual polish (verbose timestamps, h3→h2 jump, JSON-wall placement between scores and transcript), pre-existing fence-escape / pipe-escape hardening.

## Test plan

- [x] `cd backend && pytest tests/ --ignore=tests/live` — 277 passed, 1 skipped
- [x] `cd backend && ruff check .` — clean
- [x] `cd backend && mypy app tests/test_aar_export.py tests/live/test_aar_generation.py` — clean
- [x] `cd backend && ANTHROPIC_API_KEY=… pytest tests/live/test_aar_generation.py -v` — 6 passed (~$0.30, ~3:43 wall time on Opus 4.7)
- [ ] Manual: end a real session, open the AAR popup, scroll the markdown body, verify `share_data` code fences inside the transcript appendix render as code blocks, confirm sub-bullets in `what went well` are nested.

Closes #83

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5cLcWmdBZ6J2zYrJbXsM1)_