### PR TITLE
frontend: rewrite useStickyScroll to event-driven pin tracking (#79 follow-up)

### DIFF
--- a/frontend/src/__tests__/useStickyScroll.test.tsx
+++ b/frontend/src/__tests__/useStickyScroll.test.tsx
@@ -126,6 +126,11 @@ interface HarnessProps {
   /** Optional sink the test can read after each render to assert on
    *  the hook's ``hasUnreadBelow`` flag without rendering chip JSX. */
   bindHasUnread?: (value: boolean) => void;
+  /** When set, the harness passes ``[messageCount]`` as the unread-deps
+   *  argument to ``useStickyScroll``. Mirrors the production callers
+   *  (Play / Facilitator) which want the streaming flag to drive the
+   *  pin path but NOT the unread chip. */
+  narrowUnreadDeps?: boolean;
 }
 
 /**
@@ -142,6 +147,7 @@ function Harness({
   mountElement = true,
   bindForceScroll,
   bindHasUnread,
+  narrowUnreadDeps = false,
 }: HarnessProps) {
   const elRef = useRef<HTMLDivElement | null>(null);
 
@@ -151,7 +157,10 @@ function Harness({
   });
 
   const { scrollRef, forceScrollToBottom, hasUnreadBelow } =
-    useStickyScroll<HTMLDivElement>([messageCount, streamingActive]);
+    useStickyScroll<HTMLDivElement>(
+      [messageCount, streamingActive],
+      narrowUnreadDeps ? [messageCount] : undefined,
+    );
 
   useLayoutEffect(() => {
     bindForceScroll?.(forceScrollToBottom);
@@ -580,6 +589,127 @@ describe("useStickyScroll", () => {
       />,
     );
     // Still pinned → no unread.
+    expect(unread).toBe(false);
+  });
+
+  it("does NOT mark unread when only the streaming flag flips while unpinned (narrowUnreadDeps)", () => {
+    // Production callers pass the streaming flag in the pin-deps but
+    // NOT the unread-deps tuple — a streaming flip should follow the
+    // pinned user's chat (extending the AI bubble) without falsely
+    // raising the "New messages below" chip on an unpinned user when
+    // no actual new message has landed.
+    let unread = false;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        narrowUnreadDeps
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(unread).toBe(false);
+
+    // User scrolls up.
+    setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
+
+    // Streaming flag flips on (chunk arrived) — same messageCount,
+    // streamingActive flips. With narrowUnreadDeps the unread effect
+    // sees no relevant change and stays clear.
+    rerender(
+      <Harness
+        messageCount={20}
+        scrollHeight={2400}
+        clientHeight={400}
+        streamingActive={true}
+        narrowUnreadDeps
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(false);
+
+    // Now an actual new message lands. messageCount changes, so the
+    // unread effect fires and flags unread.
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2600}
+        clientHeight={400}
+        streamingActive={false}
+        narrowUnreadDeps
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(true);
+  });
+
+  it("clears hasUnreadBelow when the scroll element re-attaches", () => {
+    // Production scenario: Facilitator's ``handleNewSession()``
+    // unmounts the scroll region (intro screen) and a new session
+    // remounts a fresh one within the same hook instance. The new
+    // element starts pinned — a stale "New messages below" chip
+    // carried over from the previous session would be misleading.
+    let unread = false;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+
+    // Scroll up + new content lands → unread flag on.
+    setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(true);
+
+    // Unmount the scroll region.
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2200}
+        clientHeight={400}
+        mountElement={false}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+
+    // Re-mount with a fresh element + fresh content — the new element
+    // starts pinned and the unread flag should be cleared.
+    rerender(
+      <Harness
+        messageCount={30}
+        scrollHeight={3000}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
     expect(unread).toBe(false);
   });
 

--- a/frontend/src/__tests__/useStickyScroll.test.tsx
+++ b/frontend/src/__tests__/useStickyScroll.test.tsx
@@ -1,17 +1,17 @@
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { useCallback, useLayoutEffect, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useStickyScroll } from "../lib/useStickyScroll";
 
 /**
  * JSdom doesn't compute layout, so ``scrollHeight`` / ``clientHeight``
- * default to 0 — which would skip every scroll branch in the hook.
- * Override the prototype getters so the test can prescribe the
- * geometry of the rendered ``<div>`` and assert on the (also shimmed)
- * ``scrollTop`` setter to verify the hook actually scrolled.
+ * default to 0 and ``scrollTop`` writes are forwarded to a stub. The
+ * shims below let a test prescribe geometry on the rendered ``<div>``,
+ * observe ``scrollTop`` writes, and dispatch ``scroll`` events to
+ * exercise the hook's event-driven pin tracking.
  *
- * The shims are scoped to this file's ``beforeEach`` / ``afterEach``
- * so they don't leak into other test suites.
+ * The shims are scoped to this file's ``beforeEach`` / ``afterEach`` so
+ * they don't leak into other test suites.
  */
 interface Geometry {
   scrollHeight: number;
@@ -67,7 +67,14 @@ beforeEach(() => {
       return readGeometry(this).scrollTop;
     },
     set(this: HTMLElement, value: number) {
-      setGeometry(this, { scrollTop: value });
+      // Mirror the browser's behaviour: scrollTop is clamped to
+      // ``max(0, min(value, scrollHeight - clientHeight))``. Without
+      // this clamp the post-hoc-distance bug we just fixed wouldn't
+      // be reproducible in tests.
+      const g = readGeometry(this);
+      const max = Math.max(0, g.scrollHeight - g.clientHeight);
+      const clamped = Math.max(0, Math.min(value, max));
+      setGeometry(this, { scrollTop: clamped });
     },
   });
 });
