### PR TITLE
Phase A: hide join URL, creator-only End Session, retone WaitingChip (#82, #81, #88)

### DIFF
--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -897,6 +897,15 @@ class SessionManager:
             # (POST /sessions/{id}/end) and WS (request_end_session) call
             # sites already catch IllegalTransitionError and surface it.
             if session.creator_role_id != by_role_id:
+                # Log before raising — a misbehaving client repeatedly
+                # hitting /end is a security-relevant signal and the
+                # exception path alone leaves no operator-visible trail.
+                _logger.warning(
+                    "end_session_rejected",
+                    session_id=session_id,
+                    by_role_id=by_role_id,
+                    creator_role_id=session.creator_role_id,
+                )
                 raise IllegalTransitionError(
                     "only the creator can end the session"
                 )

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -890,6 +890,16 @@ class SessionManager:
     ) -> Session:
         async with await self._lock_for(session_id):
             session = await self._repo.get(session_id)
+            # Creator-only gate (issue #81). The AI-tool end path bypasses
+            # this method (see turn_driver.py around the
+            # ``end_session_reason`` branch), so this guard only constrains
+            # creator/participant-initiated ends. Both REST
+            # (POST /sessions/{id}/end) and WS (request_end_session) call
+            # sites already catch IllegalTransitionError and surface it.
+            if session.creator_role_id != by_role_id:
+                raise IllegalTransitionError(
+                    "only the creator can end the session"
+                )
             if session.state == SessionState.ENDED:
                 return session  # idempotent
             assert_transition(session.state, SessionState.ENDED)

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -471,9 +471,20 @@ async def _client_pump(
                     await manager.end_session(
                         session_id=session_id,
                         by_role_id=role_id,
-                        reason=str(payload.get("reason") or "ended by participant"),
+                        reason=str(payload.get("reason") or "ended by creator"),
                     )
                 except IllegalTransitionError as exc:
+                    # Surface the rejection to the operator's logs as
+                    # well as to the client. Manager-level log already
+                    # fires for the creator-only gate (issue #81); this
+                    # second line captures other transition errors
+                    # (e.g. already-ended) that arrive over WS so a
+                    # silent swallow can't mask a stuck-session report.
+                    _logger.warning(
+                        "ws_end_session_rejected",
+                        by_role_id=role_id,
+                        reason=str(exc),
+                    )
                     await websocket.send_json(
                         {"type": "error", "scope": "end_session", "message": str(exc)}
                     )

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -482,6 +482,8 @@ async def _client_pump(
                     # silent swallow can't mask a stuck-session report.
                     _logger.warning(
                         "ws_end_session_rejected",
+                        session_id=session_id,
+                        event_type=event_type,
                         by_role_id=role_id,
                         reason=str(exc),
                     )

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -500,7 +500,7 @@ def test_end_session_creator_only(client: TestClient) -> None:
     # Non-creator end is rejected with 409 (IllegalTransitionError).
     r = client.post(f"/api/sessions/{sid}/end?token={other}", json={})
     assert r.status_code == 409, r.text
-    assert "creator" in r.text.lower()
+    assert "only the creator can end the session" in r.text.lower()
 
     # Session state is unchanged (still PLAY/AWAITING_PLAYERS).
     snap = client.get(f"/api/sessions/{sid}?token={cr}").json()
@@ -511,6 +511,49 @@ def test_end_session_creator_only(client: TestClient) -> None:
     assert r.status_code == 200, r.text
     snap = client.get(f"/api/sessions/{sid}?token={cr}").json()
     assert snap["state"] == "ENDED"
+
+
+def test_ws_request_end_session_rejected_for_non_creator(
+    client: TestClient,
+) -> None:
+    """Issue #81 WS path: a non-creator tab firing request_end_session
+    over WebSocket gets a typed error event back, and the session is
+    untouched. Mirrors the REST test above for the parallel call site
+    in backend/app/ws/routes.py.
+    """
+
+    seats = _create_and_seat(client, role_count=2)
+    _install_mock_and_drive(
+        client, role_ids=seats["role_ids"], extension="lookup_threat_intel"
+    )
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    other = seats["role_tokens"][seats["role_ids"][1]]
+
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    with client.websocket_connect(
+        f"/ws/sessions/{sid}?token={other}"
+    ) as ws:
+        ws.send_json({"type": "request_end_session", "reason": "spite"})
+        saw_rejection = False
+        for _ in range(64):
+            try:
+                evt = ws.receive_json()
+            except Exception:
+                break
+            if (
+                evt.get("type") == "error"
+                and evt.get("scope") == "end_session"
+                and "creator" in str(evt.get("message", "")).lower()
+            ):
+                saw_rejection = True
+                break
+        assert saw_rejection, "expected end_session rejection error event"
+
+    snap = client.get(f"/api/sessions/{sid}?token={cr}").json()
+    assert snap["state"] != "ENDED"
 
 
 def test_ws_replay_buffer_rehydrates_on_reconnect(client: TestClient) -> None:

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -477,8 +477,14 @@ def test_force_advance_from_any_participant(client: TestClient) -> None:
     assert r.status_code == 200, r.text
 
 
-def test_end_session_from_any_participant(client: TestClient) -> None:
-    """Acceptance gate: any seated participant can end the session."""
+def test_end_session_creator_only(client: TestClient) -> None:
+    """Issue #81: only the creator can end the session.
+
+    Pre-fix any seated participant could call /end and tear the
+    exercise down for everyone. The creator-only gate now lives in
+    ``manager.end_session``; both REST and WS call sites surface
+    the rejection.
+    """
 
     seats = _create_and_seat(client, role_count=2)
     _install_mock_and_drive(
@@ -491,7 +497,17 @@ def test_end_session_from_any_participant(client: TestClient) -> None:
     client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
     client.post(f"/api/sessions/{sid}/start?token={cr}")
 
+    # Non-creator end is rejected with 409 (IllegalTransitionError).
     r = client.post(f"/api/sessions/{sid}/end?token={other}", json={})
+    assert r.status_code == 409, r.text
+    assert "creator" in r.text.lower()
+
+    # Session state is unchanged (still PLAY/AWAITING_PLAYERS).
+    snap = client.get(f"/api/sessions/{sid}?token={cr}").json()
+    assert snap["state"] != "ENDED"
+
+    # Creator end succeeds.
+    r = client.post(f"/api/sessions/{sid}/end?token={cr}", json={})
     assert r.status_code == 200, r.text
     snap = client.get(f"/api/sessions/{sid}?token={cr}").json()
     assert snap["state"] == "ENDED"

--- a/frontend/src/__tests__/RolesPanel.test.tsx
+++ b/frontend/src/__tests__/RolesPanel.test.tsx
@@ -35,7 +35,7 @@ describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
     vi.restoreAllMocks();
   });
 
-  it("Copy link writes to clipboard and never renders the URL", async () => {
+  it("Copy link writes to clipboard, never renders the URL, and reverts after the flash window", async () => {
     const reissue = vi
       .spyOn(api, "reissueRole")
       .mockResolvedValue({
@@ -55,25 +55,41 @@ describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: /Copy link/i });
+    // Accessible name stays "Copy join link" so screen readers don't
+    // double-announce. Visual label flips Copy link → Copied!.
+    const button = screen.getByRole("button", { name: /Copy join link/i });
     fireEvent.click(button);
 
     await waitFor(() => expect(reissue).toHaveBeenCalled());
     await waitFor(() => expect(writeText).toHaveBeenCalled());
 
-    // The clipboard write got a URL containing the token — that's expected.
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining("secret-token-do-not-show"),
     );
 
-    // Button label transitions to "Copied!"
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /Copied!/ })).toBeInTheDocument(),
+    // Token must NEVER appear in the rendered DOM.
+    expect(screen.queryByText(/secret-token-do-not-show/)).toBeNull();
+
+    // Visual badge transitions to Copied!.
+    await waitFor(() => expect(button.textContent).toMatch(/Copied!/));
+
+    // Bottom-of-panel success toast confirms for users with eyes
+    // elsewhere.
+    expect(screen.getByTestId("roles-panel-hint").textContent).toMatch(
+      /Join link for SOC Analyst copied/,
     );
 
-    // The token must NEVER appear in the rendered DOM.
-    expect(screen.queryByText(/secret-token-do-not-show/)).toBeNull();
-  });
+    // sr-only live region carries the audible confirmation.
+    expect(
+      screen.getByRole("status").textContent,
+    ).toMatch(/Join link for SOC Analyst copied/);
+
+    // After ~2s the visual badge reverts.
+    await waitFor(
+      () => expect(button.textContent).toMatch(/Copy link/),
+      { timeout: 3000 },
+    );
+  }, 5000);
 
   it("Add role does not render the new role's URL on screen", async () => {
     const onRoleAdded = vi.fn();
@@ -115,9 +131,61 @@ describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
     expect(
       (screen.getByPlaceholderText(/IR Lead/i) as HTMLInputElement).value,
     ).toBe("");
+    // Bottom-of-panel toast confirms the add+copy succeeded so a creator
+    // looking at the form (not the new role row) still gets feedback.
+    await waitFor(() =>
+      expect(screen.getByTestId("roles-panel-hint").textContent).toMatch(
+        /Added "Legal" — join link copied/,
+      ),
+    );
   });
 
-  it("Copy link surfaces an error when clipboard write fails", async () => {
+  it("Kick & reissue copies the new link, surfaces a hint, never renders the URL", async () => {
+    const onRoleChanged = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const revoke = vi.spyOn(api, "revokeRole").mockResolvedValue({
+      token: "fresh-kick-token",
+      join_url: `https://example.test/play/${SESSION_ID}/fresh-kick-token`,
+    });
+
+    render(
+      <RolesPanel
+        sessionId={SESSION_ID}
+        creatorToken={CREATOR_TOKEN}
+        roles={baseRoles}
+        busy={false}
+        onRoleAdded={vi.fn()}
+        onRoleChanged={onRoleChanged}
+        onError={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Kick & reissue/i }),
+    );
+    expect(confirmSpy).toHaveBeenCalled();
+
+    await waitFor(() => expect(revoke).toHaveBeenCalled());
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    await waitFor(() => expect(onRoleChanged).toHaveBeenCalled());
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("fresh-kick-token"),
+    );
+
+    // Token must not appear in the DOM.
+    expect(screen.queryByText(/fresh-kick-token/)).toBeNull();
+
+    // Confirmation hint at the bottom of the panel — recovery surface
+    // if the in-button flash was missed.
+    await waitFor(() =>
+      expect(screen.getByTestId("roles-panel-hint").textContent).toMatch(
+        /Kicked\. New join link for SOC Analyst copied/,
+      ),
+    );
+  });
+
+  it("Copy link surfaces an inline error when clipboard write fails (not bubbled to onError)", async () => {
     vi.spyOn(api, "reissueRole").mockResolvedValue({
       token: "secret-token-do-not-show",
       join_url: `https://example.test/play/${SESSION_ID}/secret-token-do-not-show`,
@@ -137,14 +205,25 @@ describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Copy link/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Copy join link/i }),
+    );
 
-    await waitFor(() => expect(onError).toHaveBeenCalled());
-    expect(onError.mock.calls[0][0]).toMatch(/clipboard/i);
+    // Inline error hint shows up next to the button — not bubbled
+    // through onError, so the error doesn't render far away in the
+    // page-level banner.
+    await waitFor(() =>
+      expect(screen.getByTestId("roles-panel-error").textContent).toMatch(
+        /Could not copy link/i,
+      ),
+    );
+    expect(onError).not.toHaveBeenCalled();
     expect(screen.queryByText(/secret-token-do-not-show/)).toBeNull();
-    // Button stays as "Copy link" (no false success).
+
+    // Button stays as Copy link (no false success badge).
     expect(
-      screen.getByRole("button", { name: /Copy link/i }),
-    ).toBeInTheDocument();
+      (screen.getByRole("button", { name: /Copy join link/i }) as HTMLElement)
+        .textContent,
+    ).toMatch(/Copy link/);
   });
 });