@@ -101,38 +108,28 @@ interface HarnessProps {
    *  changes the deps array the hook watches. */
   messageCount: number;
   /** Second-channel deps signal: stands in for the production
-   *  ``streamingActive`` flag that Play.tsx and Facilitator.tsx pass
-   *  alongside ``messageCount``. Lets the test verify that flipping
-   *  ``streamingActive`` alone (no message added) still re-triggers
-   *  the slack-follow — which is the dominant runtime signal because
-   *  chunk events fire much more often than ``message_complete``. */
+   *  ``streamingActive`` flag that Play.tsx / Facilitator.tsx pass
+   *  alongside ``messageCount``. */
   streamingActive?: boolean;
   /** Total content height. Tests prescribe this to simulate an
    *  overflowing transcript. The harness deliberately does NOT set
    *  ``scrollTop`` from props — that dimension is owned by the hook
-   *  (and by direct ``setGeometry`` calls between rerenders) so the
-   *  geometry layout effect can't accidentally clobber what the hook
-   *  just wrote. */
+   *  and by the test's direct ``setGeometry`` calls between renders. */
   scrollHeight: number;
   clientHeight: number;
   /** Conditionally render the scroll element. Lets a test simulate
    *  the production scenario where the hook lives in a long-lived
    *  parent (Facilitator) and the scroll element is mounted /
-   *  unmounted by phase / session changes — e.g.
-   *  ``handleNewSession`` resets to the intro screen, then a new
-   *  session re-mounts the scroll div within the same hook instance.
-   *  The hook must reset its per-element state on identity change so
-   *  the new element gets the initial-pin treatment. */
+   *  unmounted by phase / session changes. */
   mountElement?: boolean;
   bindForceScroll?: (fn: () => void) => void;
-  slack?: number;
 }
 
 /**
- * Test harness that wires ``useStickyScroll`` to a div and applies the
- * prescribed scroll-extent geometry via a ``useLayoutEffect`` declared
- * **before** the hook call so the geometry is in place when the hook's
- * own layout effect runs and reads ``scrollHeight``.
+ * Test harness that wires ``useStickyScroll`` to a div and applies
+ * the prescribed scrollHeight + clientHeight via a useLayoutEffect
+ * declared **before** the hook call so the geometry is in place when
+ * the hook's own layout effect runs and reads it.
  */
 function Harness({
   messageCount,
@@ -141,34 +138,28 @@ function Harness({
   clientHeight,
   mountElement = true,
   bindForceScroll,
-  slack,
 }: HarnessProps) {
   const elRef = useRef<HTMLDivElement | null>(null);
 
-  // Apply scrollHeight + clientHeight first so the hook's layout
-  // effect (declared inside useStickyScroll, *after* this hook) reads
-  // the prescribed values. Crucially, do not write ``scrollTop`` —
-  // that's the dimension the hook controls and we'd clobber the
-  // hook's write if we set it from props on every render.
   useLayoutEffect(() => {
     if (!elRef.current) return;
     setGeometry(elRef.current, { scrollHeight, clientHeight });
   });
 
-  const { scrollRef, forceScrollToBottom } = useStickyScroll<HTMLDivElement>(
-    [messageCount, streamingActive],
-    slack !== undefined ? { slack } : undefined,
-  );
+  const { scrollRef, forceScrollToBottom } = useStickyScroll<HTMLDivElement>([
+    messageCount,
+    streamingActive,
+  ]);
 
   useLayoutEffect(() => {
     bindForceScroll?.(forceScrollToBottom);
   }, [bindForceScroll, forceScrollToBottom]);
 
-  // ``scrollRef`` is memoized inside the hook (useCallback with []),
-  // so this combined callback is stable too. Stability matters: an
-  // unstable ref callback would detach + re-attach on every render,
-  // and the hook's scrollRef bumps an internal nonce on each non-null
-  // attach — which compounds into a re-render loop.
+  // ``scrollRef`` is memoized inside the hook (useCallback). The
+  // combined callback below stays stable too. Stability matters: an
+  // unstable ref callback would detach + re-attach on every render
+  // and the hook detaches its scroll listener / ResizeObserver on
+  // every detach — which would silently lose pin tracking.
   const combinedRef = useCallback(
     (node: HTMLDivElement | null) => {
       elRef.current = node;
@@ -191,50 +182,83 @@ function Harness({
 describe("useStickyScroll", () => {
   it("pins to the bottom on initial mount when content overflows", () => {
     // Issue #79: a player joining mid-exercise lands on a transcript
-    // that overflows the viewport. The pre-fix slack check read
-    // scrollTop=0 as "user has scrolled up" and stranded them at the
-    // top. The hook's initial-mount branch overrides that.
+    // that overflows the viewport. The hook starts pinned, so the
+    // first commit with overflowing content scrolls to the bottom.
     const { getByTestId } = render(
       <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
     );
     const el = getByTestId("scroll-region");
-    expect(el.scrollTop).toBe(2000);
+    // scrollTop is clamped by the browser-shim to max(0, scrollHeight
+    // - clientHeight) = 1600. That is the visual bottom — distance
+    // from bottom = scrollHeight - scrollTop - clientHeight = 0.
+    expect(el.scrollTop).toBe(1600);
   });
 
-  it("follows new content when the user is near the bottom", () => {
+  it("follows new content while pinned (browser-clamp regression net)", () => {
+    // The pre-rewrite hook bug: after a "follow" pin, scrollTop is
+    // clamped to scrollHeight-clientHeight, NOT scrollHeight. The next
+    // dep change re-evaluated distance from the post-clamp scrollTop
+    // and read the user as "scrolled up" by clientHeight. New content
+    // would NOT pin. The event-driven model fixes this — pinnedRef
+    // tracks the user's intent, not a post-hoc distance metric.
     const { getByTestId, rerender } = render(
       <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
     );
     const el = getByTestId("scroll-region");
-    // Initial mount pinned us to the bottom (2000).
-    expect(el.scrollTop).toBe(2000);
+    expect(el.scrollTop).toBe(1600);
 
-    // A new message arrives; transcript grew. User stayed pinned at
-    // the previous bottom (2000) so they're well within the slack
-    // window of the new bottom (2200) — pin should follow.
+    // New message arrives — transcript grows below the user.
     rerender(
       <Harness messageCount={21} scrollHeight={2200} clientHeight={400} />,
     );
-    expect(el.scrollTop).toBe(2200);
+    // pinnedRef is still true (user hasn't scrolled), so pin to new
+    // bottom: scrollTop clamped to 2200 - 400 = 1800.
+    expect(el.scrollTop).toBe(1800);
   });
 
-  it("leaves the user alone when they have scrolled up beyond the slack window", () => {
+  it("unpins when the user scrolls up", () => {
     const { getByTestId, rerender } = render(
       <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
     );
     const el = getByTestId("scroll-region");
-    expect(el.scrollTop).toBe(2000);
+    expect(el.scrollTop).toBe(1600);
 
-    // User scrolls up well outside the 120px slack window.
+    // User scrolls up. The shim clamps scrollTop and stores it; we
+    // dispatch a synthetic scroll event so the hook's listener fires.
     setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
 
-    // A new message arrives.
+    // New message arrives. Pinned was flipped to false → leave alone.
     rerender(
       <Harness messageCount={21} scrollHeight={2200} clientHeight={400} />,
     );
-
-    // distanceFromBottom = 2200 - 500 - 400 = 1300 >> 120 → no scroll.
     expect(el.scrollTop).toBe(500);
+  });
+
+  it("re-pins when the user scrolls back to the bottom", () => {
+    const { getByTestId, rerender } = render(
+      <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(1600);
+
+    // Scroll up → unpin.
+    setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
+    rerender(
+      <Harness messageCount={21} scrollHeight={2200} clientHeight={400} />,
+    );
+    expect(el.scrollTop).toBe(500);
+
+    // Scroll back to bottom → re-pin.
+    setGeometry(el, { scrollTop: 1800 });
+    fireEvent.scroll(el);
+
+    // Next content arrival should pin again.
+    rerender(
+      <Harness messageCount={22} scrollHeight={2400} clientHeight={400} />,
+    );
+    expect(el.scrollTop).toBe(2000);
   });
 
   it("force-scrolls to the bottom even when the user has scrolled up", () => {
@@ -250,15 +274,19 @@ describe("useStickyScroll", () => {
       />,
     );
     const el = getByTestId("scroll-region");
-    expect(el.scrollTop).toBe(2000);
+    expect(el.scrollTop).toBe(1600);
 
-    // User scrolls up far from the bottom.
+    // Scroll up.
     setGeometry(el, { scrollTop: 100 });
+    fireEvent.scroll(el);
 
-    // Local submit fires + a message lands.
+    // Local submit — hook pins synchronously and re-pins.
     act(() => {
       force?.();
     });
+    expect(el.scrollTop).toBe(1600);
+
+    // Subsequent content arrives — still pinned (force re-pinned).
     rerender(
       <Harness
         messageCount={21}
@@ -269,17 +297,12 @@ describe("useStickyScroll", () => {
         }}
       />,
     );
-
-    // Force-scroll bypasses the slack check; pin to bottom.
-    expect(el.scrollTop).toBe(2100);
+    expect(el.scrollTop).toBe(1700);
   });
 
-  it("returns to honoring the slack window after a force-scroll", () => {
-    // Regression net for the bug in the pre-fix Facilitator effect:
-    // once forceScrollNonce > 0, the slack check was bypassed
-    // forever. The hook tracks the last-seen nonce so a one-shot
-    // force-scroll doesn't permanently override the user's scroll
-    // position.
+  it("returns to honoring the user's scroll position after a force-scroll", () => {
+    // Regression net: after one force-scroll, a subsequent user
+    // scroll-up should still unpin them; the force shouldn't latch.
     let force: (() => void) | null = null;
     const { getByTestId, rerender } = render(
       <Harness
@@ -292,29 +315,22 @@ describe("useStickyScroll", () => {
       />,
     );
     const el = getByTestId("scroll-region");
-    expect(el.scrollTop).toBe(2000);
+    expect(el.scrollTop).toBe(1600);
 
-    // Local submit force-scrolls to bottom on the next message.
+    // Force-scroll.
     act(() => {
       force?.();
     });
-    rerender(
-      <Harness
-        messageCount={21}
-        scrollHeight={2100}
-        clientHeight={400}
-        bindForceScroll={(fn) => {
-          force = fn;
-        }}
-      />,
-    );
-    expect(el.scrollTop).toBe(2100);
+    expect(el.scrollTop).toBe(1600);
 
-    // Now the user scrolls up to re-read.
+    // User scrolls up afterwards.
     setGeometry(el, { scrollTop: 200 });
+    fireEvent.scroll(el);
+
+    // Next content arrives — leave alone, user is unpinned.
     rerender(
       <Harness
-        messageCount={22}
+        messageCount={21}
         scrollHeight={2200}
         clientHeight={400}
         bindForceScroll={(fn) => {
@@ -322,164 +338,26 @@ describe("useStickyScroll", () => {
         }}
       />,
     );
-
-    // distanceFromBottom = 2200 - 200 - 400 = 1600 > 120 → leave alone.
-    // The pre-fix bug would have re-pinned to 2200.
     expect(el.scrollTop).toBe(200);
-  });
-
-  it("respects a custom slack window", () => {
-    const { getByTestId, rerender } = render(
-      <Harness
-        messageCount={20}
-        slack={30}
-        scrollHeight={2000}
-        clientHeight={400}
-      />,
-    );
-    const el = getByTestId("scroll-region");
-    expect(el.scrollTop).toBe(2000);
-
-    // User scrolls up 50px (just outside the tighter 30px slack).
-    setGeometry(el, { scrollTop: 1550 });
-    rerender(
-      <Harness
-        messageCount={21}
-        slack={30}
-        scrollHeight={2050}
-        clientHeight={400}
-      />,
-    );
-
-    // distanceFromBottom = 2050 - 1550 - 400 = 100 > 30 → no scroll.
-    expect(el.scrollTop).toBe(1550);
-  });
-
-  it("follows new content when only the streaming flag flips", () => {
-    // Streaming-chunk events fire much more often than
-    // ``message_complete``, so ``streamingActive`` flipping (without
-    // ``messageCount`` changing) is the dominant runtime signal that
-    // the chat is growing. Verify the slack-follow path triggers from
-    // the streaming flag alone.
-    const { getByTestId, rerender } = render(
-      <Harness
-        messageCount={20}
-        scrollHeight={2000}
-        clientHeight={400}
-        streamingActive={false}
-      />,
-    );
-    const el = getByTestId("scroll-region");
-    // Initial mount pin.
-    expect(el.scrollTop).toBe(2000);
-
-    // Streaming kicks in. Chunk text expands the transcript.
-    // ``messageCount`` is unchanged — only ``streamingActive`` flips.
-    rerender(
-      <Harness
-        messageCount={20}
-        scrollHeight={2400}
-        clientHeight={400}
-        streamingActive={true}
-      />,
-    );
-    // distanceFromBottom = 2400 - 2000 - 400 = 0 → well within slack.
-    // Pin should follow.
-    expect(el.scrollTop).toBe(2400);
-  });
-
-  it("handles back-to-back force-scrolls without sticking", () => {
-    // Two ``forceScrollToBottom()`` calls in quick succession (e.g. a
-    // proxy submit immediately followed by a force-advance) should
-    // both pin to bottom, and the slack check should still resume
-    // honouring the user's scroll position once the nonce stabilizes.
-    let force: (() => void) | null = null;
-    const { getByTestId, rerender } = render(
-      <Harness
-        messageCount={20}
-        scrollHeight={2000}
-        clientHeight={400}
-        bindForceScroll={(fn) => {
-          force = fn;
-        }}
-      />,
-    );
-    const el = getByTestId("scroll-region");
-    expect(el.scrollTop).toBe(2000);
-
-    // First force-scroll + new message.
-    act(() => {
-      force?.();
-    });
-    rerender(
-      <Harness
-        messageCount={21}
-        scrollHeight={2100}
-        clientHeight={400}
-        bindForceScroll={(fn) => {
-          force = fn;
-        }}
-      />,
-    );
-    expect(el.scrollTop).toBe(2100);
-
-    // User scrolls up between the two forces.
-    setGeometry(el, { scrollTop: 50 });
-
-    // Second force-scroll + another new message.
-    act(() => {
-      force?.();
-    });
-    rerender(
-      <Harness
-        messageCount={22}
-        scrollHeight={2200}
-        clientHeight={400}
-        bindForceScroll={(fn) => {
-          force = fn;
-        }}
-      />,
-    );
-    // Each force bump consumed; second must still pin to bottom.
-    expect(el.scrollTop).toBe(2200);
-
-    // After the second force settles, slack check should resume:
-    // user scrolls up again, next message arrives without a force.
-    setGeometry(el, { scrollTop: 100 });
-    rerender(
-      <Harness
-        messageCount={23}
-        scrollHeight={2300}
-        clientHeight={400}
-        bindForceScroll={(fn) => {
-          force = fn;
-        }}
-      />,
-    );
-    // distanceFromBottom = 2300 - 100 - 400 = 1800 > 120 → leave alone.
-    expect(el.scrollTop).toBe(100);
   });
 
   it("re-pins when the scroll element remounts within the same hook instance", () => {
     // Production scenario: Facilitator's ``handleNewSession()`` resets
     // ``state`` to ``null`` and routes back to the intro screen,
-    // unmounting the chat scroll region. A new session then re-mounts
-    // a fresh scroll element. The hook itself stays mounted (the
-    // Facilitator component persists), so per-element state like
-    // ``didInitialScrollRef`` would carry over from the previous
-    // session and skip the initial pin on the new element — re-
-    // introducing the #79 stuck-at-top bug for the second exercise of
-    // the same browser tab. The hook resets that flag on element
-    // identity change to defend against this.
+    // unmounting the chat scroll region. A new session re-mounts a
+    // fresh element. The hook itself stays mounted (Facilitator
+    // persists), so per-element state would carry over and a stale
+    // unpinned flag would skip the auto-pin on the new session. The
+    // hook resets pinnedRef to true on every re-attach to defend
+    // against this.
     const { getByTestId, queryByTestId, rerender } = render(
       <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
     );
     const el1 = getByTestId("scroll-region");
-    expect(el1.scrollTop).toBe(2000);
+    expect(el1.scrollTop).toBe(1600);
 
-    // Unmount the scroll region (e.g. routing back to the intro
-    // screen). The hook stays mounted; ``scrollRef`` is called with
-    // null on detach.
+    // Unmount the scroll element. Hook stays mounted; scrollRef is
+    // called with null on detach.
     rerender(
       <Harness
         messageCount={20}
@@ -490,9 +368,7 @@ describe("useStickyScroll", () => {
     );
     expect(queryByTestId("scroll-region")).toBeNull();
 
-    // Re-mount the scroll region with a fresh element (e.g. starting
-    // a new session). The hook should treat this as a new initial
-    // mount and pin to the bottom of the new content.
+    // Re-mount with a fresh element + fresh content.
     rerender(
       <Harness
         messageCount={30}
@@ -502,48 +378,75 @@ describe("useStickyScroll", () => {
       />,
     );
     const el2 = getByTestId("scroll-region");
-    expect(el2.scrollTop).toBe(3000);
+    expect(el2.scrollTop).toBe(2600);
   });
 
-  it("re-pins to bottom after unmount + remount", () => {
-    // A user routing away (e.g. opening the join intro again) and
-    // routing back unmounts and remounts the component. The new mount
-    // should re-fire the initial-pin branch — ``didInitialScrollRef``
-    // is per-hook-instance and resets on remount.
+  it("re-pins after unmount + remount of the parent", () => {
+    // Different from the within-hook-instance remount above: this
+    // unmounts and remounts the entire harness (and therefore the hook
+    // instance). Catches a different class of regression — that
+    // pinnedRef defaults are correct on a fresh hook.
     const { getByTestId, unmount } = render(
       <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
     );
     const el1 = getByTestId("scroll-region");
-    expect(el1.scrollTop).toBe(2000);
+    expect(el1.scrollTop).toBe(1600);
     unmount();
 
-    // Remount with a different transcript.
     const { getByTestId: getByTestId2 } = render(
       <Harness messageCount={30} scrollHeight={3000} clientHeight={400} />,
     );
     const el2 = getByTestId2("scroll-region");
-    // Fresh hook instance → didInitialScrollRef = false → pin.
-    expect(el2.scrollTop).toBe(3000);
+    expect(el2.scrollTop).toBe(2600);
   });
 
   it("waits for overflow before consuming the initial-mount pin", () => {
     // A user who joins early (transcript empty / shorter than the
-    // viewport) shouldn't have the initial-mount branch fire and mark
-    // itself as done while there's nothing to scroll. Otherwise the
-    // first message that overflows would fall through to the slack
-    // check and read scrollTop=0 as "user has scrolled up."
+    // viewport) shouldn't have the initial-mount branch fire and
+    // settle in a way that leaves them stuck once content does
+    // overflow. With pinnedRef defaulting to true and remaining true
+    // until the user actively scrolls away, an early non-overflow
+    // render is a no-op (scrollTop = scrollHeight = clientHeight) and
+    // the first overflowing render pins to the new bottom.
     const { getByTestId, rerender } = render(
       <Harness messageCount={0} scrollHeight={400} clientHeight={400} />,
     );
     const el = getByTestId("scroll-region");
-    // No overflow yet; hook didn't write scrollTop. Default is 0.
+    // Browser-clamp shim: max(0, 400 - 400) = 0. The hook's "pin to
+    // bottom" wrote scrollTop = 400 → clamp to 0.
     expect(el.scrollTop).toBe(0);
 
-    // First real content arrives — transcript now overflows. The
-    // initial-mount branch should still be live (didInitial wasn't
-    // marked done in the no-overflow render) and pin to bottom.
+    // First real content arrives — transcript now overflows.
     rerender(
       <Harness messageCount={20} scrollHeight={2000} clientHeight={400} />,
+    );
+    // pinnedRef stayed true → pin to new bottom (clamped).
+    expect(el.scrollTop).toBe(1600);
+  });
+
+  it("follows new content when only the streaming flag flips", () => {
+    // ``streamingActive`` flipping is the dominant runtime signal
+    // because chunk events fire much more often than
+    // ``message_complete``. Verify that flag-only deps changes still
+    // pin a pinned user.
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        streamingActive={false}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    expect(el.scrollTop).toBe(1600);
+
+    rerender(
+      <Harness
+        messageCount={20}
+        scrollHeight={2400}
+        clientHeight={400}
+        streamingActive={true}
+      />,
     );
     expect(el.scrollTop).toBe(2000);
   });

--- a/frontend/src/__tests__/useStickyScroll.test.tsx
+++ b/frontend/src/__tests__/useStickyScroll.test.tsx
@@ -123,6 +123,9 @@ interface HarnessProps {
    *  unmounted by phase / session changes. */
   mountElement?: boolean;
   bindForceScroll?: (fn: () => void) => void;
+  /** Optional sink the test can read after each render to assert on
+   *  the hook's ``hasUnreadBelow`` flag without rendering chip JSX. */
+  bindHasUnread?: (value: boolean) => void;
 }
 
 /**
@@ -138,6 +141,7 @@ function Harness({
   clientHeight,
   mountElement = true,
   bindForceScroll,
+  bindHasUnread,
 }: HarnessProps) {
   const elRef = useRef<HTMLDivElement | null>(null);
 
@@ -146,14 +150,16 @@ function Harness({
     setGeometry(elRef.current, { scrollHeight, clientHeight });
   });
 
-  const { scrollRef, forceScrollToBottom } = useStickyScroll<HTMLDivElement>([
-    messageCount,
-    streamingActive,
-  ]);
+  const { scrollRef, forceScrollToBottom, hasUnreadBelow } =
+    useStickyScroll<HTMLDivElement>([messageCount, streamingActive]);
 
   useLayoutEffect(() => {
     bindForceScroll?.(forceScrollToBottom);
   }, [bindForceScroll, forceScrollToBottom]);
+
+  useLayoutEffect(() => {
+    bindHasUnread?.(hasUnreadBelow);
+  }, [bindHasUnread, hasUnreadBelow]);
 
   // ``scrollRef`` is memoized inside the hook (useCallback). The
   // combined callback below stays stable too. Stability matters: an
@@ -422,6 +428,159 @@ describe("useStickyScroll", () => {
     );
     // pinnedRef stayed true → pin to new bottom (clamped).
     expect(el.scrollTop).toBe(1600);
+  });
+
+  it("flags hasUnreadBelow when content arrives while unpinned", () => {
+    // The "New messages below ↓" chip surface. While the user is
+    // scrolled up, any dep change (new message landed, streaming
+    // flag flipped) flips ``hasUnreadBelow`` to true so the caller
+    // can render the chip.
+    let unread = false;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+    // Pinned on initial mount → no unread.
+    expect(unread).toBe(false);
+
+    // User scrolls up.
+    setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
+    // Scroll alone shouldn't flag unread — no new content yet.
+    expect(unread).toBe(false);
+
+    // New content arrives while unpinned → unread.
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(true);
+  });
+
+  it("clears hasUnreadBelow when the user scrolls back to the bottom", () => {
+    let unread = false;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+
+    // Scroll up + new content lands → unread flag on.
+    setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(true);
+
+    // User scrolls back to the bottom (within tolerance).
+    setGeometry(el, { scrollTop: 1800 });
+    fireEvent.scroll(el);
+    expect(unread).toBe(false);
+  });
+
+  it("clears hasUnreadBelow when forceScrollToBottom is called", () => {
+    // Production scenario: the user clicks the "New messages below ↓"
+    // chip, which calls ``forceScrollToBottom``. The chip must
+    // disappear immediately rather than waiting for the next render
+    // cycle.
+    let unread = false;
+    let force: (() => void) | null = null;
+    const { getByTestId, rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    const el = getByTestId("scroll-region");
+
+    // Scroll up + new content lands.
+    setGeometry(el, { scrollTop: 500 });
+    fireEvent.scroll(el);
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindForceScroll={(fn) => {
+          force = fn;
+        }}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(true);
+
+    // Click the chip.
+    act(() => {
+      force?.();
+    });
+    expect(unread).toBe(false);
+  });
+
+  it("does not flag hasUnreadBelow when content arrives while pinned", () => {
+    // A pinned user is already at the bottom — content arriving
+    // pins them to the new bottom. No unread chip should appear in
+    // that case.
+    let unread = false;
+    const { rerender } = render(
+      <Harness
+        messageCount={20}
+        scrollHeight={2000}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    expect(unread).toBe(false);
+
+    rerender(
+      <Harness
+        messageCount={21}
+        scrollHeight={2200}
+        clientHeight={400}
+        bindHasUnread={(v) => {
+          unread = v;
+        }}
+      />,
+    );
+    // Still pinned → no unread.
+    expect(unread).toBe(false);
   });
 
   it("follows new content when only the streaming flag flips", () => {

--- a/frontend/src/lib/useStickyScroll.ts
+++ b/frontend/src/lib/useStickyScroll.ts
@@ -57,14 +57,20 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
  *    advance) so the user sees their own action commit even if they'd
  *    been reading older content.
  *
- * 6. **Unread indicator.** When ``deps`` change while the user is
- *    unpinned, ``hasUnreadBelow`` flips to true so the caller can
+ * 6. **Unread indicator.** When ``unreadDeps`` change while the user
+ *    is unpinned, ``hasUnreadBelow`` flips to true so the caller can
  *    surface a "New messages below ↓" chip. Clears when the user
- *    scrolls back to the bottom (re-pin) or calls
- *    ``forceScrollToBottom``. The flag is intentionally a boolean
- *    (not a count) — callers that want a count can derive it from
- *    their own state by tracking the message count delta between
- *    "first unread arrived" and "now".
+ *    scrolls back to the bottom (re-pin), calls
+ *    ``forceScrollToBottom``, or the scroll element is re-attached.
+ *    The flag is intentionally a boolean (not a count) — callers that
+ *    want a count can derive it from their own state.
+ *
+ *    ``unreadDeps`` is a separate parameter from ``pinDeps`` so a
+ *    "streaming flag flipped" signal — which is a perfectly good
+ *    pin trigger (extends the AI bubble while the message is being
+ *    written) — doesn't falsely raise the unread chip. Production
+ *    callers pass ``[messageCount, streamingActive]`` for pinning
+ *    and ``[messageCount]`` for unread.
  *
  * ## Why a callback ref
  *
@@ -94,7 +100,15 @@ export interface UseStickyScrollResult<T extends HTMLElement = HTMLDivElement> {
 }
 
 export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
-  deps: ReadonlyArray<unknown>,
+  pinDeps: ReadonlyArray<unknown>,
+  /** Subset of ``pinDeps`` (or any other set of values) that should
+   *  flip ``hasUnreadBelow`` when they change while the user is
+   *  unpinned. Defaults to ``pinDeps`` for backwards compat, but
+   *  callers should usually narrow this to "real new content"
+   *  signals — e.g. ``messageCount`` only — so transient flags like
+   *  ``streamingActive`` don't falsely raise the chip when they
+   *  flip on / off without a new message landing. */
+  unreadDeps: ReadonlyArray<unknown> = pinDeps,
 ): UseStickyScrollResult<T> {
   const elRef = useRef<T | null>(null);
   // ``pinnedRef`` is the authoritative answer to "should we follow new
@@ -152,6 +166,13 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
         // up before any content arrives, the scroll handler will flip
         // pinnedRef to false.
         pinnedRef.current = true;
+        // Clear any unread flag carried over from the previous element.
+        // Without this, remounting the scroll region within the same
+        // hook instance (Facilitator's ``handleNewSession`` flow:
+        // intro → new session) would inherit a stale "New messages
+        // below" chip on a brand-new transcript that's already at
+        // the bottom.
+        setUnread(false);
 
         const onScroll = () => {
           const nowPinned = isAtBottom(el);
@@ -227,21 +248,16 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
     }
   }, [pinToBottom, setUnread]);
 
-  // Pin to bottom on dep change if pinned. The dep-driven path covers
-  // "new message arrived" (messageCount changed) and "streaming flag
-  // toggled" (streamingActive changed). The ResizeObserver path above
-  // covers layout shifts; together they handle every scenario the
-  // post-hoc distance math used to miss.
+  // Pin to bottom on pinDeps change if pinned. The dep-driven path
+  // covers "new message arrived" (messageCount changed) and
+  // "streaming flag toggled" (streamingActive changed). The
+  // ResizeObserver path above covers layout shifts; together they
+  // handle every scenario the post-hoc distance math used to miss.
   useLayoutEffect(() => {
     const el = elRef.current;
     if (!el) return;
     if (!pinnedRef.current) {
-      // New content arrived while the user was scrolled up. Flag
-      // unread so the caller's chip appears. The chip's onClick will
-      // call ``forceScrollToBottom`` which re-pins and clears the
-      // flag.
-      setUnread(true);
-      console.debug("[scroll] leave-alone (unpinned, marking unread)", {
+      console.debug("[scroll] leave-alone (unpinned)", {
         scrollHeight: el.scrollHeight,
         scrollTop: el.scrollTop,
         clientHeight: el.clientHeight,
@@ -253,7 +269,21 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
     // signals "content changed" (message count, streaming flag, etc.).
     // The eslint rule can't statically verify that.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...deps, refVersion]);
+  }, [...pinDeps, refVersion]);
+
+  // Mark unread on unreadDeps change if unpinned. Split from the
+  // pin layout effect above so transient pin signals (e.g. the
+  // streaming flag flipping at the start / end of an AI message) don't
+  // falsely raise the chip when no new content has actually landed.
+  // Runs as a regular effect (post-paint) — the unread state doesn't
+  // need to land before paint, and using ``useEffect`` avoids
+  // contributing to the same commit phase as the pin path.
+  useEffect(() => {
+    if (pinnedRef.current) return;
+    setUnread(true);
+    console.debug("[scroll] marked unread (unpinned + new content)");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, unreadDeps);
 
   return { scrollRef, forceScrollToBottom, hasUnreadBelow };
 }

--- a/frontend/src/lib/useStickyScroll.ts
+++ b/frontend/src/lib/useStickyScroll.ts
@@ -1,35 +1,79 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Auto-pin a scrollable region to the bottom on new content unless the
- * user has scrolled up to re-read earlier content. Three behaviors:
+ * user has scrolled up to re-read earlier content.
  *
- * 1. **Initial mount with content.** When the scroll element first
- *    attaches and has overflowing content, pin it to the bottom
- *    unconditionally so a participant joining mid-exercise lands on the
- *    latest beat. (Pre-fix, the slack check below read scrollTop=0 as
- *    "user has scrolled up" and stranded them at the top of the
- *    transcript — issue #79.)
+ * ## Why event-driven instead of post-hoc distance math
  *
- * 2. **Incoming content while pinned.** When ``deps`` change and the
- *    user is within ``slack`` px of the bottom, follow the chat down.
- *    If they've scrolled up beyond the slack window, leave their
- *    position alone so the transcript doesn't yank under them.
+ * The original (#79) implementation read ``scrollHeight - scrollTop -
+ * clientHeight`` from inside a layout effect that fired on dep change,
+ * and pinned only if that distance was below a slack window. That
+ * design was broken for two reasons that bit us in production:
  *
- * 3. **Force-scroll on local action.** ``forceScrollToBottom()`` pins
- *    to the bottom on the next render regardless of slack. Use this
- *    after a local user action (submit, force-advance) so the user
- *    sees their own action commit, even if they happen to be reading
- *    older content.
+ * 1. **The browser clamps ``scrollTop``.** Setting
+ *    ``el.scrollTop = el.scrollHeight`` doesn't store ``scrollHeight``
+ *    — it stores ``min(scrollHeight, scrollHeight - clientHeight)``,
+ *    which is the bottom-of-overflow position. So after a "follow"
+ *    pin, ``scrollTop`` reads as ``scrollHeight - clientHeight``, NOT
+ *    ``scrollHeight``. The next time content lands, the math sees the
+ *    user as having scrolled up by ``clientHeight`` and bails.
+ * 2. **Content added below shifts the user's relative position.**
+ *    When a new message lands, ``scrollHeight`` grows but ``scrollTop``
+ *    doesn't. The user *was* at the bottom a frame ago; now the
+ *    distance check reads them as scrolled up by the height of the
+ *    new content and bails. Worse, layout shifts above the chat
+ *    (the "Your turn" banner appearing) shrink ``clientHeight`` and
+ *    move the math even further off the rails.
  *
- * The returned ``scrollRef`` is a callback ref. Attach it to the
- * scrollable element instead of a plain ``useRef`` so the hook learns
- * exactly when the element mounts — a regular ``useEffect`` keyed on
- * ``deps`` won't re-run when the ref attaches if the deps haven't
- * changed, which is the exact race that bit Play.tsx (snapshot loaded
- * while JoinIntro was still showing → chat element mounted later with
- * no further dep change → effect never re-ran with a non-null ref).
+ * The robust pattern (Slack / Discord / every chat app) is to track a
+ * ``pinned`` flag updated **from scroll events** — i.e. only the
+ * user's deliberate scroll can unpin them, and content arriving below
+ * a pinned user always follows. That's what this hook does.
+ *
+ * ## Behaviors
+ *
+ * 1. **Initial mount.** Element starts pinned. The first commit with
+ *    overflowing content scrolls to the bottom unconditionally, so a
+ *    participant joining mid-exercise lands on the latest message.
+ *
+ * 2. **Pinned + new content.** Layout effect runs on dep change (new
+ *    message, streaming flag flip). If pinned, scroll to bottom.
+ *
+ * 3. **Pinned + container resize.** A ResizeObserver watches the
+ *    scroll element. When the chat region shrinks (e.g. the "Your
+ *    turn" banner appears above and the section's flex layout
+ *    redistributes height), if pinned, re-pin to the new bottom so
+ *    the user doesn't get visually "left behind" by the shrink.
+ *
+ * 4. **User scrolls.** A ``scroll`` listener checks
+ *    ``scrollHeight - scrollTop - clientHeight``. Within a small
+ *    tolerance (``PINNED_TOLERANCE``) → pinned. Otherwise → unpinned.
+ *    The hook will leave them alone until they scroll back to the
+ *    bottom (or call ``forceScrollToBottom``).
+ *
+ * 5. **Force-scroll.** ``forceScrollToBottom()`` re-pins synchronously
+ *    and scrolls. Use after a local user action (submit, force-
+ *    advance) so the user sees their own action commit even if they'd
+ *    been reading older content.
+ *
+ * ## Why a callback ref
+ *
+ * A regular ``useRef`` would race in the Play.tsx flow: the snapshot
+ * loads while JoinIntro is still showing → chat element mounts later
+ * with no further dep change → effect never re-runs with a non-null
+ * ref. The callback ref bumps an internal counter on attach so the
+ * layout effect re-fires once the element is actually in the DOM.
  */
+
+/** Tolerance for "user is at the bottom" comparisons. Browsers report
+ *  fractional values for these dimensions on hi-DPI displays, and any
+ *  layout that uses sub-pixel rounding can leave the bottom-most
+ *  scrollTop a pixel or two short of ``scrollHeight - clientHeight``.
+ *  4px is small enough that a deliberate scroll-up is still detected
+ *  and large enough that we don't unpin from rounding noise. */
+const PINNED_TOLERANCE = 4;
+
 export interface UseStickyScrollResult<T extends HTMLElement = HTMLDivElement> {
   scrollRef: (el: T | null) => void;
   forceScrollToBottom: () => void;
@@ -37,115 +81,143 @@ export interface UseStickyScrollResult<T extends HTMLElement = HTMLDivElement> {
 
 export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
   deps: ReadonlyArray<unknown>,
-  options: { slack?: number } = {},
 ): UseStickyScrollResult<T> {
-  const slack = options.slack ?? 120;
   const elRef = useRef<T | null>(null);
-  const didInitialScrollRef = useRef(false);
-  const lastForceNonceRef = useRef(0);
-  // ``refVersion`` is bumped each time the callback ref attaches a new
-  // element. Including it in the layout-effect deps guarantees the
-  // effect re-runs once the element is in the DOM, even if the caller's
-  // ``deps`` happen not to have changed since the previous render.
+  // ``pinnedRef`` is the authoritative answer to "should we follow new
+  // content to the bottom?". It's a ref (not state) so reading and
+  // writing it doesn't trigger re-renders — scroll events fire many
+  // times per second.
+  const pinnedRef = useRef(true);
+  // Detach handler for the currently attached element's scroll +
+  // ResizeObserver. Stored in a ref so the callback ref can invoke
+  // it before attaching to a new element.
+  const detachRef = useRef<(() => void) | null>(null);
+  // Bumped each time the callback ref attaches a new element. Including
+  // it in the layout-effect deps guarantees the effect re-runs once the
+  // element is in the DOM, even if the caller's ``deps`` haven't
+  // changed since the previous render. (This is the JoinIntro → chat
+  // transition race in Play.tsx.)
   const [refVersion, setRefVersion] = useState(0);
-  const [forceNonce, setForceNonce] = useState(0);
 
-  const scrollRef = useCallback((el: T | null) => {
-    const previous = elRef.current;
-    elRef.current = el;
-    if (el !== previous) {
-      // Element identity changed. Reset per-element state so a
-      // remount within the same hook instance gets fresh initial-pin
-      // treatment. Without this, Facilitator's ``handleNewSession()``
-      // (which routes back to the intro screen — unmounting the
-      // scroll region — and a new session remounts a fresh one) would
-      // skip the initial-pin branch and re-introduce the #79
-      // stuck-at-top bug for the second exercise of the same tab.
-      // Same scenario applies to anything that swaps the scroll
-      // element while keeping the parent component mounted.
-      didInitialScrollRef.current = false;
-    }
-    if (el !== null) {
-      setRefVersion((v) => v + 1);
-    }
+  const isAtBottom = useCallback((el: T) => {
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= PINNED_TOLERANCE;
+  }, []);
+
+  const pinToBottom = useCallback((el: T, reason: string) => {
+    el.scrollTop = el.scrollHeight;
+    console.debug("[scroll] pin", {
+      reason,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    });
+  }, []);
+
+  const scrollRef = useCallback(
+    (el: T | null) => {
+      // Detach listeners from the old element first.
+      if (detachRef.current) {
+        detachRef.current();
+        detachRef.current = null;
+      }
+
+      elRef.current = el;
+
+      if (el !== null) {
+        // Fresh element starts pinned. If the user immediately scrolls
+        // up before any content arrives, the scroll handler will flip
+        // pinnedRef to false.
+        pinnedRef.current = true;
+
+        const onScroll = () => {
+          const nowPinned = isAtBottom(el);
+          if (pinnedRef.current !== nowPinned) {
+            pinnedRef.current = nowPinned;
+            console.debug(
+              nowPinned ? "[scroll] re-pinned" : "[scroll] unpinned",
+              {
+                scrollHeight: el.scrollHeight,
+                scrollTop: el.scrollTop,
+                clientHeight: el.clientHeight,
+              },
+            );
+          }
+        };
+        el.addEventListener("scroll", onScroll, { passive: true });
+
+        // ResizeObserver catches layout shifts that change the chat
+        // region's height without the user touching anything — e.g.
+        // the "Your turn" banner appearing above the grid causes the
+        // flex section to shrink, which leaves a previously-pinned
+        // user a few hundred pixels above the new bottom. Re-pin in
+        // that case so the layout shift never moves them off the
+        // latest beat. We deliberately re-pin even when the resize
+        // doesn't perfectly align with a content change — the
+        // alternative ("only re-pin on content arrival") loses the
+        // user's bottom anchor in exactly the production scenario
+        // that triggered this rewrite.
+        let resizeObserver: ResizeObserver | null = null;
+        if (typeof ResizeObserver !== "undefined") {
+          resizeObserver = new ResizeObserver(() => {
+            if (pinnedRef.current && elRef.current === el) {
+              pinToBottom(el, "resize");
+            }
+          });
+          resizeObserver.observe(el);
+        }
+
+        detachRef.current = () => {
+          el.removeEventListener("scroll", onScroll);
+          resizeObserver?.disconnect();
+        };
+
+        // Bump refVersion so the layout effect below re-fires now that
+        // the element is in the DOM and ready to be measured.
+        setRefVersion((v) => v + 1);
+      }
+    },
+    [isAtBottom, pinToBottom],
+  );
+
+  // Detach on unmount.
+  useEffect(() => {
+    return () => {
+      if (detachRef.current) {
+        detachRef.current();
+        detachRef.current = null;
+      }
+    };
   }, []);
 
   const forceScrollToBottom = useCallback(() => {
-    setForceNonce((n) => n + 1);
-  }, []);
+    pinnedRef.current = true;
+    const el = elRef.current;
+    if (el) {
+      pinToBottom(el, "force");
+    }
+  }, [pinToBottom]);
 
+  // Pin to bottom on dep change if pinned. The dep-driven path covers
+  // "new message arrived" (messageCount changed) and "streaming flag
+  // toggled" (streamingActive changed). The ResizeObserver path above
+  // covers layout shifts; together they handle every scenario the
+  // post-hoc distance math used to miss.
   useLayoutEffect(() => {
     const el = elRef.current;
     if (!el) return;
-
-    if (!didInitialScrollRef.current) {
-      // First commit with the element attached. Pin to bottom so a
-      // participant joining mid-exercise lands on the latest message
-      // rather than the top of a long transcript. We only mark the
-      // initial scroll as "done" once content actually overflows —
-      // otherwise an empty / short initial render (transcript with
-      // 0 messages) would consume the initial-scroll branch, and a
-      // later content arrival would fall through to the slack check
-      // and read scrollTop=0 as "user scrolled up". Repeating the
-      // pin while there's no overflow is harmless: setting
-      // ``scrollTop`` on a non-scrollable element is a no-op.
-      if (el.scrollHeight <= el.clientHeight) {
-        // Nothing to scroll yet (empty transcript, or layout hasn't
-        // settled). Wait for the next render to retry.
-        return;
-      }
-      el.scrollTop = el.scrollHeight;
-      didInitialScrollRef.current = true;
-      lastForceNonceRef.current = forceNonce;
-      console.debug("[scroll] initial-pin", {
-        scrollHeight: el.scrollHeight,
-        clientHeight: el.clientHeight,
-      });
-      return;
-    }
-
-    if (forceNonce !== lastForceNonceRef.current) {
-      // ``forceScrollToBottom`` was called since the previous run.
-      // Pin unconditionally — the user just took a local action and
-      // wants to see the result. Tracking the last-seen nonce (rather
-      // than the original ``forceNonce > 0`` shortcut) is what keeps
-      // the slack check working *after* a force-scroll: once the
-      // nonce is stable again we go back to honoring the user's
-      // scroll position.
-      el.scrollTop = el.scrollHeight;
-      lastForceNonceRef.current = forceNonce;
-      console.debug("[scroll] force-pin", {
-        scrollHeight: el.scrollHeight,
-        nonce: forceNonce,
-      });
-      return;
-    }
-
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distanceFromBottom < slack) {
-      el.scrollTop = el.scrollHeight;
-      console.debug("[scroll] follow", {
-        scrollHeight: el.scrollHeight,
-        distanceFromBottom,
-        slack,
-      });
-    } else {
-      // Logged so a "scroll didn't follow my new message" report can
-      // be correlated to the user's scroll position. Without this the
-      // UI just sits there silently.
-      console.debug("[scroll] leave-alone", {
+    if (!pinnedRef.current) {
+      console.debug("[scroll] leave-alone (unpinned)", {
         scrollHeight: el.scrollHeight,
         scrollTop: el.scrollTop,
         clientHeight: el.clientHeight,
-        distanceFromBottom,
-        slack,
       });
+      return;
     }
+    pinToBottom(el, "deps");
     // The deps array is intentionally dynamic: callers pass whatever
     // signals "content changed" (message count, streaming flag, etc.).
     // The eslint rule can't statically verify that.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...deps, refVersion, forceNonce, slack]);
+  }, [...deps, refVersion]);
 
   return { scrollRef, forceScrollToBottom };
 }

--- a/frontend/src/lib/useStickyScroll.ts
+++ b/frontend/src/lib/useStickyScroll.ts
@@ -57,6 +57,15 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
  *    advance) so the user sees their own action commit even if they'd
  *    been reading older content.
  *
+ * 6. **Unread indicator.** When ``deps`` change while the user is
+ *    unpinned, ``hasUnreadBelow`` flips to true so the caller can
+ *    surface a "New messages below ↓" chip. Clears when the user
+ *    scrolls back to the bottom (re-pin) or calls
+ *    ``forceScrollToBottom``. The flag is intentionally a boolean
+ *    (not a count) — callers that want a count can derive it from
+ *    their own state by tracking the message count delta between
+ *    "first unread arrived" and "now".
+ *
  * ## Why a callback ref
  *
  * A regular ``useRef`` would race in the Play.tsx flow: the snapshot
@@ -77,6 +86,11 @@ const PINNED_TOLERANCE = 4;
 export interface UseStickyScrollResult<T extends HTMLElement = HTMLDivElement> {
   scrollRef: (el: T | null) => void;
   forceScrollToBottom: () => void;
+  /** True when content arrived (a dep changed) while the user was
+   *  unpinned. Caller surfaces this as a "New messages below" chip
+   *  whose onClick calls ``forceScrollToBottom``. Clears when the
+   *  user scrolls back to the bottom or force-scrolls. */
+  hasUnreadBelow: boolean;
 }
 
 export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
@@ -98,6 +112,17 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
   // changed since the previous render. (This is the JoinIntro → chat
   // transition race in Play.tsx.)
   const [refVersion, setRefVersion] = useState(0);
+  // Unread-content flag for the chip surface. Mirrored in ``unreadRef``
+  // so non-render code paths (the scroll handler, force-scroll) can
+  // read the current value without going through a state setter.
+  const [hasUnreadBelow, setHasUnreadBelow] = useState(false);
+  const unreadRef = useRef(false);
+  const setUnread = useCallback((next: boolean) => {
+    if (unreadRef.current !== next) {
+      unreadRef.current = next;
+      setHasUnreadBelow(next);
+    }
+  }, []);
 
   const isAtBottom = useCallback((el: T) => {
     return el.scrollHeight - el.scrollTop - el.clientHeight <= PINNED_TOLERANCE;
@@ -140,6 +165,11 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
                 clientHeight: el.clientHeight,
               },
             );
+            // Re-pinning means the user has caught up to the bottom;
+            // clear the unread chip.
+            if (nowPinned) {
+              setUnread(false);
+            }
           }
         };
         el.addEventListener("scroll", onScroll, { passive: true });
@@ -175,7 +205,7 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
         setRefVersion((v) => v + 1);
       }
     },
-    [isAtBottom, pinToBottom],
+    [isAtBottom, pinToBottom, setUnread],
   );
 
   // Detach on unmount.
@@ -190,11 +220,12 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
 
   const forceScrollToBottom = useCallback(() => {
     pinnedRef.current = true;
+    setUnread(false);
     const el = elRef.current;
     if (el) {
       pinToBottom(el, "force");
     }
-  }, [pinToBottom]);
+  }, [pinToBottom, setUnread]);
 
   // Pin to bottom on dep change if pinned. The dep-driven path covers
   // "new message arrived" (messageCount changed) and "streaming flag
@@ -205,7 +236,12 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
     const el = elRef.current;
     if (!el) return;
     if (!pinnedRef.current) {
-      console.debug("[scroll] leave-alone (unpinned)", {
+      // New content arrived while the user was scrolled up. Flag
+      // unread so the caller's chip appears. The chip's onClick will
+      // call ``forceScrollToBottom`` which re-pins and clears the
+      // flag.
+      setUnread(true);
+      console.debug("[scroll] leave-alone (unpinned, marking unread)", {
         scrollHeight: el.scrollHeight,
         scrollTop: el.scrollTop,
         clientHeight: el.clientHeight,
@@ -219,5 +255,5 @@ export function useStickyScroll<T extends HTMLElement = HTMLDivElement>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...deps, refVersion]);
 
-  return { scrollRef, forceScrollToBottom };
+  return { scrollRef, forceScrollToBottom, hasUnreadBelow };
 }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1280,13 +1280,16 @@ export function Facilitator() {
               it re-pins to the bottom. Mirrors the standard chat-app
               pattern (Slack / Discord) so an unpinned operator knows
               there's content below without being yanked off whatever
-              they were reading. */}
+              they were reading. See the Play.tsx counterpart for the
+              colour-choice rationale: solid sky to stay distinct from
+              the amber awaiting-response banner that often sits
+              directly below. */}
           {phase === "play" && hasUnreadBelow ? (
             <div className="pointer-events-none flex shrink-0 justify-center">
               <button
                 type="button"
                 onClick={forceScrollToBottom}
-                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-amber-500/70 bg-slate-900/95 px-4 py-1.5 text-xs font-semibold text-amber-200 shadow-lg backdrop-blur hover:bg-slate-800"
+                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white shadow-lg ring-2 ring-sky-500/30 hover:bg-sky-400"
                 aria-live="polite"
               >
                 New messages below ↓

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -547,11 +547,19 @@ export function Facilitator() {
   // submit fired, the slack check was bypassed forever and the
   // operator could no longer scroll up to re-read older beats.
   const messageCount = snapshot?.messages.length ?? 0;
+  // ``streamingActive`` is a pin trigger (the streamed AI bubble grows
+  // and a pinned operator should follow it down) but NOT an unread
+  // trigger — the chip should only appear when an actual new message
+  // lands, not when the typing indicator flips on / off. Pass a
+  // narrowed unread-deps tuple to gate that.
   const {
     scrollRef: scrollRegionRef,
     forceScrollToBottom,
     hasUnreadBelow,
-  } = useStickyScroll([messageCount, streamingActive]);
+  } = useStickyScroll(
+    [messageCount, streamingActive],
+    [messageCount],
+  );
 
   async function refreshSnapshot() {
     if (!state) return;
@@ -1285,12 +1293,18 @@ export function Facilitator() {
               the amber awaiting-response banner that often sits
               directly below. */}
           {phase === "play" && hasUnreadBelow ? (
-            <div className="pointer-events-none flex shrink-0 justify-center">
+            // Live-region semantics on the wrapper, not the button —
+            // see Play.tsx counterpart for the ARIA APG rationale.
+            <div
+              className="pointer-events-none flex shrink-0 justify-center"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               <button
                 type="button"
                 onClick={forceScrollToBottom}
                 className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white animate-chip-pulse hover:bg-sky-400 motion-reduce:animate-none motion-reduce:shadow-lg motion-reduce:ring-2 motion-reduce:ring-sky-500/30"
-                aria-live="polite"
               >
                 New messages below ↓
               </button>

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1259,6 +1259,15 @@ export function Facilitator() {
                 typingRoleIds={Object.keys(typing).filter(
                   (rid) => rid !== state.creatorRoleId,
                 )}
+                // Pair the latest-AI amber ring with the participant
+                // path. ``isMyTurn`` here is the creator-as-active-role
+                // version (line ~1072: ``activeRoleIds.includes(state.creatorRoleId)``).
+                // Pre-fix the prop was simply not passed on the creator
+                // surface, so the ring never appeared even when the
+                // creator was on the active set — an asymmetry the user
+                // flagged as a regression on the same screen as the
+                // scroll bug.
+                highlightLastAi={isMyTurn}
               />
             </>
           ) : null}

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1289,7 +1289,7 @@ export function Facilitator() {
               <button
                 type="button"
                 onClick={forceScrollToBottom}
-                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white shadow-lg ring-2 ring-sky-500/30 hover:bg-sky-400"
+                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white animate-chip-pulse hover:bg-sky-400 motion-reduce:animate-none motion-reduce:shadow-lg motion-reduce:ring-2 motion-reduce:ring-sky-500/30"
                 aria-live="polite"
               >
                 New messages below ↓

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -547,9 +547,11 @@ export function Facilitator() {
   // submit fired, the slack check was bypassed forever and the
   // operator could no longer scroll up to re-read older beats.
   const messageCount = snapshot?.messages.length ?? 0;
-  const { scrollRef: scrollRegionRef, forceScrollToBottom } = useStickyScroll(
-    [messageCount, streamingActive],
-  );
+  const {
+    scrollRef: scrollRegionRef,
+    forceScrollToBottom,
+    hasUnreadBelow,
+  } = useStickyScroll([messageCount, streamingActive]);
 
   async function refreshSnapshot() {
     if (!state) return;
@@ -1273,6 +1275,24 @@ export function Facilitator() {
           ) : null}
           {error ? <p className="text-sm text-red-400">{error}</p> : null}
           </div>
+          {/* "New messages below" chip — appears when content arrives
+              while the operator has scrolled up to re-read. Clicking
+              it re-pins to the bottom. Mirrors the standard chat-app
+              pattern (Slack / Discord) so an unpinned operator knows
+              there's content below without being yanked off whatever
+              they were reading. */}
+          {phase === "play" && hasUnreadBelow ? (
+            <div className="pointer-events-none flex shrink-0 justify-center">
+              <button
+                type="button"
+                onClick={forceScrollToBottom}
+                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-amber-500/70 bg-slate-900/95 px-4 py-1.5 text-xs font-semibold text-amber-200 shadow-lg backdrop-blur hover:bg-slate-800"
+                aria-live="polite"
+              >
+                New messages below ↓
+              </button>
+            </div>
+          ) : null}
           {phase === "play" ? (
             // Composer + WaitingChip live OUTSIDE the scroll region so they
             // stay pinned at the bottom of the section regardless of

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -692,13 +692,20 @@ export function Play({ sessionId, token }: Props) {
               re-pins to the bottom. Mirrors the standard chat-app
               pattern (Slack / Discord) so an unpinned user knows
               there's content below without being yanked off whatever
-              they were reading. */}
+              they were reading. Solid sky/blue rather than amber:
+              the "Awaiting your response" banner directly below uses
+              amber, and an amber-on-slate chip blended into it. Sky
+              is the only saturated color not already in the palette
+              (amber=awaiting/critical, emerald=AI, red=critical,
+              slate=system, sky-700/30=player bubbles — but the chip
+              is solid sky-500 which reads as distinct from the
+              translucent player-bubble border). */}
           {hasUnreadBelow ? (
             <div className="pointer-events-none flex shrink-0 justify-center">
               <button
                 type="button"
                 onClick={forceScrollToBottom}
-                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-amber-500/70 bg-slate-900/95 px-4 py-1.5 text-xs font-semibold text-amber-200 shadow-lg backdrop-blur hover:bg-slate-800"
+                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white shadow-lg ring-2 ring-sky-500/30 hover:bg-sky-400"
                 aria-live="polite"
               >
                 New messages below ↓

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -273,9 +273,11 @@ export function Play({ sessionId, token }: Props) {
   // left alone. A local submit force-pins so they always see their own
   // message commit.
   const messageCount = snapshot?.messages.length ?? 0;
-  const { scrollRef: scrollRegionRef, forceScrollToBottom } = useStickyScroll(
-    [messageCount, streamingActive],
-  );
+  const {
+    scrollRef: scrollRegionRef,
+    forceScrollToBottom,
+    hasUnreadBelow,
+  } = useStickyScroll([messageCount, streamingActive]);
 
   // Clean up the force-advance cooldown timer on unmount so a tab
   // close mid-cooldown doesn't fire setState on an unmounted component.
@@ -685,6 +687,24 @@ export function Play({ sessionId, token }: Props) {
               highlightLastAi={isMyTurn}
             />
           </div>
+          {/* "New messages below" chip — appears when a message arrives
+              while the user has scrolled up to re-read. Clicking it
+              re-pins to the bottom. Mirrors the standard chat-app
+              pattern (Slack / Discord) so an unpinned user knows
+              there's content below without being yanked off whatever
+              they were reading. */}
+          {hasUnreadBelow ? (
+            <div className="pointer-events-none flex shrink-0 justify-center">
+              <button
+                type="button"
+                onClick={forceScrollToBottom}
+                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-amber-500/70 bg-slate-900/95 px-4 py-1.5 text-xs font-semibold text-amber-200 shadow-lg backdrop-blur hover:bg-slate-800"
+                aria-live="polite"
+              >
+                New messages below ↓
+              </button>
+            </div>
+          ) : null}
           <div className="flex shrink-0 flex-col gap-2">
             {/* Sticky pending-response chip immediately above the composer.
                 When the AI addresses one role specifically (e.g. "Ben —

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -705,7 +705,7 @@ export function Play({ sessionId, token }: Props) {
               <button
                 type="button"
                 onClick={forceScrollToBottom}
-                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white shadow-lg ring-2 ring-sky-500/30 hover:bg-sky-400"
+                className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white animate-chip-pulse hover:bg-sky-400 motion-reduce:animate-none motion-reduce:shadow-lg motion-reduce:ring-2 motion-reduce:ring-sky-500/30"
                 aria-live="polite"
               >
                 New messages below ↓

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -273,11 +273,19 @@ export function Play({ sessionId, token }: Props) {
   // left alone. A local submit force-pins so they always see their own
   // message commit.
   const messageCount = snapshot?.messages.length ?? 0;
+  // ``streamingActive`` is a pin trigger (we want the AI's streamed
+  // bubble to follow the user's pinned position as it grows) but NOT
+  // an unread trigger — the chip should only appear when an actual
+  // new message has landed, not when the typing indicator flips on /
+  // off. Pass a narrowed unread-deps tuple to gate that.
   const {
     scrollRef: scrollRegionRef,
     forceScrollToBottom,
     hasUnreadBelow,
-  } = useStickyScroll([messageCount, streamingActive]);
+  } = useStickyScroll(
+    [messageCount, streamingActive],
+    [messageCount],
+  );
 
   // Clean up the force-advance cooldown timer on unmount so a tab
   // close mid-cooldown doesn't fire setState on an unmounted component.
@@ -701,12 +709,22 @@ export function Play({ sessionId, token }: Props) {
               is solid sky-500 which reads as distinct from the
               translucent player-bubble border). */}
           {hasUnreadBelow ? (
-            <div className="pointer-events-none flex shrink-0 justify-center">
+            // Live-region semantics live on the wrapper, not the
+            // button. Per ARIA APG: live regions should be applied to
+            // a non-interactive container so screen readers announce
+            // the surfaced text without misinterpreting the
+            // interactive control as the announcement target. The
+            // button stays a plain button.
+            <div
+              className="pointer-events-none flex shrink-0 justify-center"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               <button
                 type="button"
                 onClick={forceScrollToBottom}
                 className="pointer-events-auto -mt-12 mb-1 rounded-full border border-sky-300 bg-sky-500 px-4 py-1.5 text-xs font-semibold text-white animate-chip-pulse hover:bg-sky-400 motion-reduce:animate-none motion-reduce:shadow-lg motion-reduce:ring-2 motion-reduce:ring-sky-500/30"
-                aria-live="polite"
               >
                 New messages below ↓
               </button>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -8,11 +8,14 @@ const config: Config = {
       keyframes: {
         // Soft outward sky ring that fades — used by the
         // "New messages below ↓" chip in Play.tsx / Facilitator.tsx
-        // to draw the eye without thrashing. The starting / ending
-        // frame includes the static drop shadow so a motion-reduced
-        // user (``motion-reduce:animate-none``) still gets a chip
-        // with depth — the animation only touches the outer ripple
-        // ring layer.
+        // to draw the eye without thrashing. While the animation is
+        // running, every keyframe combines the outer ripple with a
+        // drop shadow so the chip keeps depth across the cycle.
+        // Under ``motion-reduce:animate-none``, this keyframe doesn't
+        // apply at all, so reduced-motion depth comes from the
+        // ``motion-reduce:shadow-lg motion-reduce:ring-2
+        // motion-reduce:ring-sky-500/30`` utility classes baked into
+        // the chip element itself, not from this keyframe.
         "chip-pulse": {
           "0%, 100%": {
             boxShadow:

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -4,7 +4,30 @@ const config: Config = {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   darkMode: "class",
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        // Soft outward sky ring that fades — used by the
+        // "New messages below ↓" chip in Play.tsx / Facilitator.tsx
+        // to draw the eye without thrashing. The starting / ending
+        // frame includes the static drop shadow so a motion-reduced
+        // user (``motion-reduce:animate-none``) still gets a chip
+        // with depth — the animation only touches the outer ripple
+        // ring layer.
+        "chip-pulse": {
+          "0%, 100%": {
+            boxShadow:
+              "0 0 0 0 rgb(14 165 233 / 0.55), 0 10px 15px -3px rgb(0 0 0 / 0.25)",
+          },
+          "50%": {
+            boxShadow:
+              "0 0 0 10px rgb(14 165 233 / 0), 0 10px 15px -3px rgb(0 0 0 / 0.25)",
+          },
+        },
+      },
+      animation: {
+        "chip-pulse": "chip-pulse 2.2s ease-in-out infinite",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

Re-fixes #79: post-merge testing showed the previous fix still left the participant chat stuck in an active session. Console logs proved the slack-window model is broken at the root, not just at the initial-mount edge case I'd patched.

## What was wrong

Smoking gun from the live console:
```
[scroll] follow      { scrollHeight: 1448, distanceFromBottom: 0 }
[scroll] leave-alone { scrollHeight: 1985, scrollTop: 421, clientHeight: 1027, distanceFromBottom: 537 }
```

Two facts the slack-window model couldn't reconcile:

1. `el.scrollTop = el.scrollHeight` is **browser-clamped** to `scrollHeight - clientHeight`. After a "follow" pin, the recorded scrollTop is the bottom-of-overflow position, not `scrollHeight`. Next dep-change → distance check reads the user as "scrolled up by clientHeight" → bail.
2. **New content arriving below a pinned user grows `scrollHeight` without moving `scrollTop`.** The next layout effect computes distance from a stale scrollTop, sees a 537px gap, trips the slack window, and silently leaves them behind.

The slack model is fundamentally post-hoc reconciliation. By the time the layout effect runs, the user has already been knocked off the bottom by the same event that triggered the effect.

## Fix: event-driven pin tracking

The pattern every well-behaved chat app uses (Slack/Discord). Track a `pinnedRef` flag updated by:
- **`scroll` event listener** — when the user actually scrolls. `PINNED_TOLERANCE` (4px) absorbs hi-DPI rounding.
- **`ResizeObserver`** — re-pin on layout shifts (the "Your turn" banner appearing above the chat redistributes flex height; without ResizeObserver the previously-pinned user ends up hundreds of pixels above the new bottom).
- **`forceScrollToBottom()`** — local actions (submit, force-advance) re-pin synchronously.

The dep-driven layout effect just pins to bottom if pinned. No slack math, no force-nonce dance.

## Also fixed: missing highlight on creator

User reported the latest-AI amber ring regressed. Turned out it was wired on `Play.tsx` (`highlightLastAi={isMyTurn}`) but **never wired on `Facilitator.tsx`** — the prop was silently absent, so the creator never saw the ring even when they were on the active set. Same screen as the scroll bug, flagged in the same report.

## Tests

10 useStickyScroll tests, rewritten for the new semantics:
- pins to bottom on initial mount with overflow (#79 root case)
- follows new content while pinned (browser-clamp regression net — the production bug)
- unpins when user scrolls up
- re-pins when user scrolls back to bottom
- force-scroll bypasses unpinned state
- force-scroll doesn't latch (subsequent scroll-up still unpins)
- re-pins on element remount within same hook instance (Facilitator's `handleNewSession` flow)
- re-pins after full unmount + remount
- waits for overflow before consuming initial-mount pin
- streaming-only deps change still pins

The test harness's `scrollTop` shim now clamps to `max(0, scrollHeight - clientHeight)` like the real browser. That's how the production bug now reproduces in tests; the previous shim accepted any value and silently passed.

## Test plan

- [x] `npm test -- --run` (48 tests pass)
- [x] `npm run lint`, `npm run typecheck`
- [ ] **Manual (please verify):** open an active session in the participant tab, send a new AI message → verify the chat scrolls to it.
- [ ] **Manual:** scroll up by ≥ 5 pixels → next AI message should NOT yank you down.
- [ ] **Manual:** scroll back to the bottom → next AI message should follow.
- [ ] **Manual:** as the active role on the participant tab, verify the latest AI message has the amber ring.
- [ ] **Manual:** as the active role on the creator tab (impersonating an active player or being the creator-as-player), verify the same amber ring now appears (was previously missing entirely on the creator).

Re-opens #79.

https://claude.ai/code/session_015d47PD4WmS8h8cYSfkKczq

---
_Generated by [Claude Code](https://claude.ai/code/session_015d47PD4WmS8h8cYSfkKczq)_