--- a/frontend/src/__tests__/RolesPanel.test.tsx
+++ b/frontend/src/__tests__/RolesPanel.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RolesPanel } from "../components/RolesPanel";
+import { api, RoleView } from "../api/client";
+
+const SESSION_ID = "sess-123";
+const CREATOR_TOKEN = "creator-token";
+
+const baseRoles: RoleView[] = [
+  {
+    id: "role-creator",
+    label: "Facilitator",
+    kind: "player",
+    is_creator: true,
+    display_name: "Owner",
+  } as RoleView,
+  {
+    id: "role-soc",
+    label: "SOC Analyst",
+    kind: "player",
+    is_creator: false,
+    display_name: null,
+  } as RoleView,
+];
+
+describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("Copy link writes to clipboard and never renders the URL", async () => {
+    const reissue = vi
+      .spyOn(api, "reissueRole")
+      .mockResolvedValue({
+        token: "secret-token-do-not-show",
+        join_url: `https://example.test/play/${SESSION_ID}/secret-token-do-not-show`,
+      });
+
+    render(
+      <RolesPanel
+        sessionId={SESSION_ID}
+        creatorToken={CREATOR_TOKEN}
+        roles={baseRoles}
+        busy={false}
+        onRoleAdded={vi.fn()}
+        onRoleChanged={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /Copy link/i });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(reissue).toHaveBeenCalled());
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+    // The clipboard write got a URL containing the token — that's expected.
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("secret-token-do-not-show"),
+    );
+
+    // Button label transitions to "Copied!"
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Copied!/ })).toBeInTheDocument(),
+    );
+
+    // The token must NEVER appear in the rendered DOM.
+    expect(screen.queryByText(/secret-token-do-not-show/)).toBeNull();
+  });
+
+  it("Add role does not render the new role's URL on screen", async () => {
+    const onRoleAdded = vi.fn();
+    const newRoleId = "role-legal";
+    const newRoleLabel = "Legal";
+
+    const addSpy = vi.spyOn(api, "addRole").mockResolvedValue({
+      role_id: newRoleId,
+      token: "another-secret-token",
+      join_url: `https://example.test/play/${SESSION_ID}/another-secret-token`,
+      label: newRoleLabel,
+      display_name: null,
+    });
+
+    render(
+      <RolesPanel
+        sessionId={SESSION_ID}
+        creatorToken={CREATOR_TOKEN}
+        roles={baseRoles}
+        busy={false}
+        onRoleAdded={onRoleAdded}
+        onRoleChanged={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/IR Lead/i), {
+      target: { value: newRoleLabel },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add role/i }));
+
+    await waitFor(() => expect(addSpy).toHaveBeenCalled());
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    await waitFor(() => expect(onRoleAdded).toHaveBeenCalled());
+
+    // Token must not appear anywhere in the DOM, even briefly.
+    expect(screen.queryByText(/another-secret-token/)).toBeNull();
+    // The form input was cleared.
+    expect(
+      (screen.getByPlaceholderText(/IR Lead/i) as HTMLInputElement).value,
+    ).toBe("");
+  });
+
+  it("Copy link surfaces an error when clipboard write fails", async () => {
+    vi.spyOn(api, "reissueRole").mockResolvedValue({
+      token: "secret-token-do-not-show",
+      join_url: `https://example.test/play/${SESSION_ID}/secret-token-do-not-show`,
+    });
+    writeText.mockRejectedValueOnce(new Error("permission denied"));
+    const onError = vi.fn();
+
+    render(
+      <RolesPanel
+        sessionId={SESSION_ID}
+        creatorToken={CREATOR_TOKEN}
+        roles={baseRoles}
+        busy={false}
+        onRoleAdded={vi.fn()}
+        onRoleChanged={vi.fn()}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy link/i }));
+
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    expect(onError.mock.calls[0][0]).toMatch(/clipboard/i);
+    expect(screen.queryByText(/secret-token-do-not-show/)).toBeNull();
+    // Button stays as "Copy link" (no false success).
+    expect(
+      screen.getByRole("button", { name: /Copy link/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/RolesPanel.test.tsx
+++ b/frontend/src/__tests__/RolesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RolesPanel } from "../components/RolesPanel";
 import { api, RoleView } from "../api/client";
@@ -29,13 +29,28 @@ describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
   beforeEach(() => {
     writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
+    // Default: real timers. Vitest fake timers and React Testing
+    // Library's `waitFor` polling don't compose cleanly (waitFor uses
+    // setTimeout internally for its timeout boundary), so individual
+    // tests that need to skip a wall-clock wait opt in to fake timers
+    // and avoid `waitFor` for that segment — see the Copy-link test.
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it("Copy link writes to clipboard, never renders the URL, and reverts after the flash window", async () => {
+    // Fake timers from the start: the 2s revert in markCopied is a
+    // setTimeout that we need to advance deterministically. Pre-fix
+    // (PR #89 v1) this used `waitFor(..., { timeout: 3000 })` which
+    // spent a real 2s of wall-clock per run and Copilot flagged as
+    // flaky under CI load. ``advanceTimersByTimeAsync`` flushes both
+    // the timer queue and pending microtasks, so the awaits inside
+    // the click handler still resolve.
+    vi.useFakeTimers();
+
     const reissue = vi
       .spyOn(api, "reissueRole")
       .mockResolvedValue({
@@ -60,36 +75,41 @@ describe("RolesPanel — issue #82 (no on-screen tokens)", () => {
     const button = screen.getByRole("button", { name: /Copy join link/i });
     fireEvent.click(button);
 
-    await waitFor(() => expect(reissue).toHaveBeenCalled());
-    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    // Flush microtasks (api.reissueRole + writeText awaits) without
+    // advancing the 2s revert timer. Wrapped in act() so the React
+    // state updates triggered by the click handler's awaits are
+    // batched cleanly (avoids "not wrapped in act(...)" warnings).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
 
+    expect(reissue).toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalled();
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining("secret-token-do-not-show"),
     );
 
     // Token must NEVER appear in the rendered DOM.
     expect(screen.queryByText(/secret-token-do-not-show/)).toBeNull();
-
     // Visual badge transitions to Copied!.
-    await waitFor(() => expect(button.textContent).toMatch(/Copied!/));
-
-    // Bottom-of-panel success toast confirms for users with eyes
-    // elsewhere.
+    expect(button.textContent).toMatch(/Copied!/);
+    // Bottom-of-panel success toast confirms for users with eyes elsewhere.
     expect(screen.getByTestId("roles-panel-hint").textContent).toMatch(
       /Join link for SOC Analyst copied/,
     );
-
     // sr-only live region carries the audible confirmation.
-    expect(
-      screen.getByRole("status").textContent,
-    ).toMatch(/Join link for SOC Analyst copied/);
-
-    // After ~2s the visual badge reverts.
-    await waitFor(
-      () => expect(button.textContent).toMatch(/Copy link/),
-      { timeout: 3000 },
+    expect(screen.getByRole("status").textContent).toMatch(
+      /Join link for SOC Analyst copied/,
     );
-  }, 5000);
+
+    // Fast-forward past the 2s flash window — deterministic, no
+    // wall-clock wait. act() wraps the state update fired by the
+    // setTimeout cleanup in markCopied.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2100);
+    });
+    expect(button.textContent).toMatch(/Copy link/);
+  });
 
   it("Add role does not render the new role's URL on screen", async () => {
     const onRoleAdded = vi.fn();

--- a/frontend/src/__tests__/WaitingChip.test.tsx
+++ b/frontend/src/__tests__/WaitingChip.test.tsx
@@ -101,4 +101,31 @@ describe("WaitingChip — issue #88 (slate tone, no Copy invite, actor-led copy)
     expect(screen.getByText(/Waiting on Comms to respond\./)).toBeInTheDocument();
     expect(screen.queryByText(/\(\)/)).toBeNull();
   });
+
+  it("multi-pending mix: prints display_name where present, label-only otherwise, no empty parens", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-soc", "r-comms"]}
+        submittedRoleIds={[]}
+        roles={ROSTER}
+      />,
+    );
+    expect(
+      screen.getByText(/Waiting on SOC Analyst \(Bridget\) and Comms\./),
+    ).toBeInTheDocument();
+    // No "Comms ()" empty-parens artefact.
+    expect(screen.queryByText(/Comms \(\)/)).toBeNull();
+  });
+
+  it("exposes role=status with aria-live=polite (assistive tech contract)", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-soc"]}
+        submittedRoleIds={[]}
+        roles={ROSTER}
+      />,
+    );
+    const status = screen.getByRole("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+  });
 });

--- a/frontend/src/__tests__/WaitingChip.test.tsx
+++ b/frontend/src/__tests__/WaitingChip.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { WaitingChip } from "../pages/Facilitator";
+import type { RoleView } from "../api/client";
+
+function role(id: string, label: string, displayName: string | null = null): RoleView {
+  return {
+    id,
+    label,
+    kind: "player",
+    is_creator: false,
+    display_name: displayName,
+  } as RoleView;
+}
+
+const ROSTER = [
+  role("r-soc", "SOC Analyst", "Bridget"),
+  role("r-legal", "Legal", "Marcus"),
+  role("r-comms", "Comms"),
+  role("r-ir", "IR Lead", "Pat"),
+];
+
+describe("WaitingChip — issue #88 (slate tone, no Copy invite, actor-led copy)", () => {
+  it("renders nothing when no roles are pending", () => {
+    const { container } = render(
+      <WaitingChip
+        activeRoleIds={["r-soc"]}
+        submittedRoleIds={["r-soc"]}
+        roles={ROSTER}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("1 pending → 'Waiting on X (display_name) to respond.'", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-soc", "r-legal"]}
+        submittedRoleIds={["r-legal"]}
+        roles={ROSTER}
+      />,
+    );
+    expect(
+      screen.getByText(/Waiting on SOC Analyst \(Bridget\) to respond\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/\(1 of 2\)/)).toBeInTheDocument();
+  });
+
+  it("2 pending → 'Waiting on A and B.'", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-soc", "r-legal"]}
+        submittedRoleIds={[]}
+        roles={ROSTER}
+      />,
+    );
+    expect(
+      screen.getByText(
+        /Waiting on SOC Analyst \(Bridget\) and Legal \(Marcus\)\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/\(2 of 2\)/)).toBeInTheDocument();
+  });
+
+  it("3+ pending → 'Waiting on A, B and N more.'", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-soc", "r-legal", "r-comms", "r-ir"]}
+        submittedRoleIds={[]}
+        roles={ROSTER}
+      />,
+    );
+    expect(
+      screen.getByText(
+        /Waiting on SOC Analyst \(Bridget\), Legal \(Marcus\) and 2 more\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/\(4 of 4\)/)).toBeInTheDocument();
+  });
+
+  it("does not render any Copy invite button (issue #88 — duplicative with Roles panel)", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-soc", "r-legal"]}
+        submittedRoleIds={[]}
+        roles={ROSTER}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Copy invite/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Copy link/i })).toBeNull();
+  });
+
+  it("falls back to label when display_name is missing", () => {
+    render(
+      <WaitingChip
+        activeRoleIds={["r-comms"]}
+        submittedRoleIds={[]}
+        roles={ROSTER}
+      />,
+    );
+    expect(screen.getByText(/Waiting on Comms to respond\./)).toBeInTheDocument();
+    expect(screen.queryByText(/\(\)/)).toBeNull();
+  });
+});

--- a/frontend/src/components/RolesPanel.tsx
+++ b/frontend/src/components/RolesPanel.tsx
@@ -21,8 +21,12 @@ interface Props {
 /**
  * Creator-only role manager: add a role, copy a role's join link, kick
  * (revoke + reissue), or remove a role entirely. Each per-role action is
- * a single round-trip; the join URL is rendered inline + auto-copied.
+ * a single round-trip; copies go straight to the clipboard with a
+ * transient "Copied!" badge on the originating button — no token ever
+ * renders on screen (issue #82, screenshare hijack risk).
  */
+const COPIED_FLASH_MS = 2000;
+
 export function RolesPanel({
   sessionId,
   creatorToken,
@@ -34,7 +38,12 @@ export function RolesPanel({
   connectedRoleIds,
 }: Props) {
   const [newRole, setNewRole] = useState("");
-  const [linksByRole, setLinksByRole] = useState<Record<string, string>>({});
+  // Set of role_ids whose Copy/Add/Kick button is currently flashing
+  // "Copied!". Holds no token data — copies happen inside the handler
+  // via navigator.clipboard, never via React state.
+  const [copiedRoleIds, setCopiedRoleIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [hint, setHint] = useState<string | null>(null);
   const origin = window.location.origin;
 
@@ -43,16 +52,45 @@ export function RolesPanel({
     setTimeout(() => setHint(null), 2500);
   }
 
+  function markCopied(roleId: string) {
+    setCopiedRoleIds((prev) => {
+      const next = new Set(prev);
+      next.add(roleId);
+      return next;
+    });
+    setTimeout(() => {
+      setCopiedRoleIds((prev) => {
+        if (!prev.has(roleId)) return prev;
+        const next = new Set(prev);
+        next.delete(roleId);
+        return next;
+      });
+    }, COPIED_FLASH_MS);
+  }
+
+  async function writeUrl(url: string): Promise<boolean> {
+    try {
+      await navigator.clipboard?.writeText(url);
+      return true;
+    } catch (err) {
+      console.warn("[RolesPanel] clipboard write failed", err);
+      return false;
+    }
+  }
+
   async function add(e: FormEvent) {
     e.preventDefault();
     if (!newRole.trim()) return;
     try {
       const r = await api.addRole(sessionId, creatorToken, { label: newRole.trim() });
       const url = `${origin}/play/${sessionId}/${encodeURIComponent(r.token)}`;
-      setLinksByRole((s) => ({ ...s, [r.role_id]: url }));
-      await navigator.clipboard?.writeText(url).catch(() => undefined);
+      const ok = await writeUrl(url);
       setNewRole("");
-      flash(`Added "${r.label}" — join link copied`);
+      if (ok) {
+        markCopied(r.role_id);
+      } else {
+        onError("Could not copy link to clipboard. Use Kick & reissue to retry.");
+      }
       onRoleAdded();
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err));
@@ -63,9 +101,12 @@ export function RolesPanel({
     try {
       const r = await api.reissueRole(sessionId, creatorToken, roleId);
       const url = `${origin}/play/${sessionId}/${encodeURIComponent(r.token)}`;
-      setLinksByRole((s) => ({ ...s, [roleId]: url }));
-      await navigator.clipboard?.writeText(url).catch(() => undefined);
-      flash("Join link copied to clipboard");
+      const ok = await writeUrl(url);
+      if (ok) {
+        markCopied(roleId);
+      } else {
+        onError("Could not copy link to clipboard.");
+      }
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err));
     }
@@ -82,9 +123,12 @@ export function RolesPanel({
     try {
       const r = await api.revokeRole(sessionId, creatorToken, roleId);
       const url = `${origin}/play/${sessionId}/${encodeURIComponent(r.token)}`;
-      setLinksByRole((s) => ({ ...s, [roleId]: url }));
-      await navigator.clipboard?.writeText(url).catch(() => undefined);
-      flash(`Kicked. New join link copied — share with the replacement.`);
+      const ok = await writeUrl(url);
+      if (ok) {
+        markCopied(roleId);
+      } else {
+        onError("Kicked, but copying the new link failed. Use Copy link to retry.");
+      }
       onRoleChanged();
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err));
@@ -95,10 +139,11 @@ export function RolesPanel({
     if (!confirm(`Remove the "${label}" role from this session?`)) return;
     try {
       await api.removeRole(sessionId, creatorToken, roleId);
-      setLinksByRole((s) => {
-        const out = { ...s };
-        delete out[roleId];
-        return out;
+      setCopiedRoleIds((prev) => {
+        if (!prev.has(roleId)) return prev;
+        const next = new Set(prev);
+        next.delete(roleId);
+        return next;
       });
       flash(`Removed "${label}".`);
       onRoleChanged();
@@ -180,10 +225,17 @@ export function RolesPanel({
                     type="button"
                     onClick={() => copyExistingLink(r.id)}
                     disabled={busy}
-                    className="rounded border border-slate-700 px-2 py-0.5 text-xs text-slate-200 hover:bg-slate-800 disabled:opacity-50"
+                    className={
+                      "rounded border px-2 py-0.5 text-xs disabled:opacity-50 " +
+                      (copiedRoleIds.has(r.id)
+                        ? "border-emerald-500 bg-emerald-900/40 text-emerald-100"
+                        : "border-slate-700 text-slate-200 hover:bg-slate-800")
+                    }
                     title="Re-mint and copy the join link without invalidating any existing tabs."
                   >
-                    Copy link
+                    <span aria-live="polite">
+                      {copiedRoleIds.has(r.id) ? "Copied!" : "Copy link"}
+                    </span>
                   </button>
                   <button
                     type="button"
@@ -206,11 +258,6 @@ export function RolesPanel({
                 </div>
               ) : null}
             </div>
-            {linksByRole[r.id] ? (
-              <p className="break-all rounded bg-slate-900 p-1 text-xs text-emerald-300">
-                {linksByRole[r.id]}
-              </p>
-            ) : null}
           </li>
           );
         })}

--- a/frontend/src/components/RolesPanel.tsx
+++ b/frontend/src/components/RolesPanel.tsx
@@ -58,7 +58,19 @@ export function RolesPanel({
   // is now a *visual* affordance: the button keeps the static
   // accessible name "Copy link" so screen readers don't double-
   // announce when the label flips for two seconds.
-  const [announcement, setAnnouncement] = useState("");
+  //
+  // ``epoch`` increments on every announce(). Same-string assignments
+  // would be a React no-op and screen readers wouldn't re-fire — the
+  // counter is keyed onto the live-region span so React remounts it
+  // each time, making AT treat each copy as a fresh announcement
+  // even when the user copies the same role twice in a row.
+  const [announcement, setAnnouncement] = useState<{ epoch: number; text: string }>(
+    () => ({ epoch: 0, text: "" }),
+  );
+
+  function announce(text: string) {
+    setAnnouncement((prev) => ({ epoch: prev.epoch + 1, text }));
+  }
   const origin = window.location.origin;
 
   function flash(message: string) {
@@ -83,7 +95,7 @@ export function RolesPanel({
       next.add(roleId);
       return next;
     });
-    setAnnouncement(`Join link for ${label} copied to clipboard.`);
+    announce(`Join link for ${label} copied to clipboard.`);
     setTimeout(() => {
       setCopiedRoleIds((prev) => {
         if (!prev.has(roleId)) return prev;
@@ -95,8 +107,21 @@ export function RolesPanel({
   }
 
   async function writeUrl(url: string): Promise<boolean> {
+    // Optional chaining on `navigator.clipboard?.writeText` resolves
+    // to `undefined` on browsers/contexts without the Clipboard API
+    // (insecure contexts, older browsers, some embedded webviews).
+    // Without an explicit availability check, the await would succeed
+    // and we'd flash a false "Copied!" while the URL was never
+    // actually written. Explicit check + return false routes through
+    // the existing inline-error path.
+    if (typeof navigator.clipboard?.writeText !== "function") {
+      console.warn(
+        "[RolesPanel] clipboard API unavailable (insecure context or unsupported browser)",
+      );
+      return false;
+    }
     try {
-      await navigator.clipboard?.writeText(url);
+      await navigator.clipboard.writeText(url);
       return true;
     } catch (err) {
       console.warn("[RolesPanel] clipboard write failed", err);
@@ -334,9 +359,17 @@ export function RolesPanel({
       {/* Visually-hidden live region for assistive tech. The in-button
           "Copied!" flash is purely visual; accessible-name double-
           announce was the bug — this is the single source of audible
-          confirmation. */}
-      <span className="sr-only" role="status" aria-live="polite">
-        {announcement}
+          confirmation. ``key={epoch}`` forces React to remount on
+          every announce() so AT re-fires even when the user copies
+          the same role twice in a row (a same-string state set is a
+          React no-op and screen readers wouldn't otherwise notice). */}
+      <span
+        key={announcement.epoch}
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+      >
+        {announcement.text}
       </span>
     </div>
   );

--- a/frontend/src/components/RolesPanel.tsx
+++ b/frontend/src/components/RolesPanel.tsx
@@ -44,20 +44,46 @@ export function RolesPanel({
   const [copiedRoleIds, setCopiedRoleIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  // Inline confirmation hint shown beneath the form (success, e.g.
+  // "Link for SOC Analyst copied"). Lives at the bottom of the panel
+  // so a creator with eyes on the form / Slack still sees confirmation
+  // even if they missed the in-button "Copied!" flash.
   const [hint, setHint] = useState<string | null>(null);
+  // Inline error hint (clipboard denied, etc.) — kept in-panel rather
+  // than bubbling through onError so the message lives next to the
+  // button the user just clicked. Server-side failures still bubble
+  // via onError so the page-level error banner surfaces them.
+  const [errorHint, setErrorHint] = useState<string | null>(null);
+  // Live-region announcement (sr-only). The in-button "Copied!" flash
+  // is now a *visual* affordance: the button keeps the static
+  // accessible name "Copy link" so screen readers don't double-
+  // announce when the label flips for two seconds.
+  const [announcement, setAnnouncement] = useState("");
   const origin = window.location.origin;
 
   function flash(message: string) {
     setHint(message);
-    setTimeout(() => setHint(null), 2500);
+    setErrorHint(null);
+    setTimeout(() => {
+      setHint((cur) => (cur === message ? null : cur));
+    }, 2500);
   }
 
-  function markCopied(roleId: string) {
+  function flashError(message: string) {
+    setErrorHint(message);
+    setHint(null);
+    setTimeout(() => {
+      setErrorHint((cur) => (cur === message ? null : cur));
+    }, 4000);
+  }
+
+  function markCopied(roleId: string, label: string) {
     setCopiedRoleIds((prev) => {
       const next = new Set(prev);
       next.add(roleId);
       return next;
     });
+    setAnnouncement(`Join link for ${label} copied to clipboard.`);
     setTimeout(() => {
       setCopiedRoleIds((prev) => {
         if (!prev.has(roleId)) return prev;
@@ -87,9 +113,12 @@ export function RolesPanel({
       const ok = await writeUrl(url);
       setNewRole("");
       if (ok) {
-        markCopied(r.role_id);
+        markCopied(r.role_id, r.label);
+        flash(`Added "${r.label}" — join link copied.`);
       } else {
-        onError("Could not copy link to clipboard. Use Kick & reissue to retry.");
+        flashError(
+          `Added "${r.label}", but copying the link failed. Use the new "Copy link" button on the row.`,
+        );
       }
       onRoleAdded();
     } catch (err) {
@@ -97,15 +126,18 @@ export function RolesPanel({
     }
   }
 
-  async function copyExistingLink(roleId: string) {
+  async function copyExistingLink(roleId: string, label: string) {
     try {
       const r = await api.reissueRole(sessionId, creatorToken, roleId);
       const url = `${origin}/play/${sessionId}/${encodeURIComponent(r.token)}`;
       const ok = await writeUrl(url);
       if (ok) {
-        markCopied(roleId);
+        markCopied(roleId, label);
+        flash(`Join link for ${label} copied.`);
       } else {
-        onError("Could not copy link to clipboard.");
+        flashError(
+          "Could not copy link to clipboard. Check browser permissions.",
+        );
       }
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err));
@@ -125,9 +157,12 @@ export function RolesPanel({
       const url = `${origin}/play/${sessionId}/${encodeURIComponent(r.token)}`;
       const ok = await writeUrl(url);
       if (ok) {
-        markCopied(roleId);
+        markCopied(roleId, label);
+        flash(`Kicked. New join link for ${label} copied — share with the replacement.`);
       } else {
-        onError("Kicked, but copying the new link failed. Use Copy link to retry.");
+        flashError(
+          `Kicked ${label}, but copying the new link failed. Click "Copy link" on the row to retry.`,
+        );
       }
       onRoleChanged();
     } catch (err) {
@@ -223,17 +258,23 @@ export function RolesPanel({
                 <div className="flex flex-wrap gap-1">
                   <button
                     type="button"
-                    onClick={() => copyExistingLink(r.id)}
+                    onClick={() => copyExistingLink(r.id, r.label)}
                     disabled={busy}
+                    aria-label="Copy join link"
                     className={
-                      "rounded border px-2 py-0.5 text-xs disabled:opacity-50 " +
+                      "rounded border px-2 py-0.5 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 disabled:opacity-50 " +
                       (copiedRoleIds.has(r.id)
                         ? "border-emerald-500 bg-emerald-900/40 text-emerald-100"
                         : "border-slate-700 text-slate-200 hover:bg-slate-800")
                     }
                     title="Re-mint and copy the join link without invalidating any existing tabs."
                   >
-                    <span aria-live="polite">
+                    {/* Visual flash only — accessible name stays
+                        "Copy join link" via aria-label so screen
+                        readers don't double-announce when the label
+                        flips for 2s. The audible confirmation comes
+                        from the panel-level live region below. */}
+                    <span aria-hidden="true">
                       {copiedRoleIds.has(r.id) ? "Copied!" : "Copy link"}
                     </span>
                   </button>
@@ -241,7 +282,7 @@ export function RolesPanel({
                     type="button"
                     onClick={() => kick(r.id, r.label)}
                     disabled={busy}
-                    className="rounded border border-amber-600 px-2 py-0.5 text-xs text-amber-300 hover:bg-amber-900/30 disabled:opacity-50"
+                    className="rounded border border-amber-600 px-2 py-0.5 text-xs text-amber-300 hover:bg-amber-900/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-300 disabled:opacity-50"
                     title="Disconnect anyone using the current link and issue a new link."
                   >
                     Kick &amp; reissue
@@ -250,7 +291,7 @@ export function RolesPanel({
                     type="button"
                     onClick={() => remove(r.id, r.label)}
                     disabled={busy}
-                    className="rounded border border-red-600 px-2 py-0.5 text-xs text-red-300 hover:bg-red-900/30 disabled:opacity-50"
+                    className="rounded border border-red-600 px-2 py-0.5 text-xs text-red-300 hover:bg-red-900/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-300 disabled:opacity-50"
                     title="Remove this role from the session."
                   >
                     Remove
@@ -274,13 +315,29 @@ export function RolesPanel({
         <button
           type="submit"
           disabled={busy || !newRole.trim()}
-          className="rounded bg-sky-600 px-2 py-1 text-xs font-semibold text-white hover:bg-sky-500 disabled:opacity-50"
+          className="rounded bg-sky-600 px-2 py-1 text-xs font-semibold text-white hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-300 disabled:opacity-50"
         >
           Add role
         </button>
       </form>
 
-      {hint ? <p className="text-xs text-emerald-300">{hint}</p> : null}
+      {hint ? (
+        <p className="text-xs text-emerald-300" data-testid="roles-panel-hint">
+          {hint}
+        </p>
+      ) : null}
+      {errorHint ? (
+        <p className="text-xs text-red-300" data-testid="roles-panel-error">
+          {errorHint}
+        </p>
+      ) : null}
+      {/* Visually-hidden live region for assistive tech. The in-button
+          "Copied!" flash is purely visual; accessible-name double-
+          announce was the bug — this is the single source of audible
+          confirmation. */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {announcement}
+      </span>
     </div>
   );
 }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1327,8 +1327,6 @@ export function Facilitator() {
                     snapshot.current_turn?.submitted_role_ids ?? []
                   }
                   roles={snapshot.roles}
-                  sessionId={state.sessionId}
-                  creatorToken={state.token}
                 />
               ) : null}
               {(() => {
@@ -1863,91 +1861,53 @@ function ActiveRolesHint({
 }
 
 /**
- * Pinned above the Composer when *other* roles still owe a response. Tells
- * the local player exactly who we're blocked on so the screen doesn't look
- * frozen, and surfaces the count ("waiting on 1 of 3") for at-a-glance scan.
+ * Pinned above the Composer when *other* roles still owe a response. Names
+ * the actor we're blocked on so the screen doesn't look frozen, with a
+ * smaller ``(N of M)`` tail for at-a-glance count.
+ *
+ * Issue #88: previously rendered amber-on-amber (read as "warning") and
+ * exposed a per-role "Copy invite" button that duplicated the Copy link
+ * affordance already in the Roles panel. The tone is now neutral slate
+ * matching the rest of the awaiting-state banners; copy/issuing links is
+ * handled exclusively by the Roles panel.
  */
-function WaitingChip({
+export function WaitingChip({
   activeRoleIds,
   submittedRoleIds,
   roles,
-  sessionId,
-  creatorToken,
 }: {
   activeRoleIds: string[];
   submittedRoleIds: string[];
   roles: RoleView[];
-  /** When provided, the chip exposes a "Copy invite link" button per
-   *  pending role so the operator can re-share a join link without
-   *  scrolling up to the Roles panel. Tokens are fetched on-demand via
-   *  ``api.reissueRole`` so they're never embedded in the snapshot. */
-  sessionId?: string;
-  creatorToken?: string;
 }) {
-  const [copiedRoleId, setCopiedRoleId] = useState<string | null>(null);
-  const [copyErr, setCopyErr] = useState<string | null>(null);
   const submitted = new Set(submittedRoleIds);
   const pending = activeRoleIds.filter((id) => !submitted.has(id));
   if (pending.length === 0) return null;
-  const pendingRoles = pending.map(
-    (id) => roles.find((r) => r.id === id) ?? { id, label: id, display_name: null },
-  );
-  const canResend = Boolean(sessionId && creatorToken);
-
-  async function copyInvite(roleId: string) {
-    if (!sessionId || !creatorToken) return;
-    setCopyErr(null);
-    try {
-      const r = await api.reissueRole(sessionId, creatorToken, roleId);
-      await navigator.clipboard.writeText(r.join_url);
-      setCopiedRoleId(roleId);
-      setTimeout(() => {
-        setCopiedRoleId((cur) => (cur === roleId ? null : cur));
-      }, 2000);
-    } catch (err) {
-      setCopyErr(err instanceof Error ? err.message : String(err));
-    }
+  const labels = pending.map((id) => {
+    const r = roles.find((x) => x.id === id);
+    if (!r) return id;
+    return r.display_name ? `${r.label} (${r.display_name})` : r.label;
+  });
+  let phrase: string;
+  if (labels.length === 1) {
+    phrase = `Waiting on ${labels[0]} to respond.`;
+  } else if (labels.length === 2) {
+    phrase = `Waiting on ${labels[0]} and ${labels[1]}.`;
+  } else {
+    const head = labels.slice(0, 2).join(", ");
+    phrase = `Waiting on ${head} and ${labels.length - 2} more.`;
   }
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className="mb-2 flex flex-col gap-1 rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1 text-xs text-amber-100"
+      className="mb-2 flex items-center gap-2 rounded bg-slate-800 px-2 py-1 text-xs text-slate-200"
     >
-      <span className="flex items-center gap-2">
-        <span
-          aria-hidden="true"
-          className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-amber-300"
-        />
-        <span>
-          Waiting on{" "}
-          <span className="font-semibold">{pending.length} of {activeRoleIds.length}</span>
-        </span>
+      <span>{phrase}</span>
+      <span className="text-slate-400">
+        ({pending.length} of {activeRoleIds.length})
       </span>
-      <ul className="flex flex-wrap items-center gap-1">
-        {pendingRoles.map((r) => (
-          <li
-            key={r.id}
-            className="inline-flex items-center gap-1 rounded bg-amber-950/60 px-1.5 py-0.5"
-          >
-            <span className="text-amber-200">{r.label}</span>
-            {canResend ? (
-              <button
-                type="button"
-                onClick={() => copyInvite(r.id)}
-                className="rounded border border-amber-500/50 px-1 py-0 text-[10px] text-amber-100 hover:bg-amber-900/40"
-                title={`Reissue and copy ${r.label}'s join link.`}
-              >
-                {copiedRoleId === r.id ? "Copied!" : "Copy invite"}
-              </button>
-            ) : null}
-          </li>
-        ))}
-      </ul>
-      {copyErr ? (
-        <p className="text-[10px] text-red-300">copy failed: {copyErr}</p>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -402,7 +402,12 @@ export function Play({ sessionId, token }: Props) {
     // role; this guard is just early UX. Left intact (rather than
     // inlined into the JSX onClick) so a future "request that the
     // creator end" flow can re-wire the same handler.
-    wsRef.current?.send({ type: "request_end_session", reason: "ended by creator" });
+    try {
+      wsRef.current?.send({ type: "request_end_session", reason: "ended by creator" });
+    } catch (err) {
+      console.warn("[play] end-session send failed", err);
+      setError(err instanceof Error ? err.message : String(err));
+    }
   }
 
   const myRoleFromSnapshot = snapshot?.roles.find((r) => r.id === selfRoleId);

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -397,7 +397,12 @@ export function Play({ sessionId, token }: Props) {
   }
 
   function handleEnd() {
-    wsRef.current?.send({ type: "request_end_session", reason: "ended by participant" });
+    // Issue #81: button is rendered only when the local participant is
+    // the creator. Backend manager.end_session also gates by creator
+    // role; this guard is just early UX. Left intact (rather than
+    // inlined into the JSX onClick) so a future "request that the
+    // creator end" flow can re-wire the same handler.
+    wsRef.current?.send({ type: "request_end_session", reason: "ended by creator" });
   }
 
   const myRoleFromSnapshot = snapshot?.roles.find((r) => r.id === selfRoleId);
@@ -548,6 +553,11 @@ export function Play({ sessionId, token }: Props) {
   // The backend WS gate still rejects, but disabling here keeps the
   // loud red error banner off the screen during the brief gap.
   const isPlayer = !!myRole && myRole.kind !== "spectator";
+  // Issue #81: only the creator gets the End-session affordance. Any
+  // participant pressing it would have torn the exercise down for
+  // everyone — backend now rejects that path too, but the button
+  // shouldn't even render for non-creators.
+  const isSelfCreator = myRole?.is_creator ?? false;
   const otherPending = activeRoleIds
     .filter((id) => id !== selfRoleId && !submittedRoleIds.includes(id))
     .map((id) => snapshot.roles.find((r) => r.id === id)?.label ?? id);
@@ -662,12 +672,14 @@ export function Play({ sessionId, token }: Props) {
                 ? "Force-advance turn (cooling down)"
                 : "Force-advance turn"}
             </button>
-            <button
-              onClick={handleEnd}
-              className="rounded border border-red-500 px-2 py-1 font-semibold text-red-300 hover:bg-red-900/30"
-            >
-              End session
-            </button>
+            {isSelfCreator ? (
+              <button
+                onClick={handleEnd}
+                className="rounded border border-red-500 px-2 py-1 font-semibold text-red-300 hover:bg-red-900/30"
+              >
+                End session
+              </button>
+            ) : null}
           </div>
         </aside>
         <section className="flex min-w-0 flex-col gap-3 lg:min-h-0 lg:overflow-hidden">


### PR DESCRIPTION
## Summary

Phase A of the multi-phase plan in `/root/.claude/plans/fluffy-brewing-scott.md` (approved). Low-risk, frontend-mostly polish covering three open issues. Phase B (#76, #80) and Phase C (#77) ship as separate follow-up PRs.

- **#82 — Hide join URL.** `RolesPanel` no longer renders tokens to the DOM at all. Copies go to the clipboard with an in-button `Copied!` flash plus an inline confirmation hint at the bottom of the panel.
- **#81 — Creator-only End Session.** Frontend hides the button for non-creators. Backend `manager.end_session` raises `IllegalTransitionError` on the same gate (defence-in-depth); REST returns 409, WS emits an `error` event with `scope=end_session`. The AI-tool end path (`turn_driver.py` around `outcome.end_session_reason`) bypasses `manager.end_session` and is unaffected.
- **#88 — Retone WaitingChip.** Amber → neutral slate. Per-role `Copy invite` button removed (duplicative of the `RolesPanel` Copy link). Copy now leads with the actor: `Waiting on SOC Analyst (Bridget) to respond. (1 of 3)`.

Closes #82
Closes #81
Closes #88

## Sub-agent review pass

Six reviewers ran in parallel (QA, Security, UI/UX, Product, User-creator-persona, Prompt Expert) per `CLAUDE.md`. No `BLOCK`/`CRITICAL` findings. All 11 `HIGH` findings + 1 Security `LOW` (debuggability) addressed in the follow-up commit `33177a5` — see commit body for the full mapping. Notable HIGH fixes:

- Restored an inline success toast so creators with eyes on the form / Slack don't miss the per-row `Copied!` flash (User-Agent H1).
- Fixed an ARIA double-announce: `aria-live` now lives on a panel-level sr-only `role=status` region, not wrapping the button label that flips for 2s (UI/UX H2).
- Routed clipboard-write failures to an inline error hint inside `RolesPanel` rather than bubbling to the page-level error banner far from the offending button (UI/UX H1).
- Added `focus-visible` outlines to all four `RolesPanel` buttons (UI/UX H3).
- Added `_logger.warning("end_session_rejected", …)` in the manager and `ws_end_session_rejected` in the WS handler before raising / forwarding — silent rejections were a security telemetry gap (Security HIGH).
- Wrapped `Play.tsx::handleEnd`'s `wsRef.send` in try/catch (Security LOW debuggability).

Deferred MEDIUM/LOW: WaitingChip slate-on-slate contrast tune-up, hidden-vs-disabled End-button (User M3), `isSelfCreator` hydrate-race flicker. None blocking; tracked as follow-ups.

## Test plan

- [x] `cd backend && pytest -q` — 287 passed, 16 skipped
- [x] `cd backend && ruff check .` — clean
- [x] `cd backend && mypy app` — clean (39 source files)
- [x] `cd frontend && npm test -- --run` — 66 passed (+3 new RolesPanel tests, +3 new WaitingChip tests, +1 new WS-path end-session test on backend)
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [ ] Manual QA (per plan §Verification, blocked on a running stack):
  - [ ] Screenshare the SETUP page; no join URL visible anywhere in the Roles panel
  - [ ] `Copy link` button transitions to `Copied!` for ~2s then reverts; clipboard contains the URL; bottom-of-panel hint reads `Join link for X copied.`
  - [ ] Add role / Kick & reissue same flow
  - [ ] Non-creator's Play tab has **no** End-session button; Force-advance still visible
  - [ ] Creator's Facilitator tab still has the prominent End-session button
  - [ ] WS `request_end_session` from a non-creator token receives `{type:"error", scope:"end_session", message:"only the creator can end the session"}` and session state stays unchanged
  - [ ] WaitingChip during PLAY reads `Waiting on {role} ({display_name}) to respond. (N of M)` in slate, no per-role Copy invite button

https://claude.ai/code/session_0122qBQpK5Nwt7rBctwK4de5

---
_Generated by [Claude Code](https://claude.ai/code/session_0122qBQpK5Nwt7rBctwK4de5)_