### PR TITLE
Phase B: hold participants on JoinIntro until session starts (#76) + proxy-respond + mid-session-joiner chip (#80)

### DIFF
--- a/frontend/src/__tests__/JoinIntro.waiting.test.tsx
+++ b/frontend/src/__tests__/JoinIntro.waiting.test.tsx
@@ -21,8 +21,8 @@ const COMMON_PROPS = {
 
 describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
   beforeEach(() => {
-    // Tip rotation uses setInterval; fake timers let us assert the
-    // carousel advances without a 7s wall-clock wait.
+    // Tip rotation uses setTimeout (length-aware dwell); fake timers
+    // let us assert the carousel advances without a wall-clock wait.
     vi.useFakeTimers();
   });
 

--- a/frontend/src/__tests__/JoinIntro.waiting.test.tsx
+++ b/frontend/src/__tests__/JoinIntro.waiting.test.tsx
@@ -1,0 +1,152 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { JoinIntro } from "../pages/Play";
+
+// Issue #76 — joined-but-waiting variant of JoinIntro. The Play page
+// holds the participant on JoinIntro instead of bouncing them to a
+// blank chat shell while the creator drafts the plan; the form is
+// swapped for a spinner panel + tip carousel.
+
+const COMMON_PROPS = {
+  sessionId: "sess-123",
+  token: "play-token",
+  roleLabel: "SOC Analyst",
+  roleKind: "player" as const,
+  roleExistingDisplayName: null,
+  snapshotLoaded: true,
+  snapshotError: null,
+  onRetry: () => undefined,
+  onJoined: () => undefined,
+};
+
+describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
+  beforeEach(() => {
+    // Tip rotation uses setInterval; fake timers let us assert the
+    // carousel advances without a 7s wall-clock wait.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hasName=false, sessionState=SETUP → renders the name form, not the waiting panel", () => {
+    render(
+      <JoinIntro {...COMMON_PROPS} sessionState="SETUP" hasName={false} />,
+    );
+    expect(screen.queryByTestId("join-intro-waiting")).toBeNull();
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Begin/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hasName=true, sessionState=SETUP → renders the waiting panel, not the form", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    expect(screen.getByTestId("join-intro-waiting")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Waiting for your facilitator to start the scenario/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/seated as/i).textContent,
+    ).toMatch(/SOC Analyst/);
+    expect(
+      screen.getByText(/seated as/i).textContent,
+    ).toMatch(/Bridget/);
+    // Form must be gone.
+    expect(screen.queryByLabelText(/display name/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /Begin/i })).toBeNull();
+  });
+
+  it("hasName=true, sessionState=BRIEFING → AI-preparing copy variant", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="BRIEFING"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    expect(
+      screen.getByText(/AI is preparing the scenario brief/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Waiting for your facilitator to start/i),
+    ).toBeNull();
+  });
+
+  it("tip carousel rotates after the configured interval", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    const tipPanel = screen.getByTestId("join-intro-tip");
+    const initial = tipPanel.textContent;
+    expect(initial).toBeTruthy();
+
+    // Advance past one rotation interval (carousel uses 7s).
+    act(() => {
+      vi.advanceTimersByTime(7100);
+    });
+    const next = screen.getByTestId("join-intro-tip").textContent;
+    expect(next).not.toBe(initial);
+
+    // Another rotation lands on a different tip again (or wraps).
+    act(() => {
+      vi.advanceTimersByTime(7100);
+    });
+    const third = screen.getByTestId("join-intro-tip").textContent;
+    expect(third).not.toBe(next);
+  });
+
+  it("joinedSeatCount>0 surfaces a 'N seats joined' momentum cue", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+        joinedSeatCount={3}
+      />,
+    );
+    expect(screen.getByText(/3 seats joined/i)).toBeInTheDocument();
+  });
+
+  it("joinedSeatCount=1 → singular form", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+        joinedSeatCount={1}
+      />,
+    );
+    expect(screen.getByText(/1 seat joined/i)).toBeInTheDocument();
+  });
+
+  it("waiting panel exposes role=status with aria-live=polite", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    const panel = screen.getByTestId("join-intro-waiting");
+    expect(panel.getAttribute("role")).toBe("status");
+    expect(panel.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/frontend/src/__tests__/JoinIntro.waiting.test.tsx
+++ b/frontend/src/__tests__/JoinIntro.waiting.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { JoinIntro } from "../pages/Play";
 
@@ -95,22 +95,25 @@ describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
     const initial = tipPanel.textContent;
     expect(initial).toBeTruthy();
 
-    // Advance past one rotation interval (carousel uses 7s).
+    // Carousel dwell scales with tip length (UI/UX review HIGH —
+    // 7s was borderline for the longest tips). 12s is enough for
+    // every tip in the array, including the longest at ~140 chars
+    // (which yields ~10s dwell).
     act(() => {
-      vi.advanceTimersByTime(7100);
+      vi.advanceTimersByTime(12_000);
     });
     const next = screen.getByTestId("join-intro-tip").textContent;
     expect(next).not.toBe(initial);
 
     // Another rotation lands on a different tip again (or wraps).
     act(() => {
-      vi.advanceTimersByTime(7100);
+      vi.advanceTimersByTime(12_000);
     });
     const third = screen.getByTestId("join-intro-tip").textContent;
     expect(third).not.toBe(next);
   });
 
-  it("joinedSeatCount>0 surfaces a 'N seats joined' momentum cue", () => {
+  it("joinedSeatCount>0 surfaces an 'N other seats are connected' momentum cue", () => {
     render(
       <JoinIntro
         {...COMMON_PROPS}
@@ -120,7 +123,12 @@ describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
         joinedSeatCount={3}
       />,
     );
-    expect(screen.getByText(/3 seats joined/i)).toBeInTheDocument();
+    // Copy shifted from "N seats joined" to "N other seats are
+    // connected" (UI/UX review: pre-fix included the local
+    // participant in the count, so "1 seat joined" was just *me*).
+    expect(
+      screen.getByText(/3 other seats are connected/i),
+    ).toBeInTheDocument();
   });
 
   it("joinedSeatCount=1 → singular form", () => {
@@ -133,10 +141,12 @@ describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
         joinedSeatCount={1}
       />,
     );
-    expect(screen.getByText(/1 seat joined/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 other seat is connected/i),
+    ).toBeInTheDocument();
   });
 
-  it("waiting panel exposes role=status with aria-live=polite", () => {
+  it("waiting panel exposes role=status; aria-live is scoped to the rotating tip only (UI/UX review)", () => {
     render(
       <JoinIntro
         {...COMMON_PROPS}
@@ -147,6 +157,97 @@ describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
     );
     const panel = screen.getByTestId("join-intro-waiting");
     expect(panel.getAttribute("role")).toBe("status");
-    expect(panel.getAttribute("aria-live")).toBe("polite");
+    // Pre-fix the whole panel had aria-live=polite; the tip
+    // rotation re-announced the headline + role + seat count
+    // every 7-10s. Now aria-live lives only on the tip <p>.
+    expect(panel.getAttribute("aria-live")).toBeNull();
+    const tipPanel = screen.getByTestId("join-intro-tip");
+    const liveTip = within(tipPanel).getByText(/.+/, {
+      selector: "p[aria-live='polite']",
+    });
+    expect(liveTip).toBeInTheDocument();
+  });
+
+  it("personalised welcome headline includes the joined display name", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    // Scope to the waiting panel — the surrounding "How to play"
+    // section also has an h2.
+    const panel = screen.getByTestId("join-intro-waiting");
+    const heading = within(panel).getByRole("heading", { level: 2 });
+    expect(heading.textContent).toMatch(/Welcome, Bridget/);
+  });
+
+  it("auto-resolves when sessionState transitions out of SETUP/BRIEFING", () => {
+    const { rerender } = render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    expect(screen.getByTestId("join-intro-waiting")).toBeInTheDocument();
+
+    // Simulate the engine flipping to AWAITING_PLAYERS — JoinIntro
+    // should swap back to the form variant (the gate in Play.tsx
+    // would also unmount it; here we just confirm the variant
+    // flip logic is keyed correctly off ``sessionState``).
+    rerender(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="AWAITING_PLAYERS"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    expect(screen.queryByTestId("join-intro-waiting")).toBeNull();
+  });
+
+  it("tip carousel cycles through all WAITING_TIPS and wraps back", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    const seen = new Set<string>();
+    seen.add(screen.getByTestId("join-intro-tip").textContent ?? "");
+    // Advance through enough rotations to see every tip + wrap.
+    // The carousel uses dwell scaled to length; advancing 12s per
+    // beat is enough to clear even the longest tip.
+    for (let i = 0; i < 8; i++) {
+      act(() => {
+        vi.advanceTimersByTime(12_000);
+      });
+      seen.add(screen.getByTestId("join-intro-tip").textContent ?? "");
+    }
+    // We've seen at least 4 distinct tip texts (5 tips total; the
+    // textContent includes the "1 / 5" indicator so the strings
+    // differ even if the carousel re-emits the same body text on
+    // wrap).
+    expect(seen.size).toBeGreaterThanOrEqual(4);
+  });
+
+  it("tip indicator shows current/total position", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    const tipPanel = screen.getByTestId("join-intro-tip");
+    // Initial tip is index 0 → "1 / N"
+    expect(tipPanel.textContent).toMatch(/1\s*\/\s*\d+/);
   });
 });

--- a/frontend/src/__tests__/proxyAndJoiner.test.tsx
+++ b/frontend/src/__tests__/proxyAndJoiner.test.tsx
@@ -10,12 +10,16 @@ import type { RoleView } from "../api/client";
 function role(
   id: string,
   label: string,
-  opts: { is_creator?: boolean; display_name?: string | null } = {},
+  opts: {
+    is_creator?: boolean;
+    display_name?: string | null;
+    kind?: "player" | "spectator";
+  } = {},
 ): RoleView {
   return {
     id,
     label,
-    kind: "player",
+    kind: opts.kind ?? "player",
     is_creator: opts.is_creator ?? false,
     display_name: opts.display_name ?? null,
   } as RoleView;
@@ -35,6 +39,20 @@ describe("buildImpersonateOptions — issue #80 (dropdown roster source)", () =>
     expect(options.map((o) => o.id)).toEqual(["r-soc"]);
   });
 
+  it("excludes spectators (backend rejects spectator proxy submits)", () => {
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-soc", "SOC Analyst"),
+      role("r-watcher", "Auditor", { kind: "spectator" }),
+    ];
+    const options = buildImpersonateOptions({
+      roles,
+      activeRoleIds: ["r-soc", "r-watcher"],
+      submittedRoleIds: [],
+    });
+    expect(options.map((o) => o.id)).toEqual(["r-soc"]);
+  });
+
   it("excludes roles that already submitted on the current turn", () => {
     const roles = [
       role("r-creator", "Facilitator", { is_creator: true }),
@@ -49,7 +67,7 @@ describe("buildImpersonateOptions — issue #80 (dropdown roster source)", () =>
     expect(options.map((o) => o.id)).toEqual(["r-legal"]);
   });
 
-  it("on-turn roles render with their plain label", () => {
+  it("on-turn roles return offTurn=false with a plain label", () => {
     const roles = [
       role("r-creator", "Facilitator", { is_creator: true }),
       role("r-soc", "SOC Analyst"),
@@ -59,13 +77,18 @@ describe("buildImpersonateOptions — issue #80 (dropdown roster source)", () =>
       activeRoleIds: ["r-soc"],
       submittedRoleIds: [],
     });
-    expect(options).toEqual([{ id: "r-soc", label: "SOC Analyst" }]);
+    expect(options).toEqual([
+      { id: "r-soc", label: "SOC Analyst", offTurn: false },
+    ]);
   });
 
-  it("off-turn roles get the '(off-turn)' suffix", () => {
-    // Issue #80 core scenario: "Legal" was added mid-turn, isn't on
-    // the running turn's active_role_ids, but should still surface
-    // in the dropdown so the creator can post on their behalf.
+  it("off-turn roles return offTurn=true with the bare label", () => {
+    // Issue #80 core scenario: "Legal" added mid-turn, isn't on the
+    // running turn's active_role_ids, but should surface in the
+    // dropdown. The Composer renders the (sidebar) suffix from the
+    // structured ``offTurn`` flag — pre-fix the suffix was inlined
+    // into the label and collided with Composer's own " (proxy)"
+    // append, producing "Legal (off-turn) (proxy)".
     const roles = [
       role("r-creator", "Facilitator", { is_creator: true }),
       role("r-soc", "SOC Analyst"),
@@ -77,8 +100,8 @@ describe("buildImpersonateOptions — issue #80 (dropdown roster source)", () =>
       submittedRoleIds: [],
     });
     expect(options).toEqual([
-      { id: "r-soc", label: "SOC Analyst" },
-      { id: "r-legal", label: "Legal (off-turn)" },
+      { id: "r-soc", label: "SOC Analyst", offTurn: false },
+      { id: "r-legal", label: "Legal", offTurn: true },
     ]);
   });
 
@@ -103,6 +126,20 @@ describe("buildImpersonateOptions — issue #80 (dropdown roster source)", () =>
       buildImpersonateOptions({
         roles,
         activeRoleIds: ["r-creator"],
+        submittedRoleIds: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns an empty array when the only non-creator is a spectator", () => {
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-watcher", "Auditor", { kind: "spectator" }),
+    ];
+    expect(
+      buildImpersonateOptions({
+        roles,
+        activeRoleIds: ["r-watcher"],
         submittedRoleIds: [],
       }),
     ).toEqual([]);
@@ -196,5 +233,44 @@ describe("isMidSessionJoiner — issue #80 bonus chip predicate", () => {
         selfRoleId: null,
       }),
     ).toBe(false);
+  });
+
+  it("false for spectators (chip would be a false promise — engine never adds them)", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: "r-watcher",
+        selfRoleKind: "spectator",
+      }),
+    ).toBe(false);
+  });
+
+  it("false for the creator's own seat (creator authored the session)", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: "r-creator",
+        selfRoleKind: "player",
+        selfIsCreator: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still true for a player non-creator with no selfRoleKind passed (back-compat)", () => {
+    // Defensive: callers that don't yet pass selfRoleKind/selfIsCreator
+    // (older test scaffolds) should still get the historical truth
+    // table. Both new gates are opt-in, false-only-when-set.
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: "r-legal",
+      }),
+    ).toBe(true);
   });
 });

--- a/frontend/src/__tests__/proxyAndJoiner.test.tsx
+++ b/frontend/src/__tests__/proxyAndJoiner.test.tsx
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { buildImpersonateOptions, isMidSessionJoiner } from "../lib/proxy";
+import type { RoleView } from "../api/client";
+
+// Issue #80 helpers — both extracted as pure functions so the
+// proxy-respond filter logic and the mid-session-joiner predicate
+// can be tested without spinning up a Facilitator/Play render
+// scaffold.
+
+function role(
+  id: string,
+  label: string,
+  opts: { is_creator?: boolean; display_name?: string | null } = {},
+): RoleView {
+  return {
+    id,
+    label,
+    kind: "player",
+    is_creator: opts.is_creator ?? false,
+    display_name: opts.display_name ?? null,
+  } as RoleView;
+}
+
+describe("buildImpersonateOptions — issue #80 (dropdown roster source)", () => {
+  it("excludes the creator's own seat", () => {
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-soc", "SOC Analyst"),
+    ];
+    const options = buildImpersonateOptions({
+      roles,
+      activeRoleIds: ["r-creator", "r-soc"],
+      submittedRoleIds: [],
+    });
+    expect(options.map((o) => o.id)).toEqual(["r-soc"]);
+  });
+
+  it("excludes roles that already submitted on the current turn", () => {
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-soc", "SOC Analyst"),
+      role("r-legal", "Legal"),
+    ];
+    const options = buildImpersonateOptions({
+      roles,
+      activeRoleIds: ["r-soc", "r-legal"],
+      submittedRoleIds: ["r-soc"],
+    });
+    expect(options.map((o) => o.id)).toEqual(["r-legal"]);
+  });
+
+  it("on-turn roles render with their plain label", () => {
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-soc", "SOC Analyst"),
+    ];
+    const options = buildImpersonateOptions({
+      roles,
+      activeRoleIds: ["r-soc"],
+      submittedRoleIds: [],
+    });
+    expect(options).toEqual([{ id: "r-soc", label: "SOC Analyst" }]);
+  });
+
+  it("off-turn roles get the '(off-turn)' suffix", () => {
+    // Issue #80 core scenario: "Legal" was added mid-turn, isn't on
+    // the running turn's active_role_ids, but should still surface
+    // in the dropdown so the creator can post on their behalf.
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-soc", "SOC Analyst"),
+      role("r-legal", "Legal"),
+    ];
+    const options = buildImpersonateOptions({
+      roles,
+      activeRoleIds: ["r-soc"], // legal NOT in active set
+      submittedRoleIds: [],
+    });
+    expect(options).toEqual([
+      { id: "r-soc", label: "SOC Analyst" },
+      { id: "r-legal", label: "Legal (off-turn)" },
+    ]);
+  });
+
+  it("preserves snapshot.roles ordering", () => {
+    const roles = [
+      role("r-creator", "Facilitator", { is_creator: true }),
+      role("r-c", "Comms"),
+      role("r-a", "IR Lead"),
+      role("r-b", "Legal"),
+    ];
+    const options = buildImpersonateOptions({
+      roles,
+      activeRoleIds: ["r-a", "r-b", "r-c"],
+      submittedRoleIds: [],
+    });
+    expect(options.map((o) => o.id)).toEqual(["r-c", "r-a", "r-b"]);
+  });
+
+  it("returns an empty array when only the creator remains unsubmitted", () => {
+    const roles = [role("r-creator", "Facilitator", { is_creator: true })];
+    expect(
+      buildImpersonateOptions({
+        roles,
+        activeRoleIds: ["r-creator"],
+        submittedRoleIds: [],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("isMidSessionJoiner — issue #80 bonus chip predicate", () => {
+  const baseMessages: { kind: string; role_id?: string | null }[] = [
+    { kind: "ai_text" },
+    { kind: "player", role_id: "r-soc" },
+    { kind: "system" },
+  ];
+
+  it("true when joining mid-PLAY, not in active set, no prior posts", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: "r-legal",
+      }),
+    ).toBe(true);
+  });
+
+  it("true also during AWAITING_PLAYERS for the new joiner", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AWAITING_PLAYERS",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: "r-legal",
+      }),
+    ).toBe(true);
+  });
+
+  it("false during SETUP / BRIEFING (handled by JoinIntro waiting variant)", () => {
+    for (const state of ["SETUP", "BRIEFING"]) {
+      expect(
+        isMidSessionJoiner({
+          sessionState: state,
+          iAmActive: false,
+          messages: baseMessages,
+          selfRoleId: "r-legal",
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("false during ENDED", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "ENDED",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: "r-legal",
+      }),
+    ).toBe(false);
+  });
+
+  it("false when the participant is in the current turn's active set", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: true,
+        messages: baseMessages,
+        selfRoleId: "r-legal",
+      }),
+    ).toBe(false);
+  });
+
+  it("false once the participant has posted at least one PLAYER message", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: false,
+        messages: [
+          ...baseMessages,
+          { kind: "player", role_id: "r-legal" },
+        ],
+        selfRoleId: "r-legal",
+      }),
+    ).toBe(false);
+  });
+
+  it("false when selfRoleId is null (token rehydration not done)", () => {
+    expect(
+      isMidSessionJoiner({
+        sessionState: "AI_PROCESSING",
+        iAmActive: false,
+        messages: baseMessages,
+        selfRoleId: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -3,8 +3,16 @@ import { FormEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
 interface ImpersonateOption {
   /** Role-id to submit as. */
   id: string;
-  /** Visible label, e.g. "SOC Analyst". */
+  /** Visible label, e.g. "SOC Analyst". Bare role label only — no
+   *  decorations; the Composer adds them based on ``offTurn``. */
   label: string;
+  /** ``true`` when the role isn't on the current turn's active set.
+   *  Submitting as them lands as an interjection (sidebar comment),
+   *  not a turn answer (issue #80). The dropdown row + the
+   *  "Submitting as …" banner change wording so a fast-typing
+   *  creator can't miss that this won't count as the role's turn
+   *  answer. */
+  offTurn?: boolean;
 }
 
 interface Props {
@@ -230,41 +238,57 @@ export function Composer({
               <option value="">{selfLabel ?? "self"} (you)</option>
               {(impersonateOptions ?? []).map((o) => (
                 <option key={o.id} value={o.id}>
-                  {o.label} (proxy)
+                  {/* Off-turn proxy lands as an interjection (sidebar
+                      comment); call that out plainly so a creator
+                      doesn't think they're submitting a turn answer
+                      under the role's name. Issue #80. */}
+                  {o.label}
+                  {o.offTurn ? " — sidebar (off-turn)" : " (proxy)"}
                 </option>
               ))}
             </select>
           </label>
         ) : null}
       </div>
-      {asRoleId ? (
+      {asRoleId ? (() => {
         // Loud impersonation banner so a creator who picked "as: SOC" but
         // then types fast can't miss that they're about to post under
         // someone else's name. The submit button colour shifts to amber
         // for the same reason. The inline "back to me" button is the
         // user-agent's MEDIUM ask: switching out of proxy mode shouldn't
         // require reopening the dropdown.
-        <div
-          className="flex flex-wrap items-center justify-between gap-2 rounded border border-amber-600/60 bg-amber-950/40 px-2 py-1 text-xs text-amber-100"
-          role="status"
-          aria-live="polite"
-        >
-          <span>
-            Submitting as{" "}
-            <span className="font-semibold">
-              {(impersonateOptions ?? []).find((o) => o.id === asRoleId)?.label ?? asRoleId}
-            </span>{" "}
-            (proxy)
-          </span>
-          <button
-            type="button"
-            onClick={() => setAsRoleId("")}
-            className="rounded border border-amber-500/60 px-2 py-0.5 text-[11px] font-semibold text-amber-100 hover:bg-amber-900/40"
+        //
+        // Issue #80: when the selected role is off-turn the wording
+        // shifts from "(proxy)" to "(sidebar — not a turn answer)" so
+        // the creator knows the submission won't count as the role's
+        // turn answer.
+        const selected = (impersonateOptions ?? []).find(
+          (o) => o.id === asRoleId,
+        );
+        const offTurn = Boolean(selected?.offTurn);
+        return (
+          <div
+            className="flex flex-wrap items-center justify-between gap-2 rounded border border-amber-600/60 bg-amber-950/40 px-2 py-1 text-xs text-amber-100"
+            role="status"
+            aria-live="polite"
           >
-            Back to {selfLabel ?? "me"}
-          </button>
-        </div>
-      ) : null}
+            <span>
+              Submitting as{" "}
+              <span className="font-semibold">
+                {selected?.label ?? asRoleId}
+              </span>{" "}
+              {offTurn ? "(sidebar — not a turn answer)" : "(proxy)"}
+            </span>
+            <button
+              type="button"
+              onClick={() => setAsRoleId("")}
+              className="rounded border border-amber-500/60 px-2 py-0.5 text-[11px] font-semibold text-amber-100 hover:bg-amber-900/40"
+            >
+              Back to {selfLabel ?? "me"}
+            </button>
+          </div>
+        );
+      })() : null}
       <textarea
         id="composer"
         value={text}
@@ -294,7 +318,13 @@ export function Composer({
               : "bg-sky-600 hover:bg-sky-500 focus-visible:outline-sky-300"
           }`}
         >
-          Submit{asRoleId ? " (proxy)" : ""}
+          {(() => {
+            if (!asRoleId) return "Submit";
+            const selected = (impersonateOptions ?? []).find(
+              (o) => o.id === asRoleId,
+            );
+            return selected?.offTurn ? "Submit (sidebar)" : "Submit (proxy)";
+          })()}
         </button>
       </div>
     </form>

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -1,19 +1,10 @@
 import { FormEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
+import type { ImpersonateOption } from "../lib/proxy";
 
-interface ImpersonateOption {
-  /** Role-id to submit as. */
-  id: string;
-  /** Visible label, e.g. "SOC Analyst". Bare role label only — no
-   *  decorations; the Composer adds them based on ``offTurn``. */
-  label: string;
-  /** ``true`` when the role isn't on the current turn's active set.
-   *  Submitting as them lands as an interjection (sidebar comment),
-   *  not a turn answer (issue #80). The dropdown row + the
-   *  "Submitting as …" banner change wording so a fast-typing
-   *  creator can't miss that this won't count as the role's turn
-   *  answer. */
-  offTurn?: boolean;
-}
+// ``ImpersonateOption`` lives in ``../lib/proxy`` so the helper that
+// builds the dropdown options and the consumer here can't drift on
+// the shape of ``offTurn`` (issue #80, Copilot review on PR #91).
+// See ``lib/proxy.ts`` for the field-by-field contract.
 
 interface Props {
   enabled: boolean;

--- a/frontend/src/lib/proxy.ts
+++ b/frontend/src/lib/proxy.ts
@@ -1,0 +1,83 @@
+import type { RoleView } from "../api/client";
+
+export interface ImpersonateOption {
+  id: string;
+  label: string;
+}
+
+/**
+ * Build the creator's "Respond as" dropdown options (issue #80).
+ *
+ * Sources from the full session roster, not the current turn's active
+ * set, so a role added mid-turn (``api.addRole``) shows up in the
+ * dropdown immediately. Roles that aren't on the current turn's
+ * active set get an "(off-turn)" label suffix — submitting as them
+ * lands as an interjection (sidebar comment) rather than a turn
+ * answer, matching the existing out-of-turn participant submit
+ * semantics. The creator's own seat is always excluded (the implicit
+ * default), and roles that have already submitted on the current
+ * turn are filtered out so they can't be double-submitted.
+ *
+ * Pre-fix the source was the engine's ``activeRoleIds`` (locked at
+ * turn start), which left mid-session role-adds invisible to proxy
+ * until the next turn rolled — see the issue thread.
+ */
+export function buildImpersonateOptions({
+  roles,
+  activeRoleIds,
+  submittedRoleIds,
+}: {
+  roles: RoleView[];
+  activeRoleIds: string[];
+  submittedRoleIds: string[];
+}): ImpersonateOption[] {
+  const submittedSet = new Set(submittedRoleIds);
+  const activeSet = new Set(activeRoleIds);
+  return roles
+    .filter((r) => !r.is_creator)
+    .filter((r) => !submittedSet.has(r.id))
+    .map((r) => {
+      const offTurn = !activeSet.has(r.id);
+      return {
+        id: r.id,
+        label: offTurn ? `${r.label} (off-turn)` : r.label,
+      };
+    });
+}
+
+/**
+ * Issue #80 bonus: predicate for the "Just joined? You'll be brought
+ * into the next turn" chip in the participant Play view.
+ *
+ * Fires when:
+ * - the session is mid-PLAY (``AI_PROCESSING`` or ``AWAITING_PLAYERS``);
+ * - the local participant is **not** in the current turn's active
+ *   set (so the AI hasn't called on them yet); AND
+ * - they have no prior PLAYER messages from their role_id (heuristic
+ *   for "just joined this session", separating them from a
+ *   passive-but-already-engaged participant).
+ *
+ * Once the next turn rolls them into the active set or they post a
+ * message, the chip disappears naturally.
+ */
+export function isMidSessionJoiner({
+  sessionState,
+  iAmActive,
+  messages,
+  selfRoleId,
+}: {
+  sessionState: string;
+  iAmActive: boolean;
+  messages: ReadonlyArray<{ kind: string; role_id?: string | null }>;
+  selfRoleId: string | null;
+}): boolean {
+  if (iAmActive) return false;
+  if (sessionState !== "AI_PROCESSING" && sessionState !== "AWAITING_PLAYERS") {
+    return false;
+  }
+  if (!selfRoleId) return false;
+  const iHavePosted = messages.some(
+    (m) => m.kind === "player" && m.role_id === selfRoleId,
+  );
+  return !iHavePosted;
+}

--- a/frontend/src/lib/proxy.ts
+++ b/frontend/src/lib/proxy.ts
@@ -1,8 +1,20 @@
 import type { RoleView } from "../api/client";
 
+/**
+ * One row in the creator's "Respond as" dropdown.
+ *
+ * ``offTurn`` is broken out as a structured flag so the renderer (the
+ * Composer) can decorate the row + the "Submitting as …" banner
+ * differently for off-turn proxy submissions without needing to
+ * string-match a "(off-turn)" suffix. Pre-fix the suffix was inlined
+ * into ``label`` and collided with Composer's own " (proxy)" suffix,
+ * producing "Legal (off-turn) (proxy)" — confusing on the option and
+ * worse in the running banner.
+ */
 export interface ImpersonateOption {
   id: string;
   label: string;
+  offTurn: boolean;
 }
 
 /**
@@ -10,13 +22,18 @@ export interface ImpersonateOption {
  *
  * Sources from the full session roster, not the current turn's active
  * set, so a role added mid-turn (``api.addRole``) shows up in the
- * dropdown immediately. Roles that aren't on the current turn's
- * active set get an "(off-turn)" label suffix — submitting as them
- * lands as an interjection (sidebar comment) rather than a turn
- * answer, matching the existing out-of-turn participant submit
- * semantics. The creator's own seat is always excluded (the implicit
- * default), and roles that have already submitted on the current
- * turn are filtered out so they can't be double-submitted.
+ * dropdown immediately. Roles flagged ``offTurn`` lead to interjection
+ * (sidebar) submissions rather than turn answers — matching the
+ * existing out-of-turn participant submit semantics; the Composer
+ * decorates the option and the running banner accordingly.
+ *
+ * Filters:
+ * - ``is_creator`` — the creator's own seat is the implicit default.
+ * - ``kind === "spectator"`` — the backend rejects spectator proxy
+ *   attempts (``proxy_submit_as`` raises "role X is not a player
+ *   role"); excluding them client-side avoids the dead 409 path.
+ * - already-submitted roles for the current turn — can't be
+ *   double-submitted.
  *
  * Pre-fix the source was the engine's ``activeRoleIds`` (locked at
  * turn start), which left mid-session role-adds invisible to proxy
@@ -35,24 +52,28 @@ export function buildImpersonateOptions({
   const activeSet = new Set(activeRoleIds);
   return roles
     .filter((r) => !r.is_creator)
+    .filter((r) => r.kind === "player")
     .filter((r) => !submittedSet.has(r.id))
-    .map((r) => {
-      const offTurn = !activeSet.has(r.id);
-      return {
-        id: r.id,
-        label: offTurn ? `${r.label} (off-turn)` : r.label,
-      };
-    });
+    .map((r) => ({
+      id: r.id,
+      label: r.label,
+      offTurn: !activeSet.has(r.id),
+    }));
 }
 
 /**
  * Issue #80 bonus: predicate for the "Just joined? You'll be brought
  * into the next turn" chip in the participant Play view.
  *
- * Fires when:
+ * Fires when ALL of:
  * - the session is mid-PLAY (``AI_PROCESSING`` or ``AWAITING_PLAYERS``);
  * - the local participant is **not** in the current turn's active
- *   set (so the AI hasn't called on them yet); AND
+ *   set (so the AI hasn't called on them yet);
+ * - the local participant is a **player** (spectators get their own
+ *   read-only intro and never get called on, so a chip promising
+ *   "you'll be brought in" is a false promise for them);
+ * - the local participant is **not the creator** (the creator's seat
+ *   is the session author, not a "just joined" guest);
  * - they have no prior PLAYER messages from their role_id (heuristic
  *   for "just joined this session", separating them from a
  *   passive-but-already-engaged participant).
@@ -65,13 +86,19 @@ export function isMidSessionJoiner({
   iAmActive,
   messages,
   selfRoleId,
+  selfRoleKind,
+  selfIsCreator,
 }: {
   sessionState: string;
   iAmActive: boolean;
   messages: ReadonlyArray<{ kind: string; role_id?: string | null }>;
   selfRoleId: string | null;
+  selfRoleKind?: "player" | "spectator";
+  selfIsCreator?: boolean;
 }): boolean {
   if (iAmActive) return false;
+  if (selfIsCreator) return false;
+  if (selfRoleKind === "spectator") return false;
   if (sessionState !== "AI_PROCESSING" && sessionState !== "AWAITING_PLAYERS") {
     return false;
   }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -19,6 +19,7 @@ import { RolesPanel } from "../components/RolesPanel";
 import { SessionActivityPanel } from "../components/SessionActivityPanel";
 import { SetupChat } from "../components/SetupChat";
 import { Transcript } from "../components/Transcript";
+import { buildImpersonateOptions } from "../lib/proxy";
 import { useStickyScroll } from "../lib/useStickyScroll";
 import { ServerEvent, WsClient } from "../lib/ws";
 
@@ -1330,23 +1331,18 @@ export function Facilitator() {
                 />
               ) : null}
               {(() => {
-                // Creator-only "respond as" dropdown: list every active
-                // role except the creator's own seat. Lets a solo
-                // tester answer for SOC Analyst etc. without juggling
-                // browser tabs. Empty when no other seats need a voice.
-                const impersonateOptions = activeRoleIds
-                  .filter((rid) => rid !== state.creatorRoleId)
-                  .filter(
-                    (rid) =>
-                      !(snapshot.current_turn?.submitted_role_ids ?? []).includes(rid),
-                  )
-                  .map((rid) => {
-                    const r = snapshot.roles.find((x) => x.id === rid);
-                    return {
-                      id: rid,
-                      label: r ? r.label : rid,
-                    };
-                  });
+                // Creator-only "respond as" dropdown. See
+                // ``buildImpersonateOptions`` for the filter logic
+                // (issue #80 — sources from the full roster so a
+                // mid-session role-add appears immediately, with an
+                // "(off-turn)" suffix when the role isn't on the
+                // current turn's active set).
+                const impersonateOptions = buildImpersonateOptions({
+                  roles: snapshot.roles,
+                  activeRoleIds,
+                  submittedRoleIds:
+                    snapshot.current_turn?.submitted_role_ids ?? [],
+                });
                 const selfRole = snapshot.roles.find(
                   (r) => r.id === state.creatorRoleId,
                 );

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -90,6 +90,11 @@ export function Play({ sessionId, token }: Props) {
   // ~4s on the first render of the main view after the transition.
   const [sessionStartedFlash, setSessionStartedFlash] = useState(false);
   const wasWaitingRef = useRef(false);
+  // Issue #80 bonus: tracks the previous value of the joiner-chip
+  // predicate so the boundary log only fires on the false→true edge.
+  // Pre-fix the log fired every time the WS replaced ``snapshot``
+  // (multiple times per turn) — too noisy in production.
+  const wasShowingMidSessionChipRef = useRef(false);
   const wsRef = useRef<WsClient | null>(null);
   const forceAdvanceTimerRef = useRef<number | null>(null);
 
@@ -474,24 +479,43 @@ export function Play({ sessionId, token }: Props) {
   // but shouldn't have" has no telemetry trail. Effect lives ABOVE
   // the early returns so the hook count is stable across renders;
   // the predicate guards on snapshot existing.
+  //
+  // The full ``snapshot`` object is in the dep array (it's a single
+  // reference that gets replaced on every WS event), but the log
+  // itself is gated on the previous-value ref so it only fires on
+  // the false→true edge — pre-fix it churned a line on every
+  // turn-message arrival even when the chip was already on screen.
+  // ``console.debug`` (not info) keeps this out of production
+  // console noise; the boundary log is for operators inspecting a
+  // stuck-chip report.
   useEffect(() => {
-    if (!snapshot || !selfRoleId) return;
-    const myRoleHere = snapshot.roles.find((r) => r.id === selfRoleId);
-    const activeIds = snapshot.current_turn?.active_role_ids ?? [];
-    const show = isMidSessionJoiner({
-      sessionState: snapshot.state,
-      iAmActive: activeIds.includes(selfRoleId),
-      messages: snapshot.messages,
-      selfRoleId,
-      selfRoleKind: myRoleHere?.kind,
-      selfIsCreator: myRoleHere?.is_creator ?? false,
-    });
-    if (!show) return;
-    console.info("[play] mid-session-joiner chip", {
-      session_id: sessionId,
-      role_id: selfRoleId,
-      session_state: snapshot.state,
-    });
+    let show = false;
+    if (snapshot && selfRoleId) {
+      const myRoleHere = snapshot.roles.find((r) => r.id === selfRoleId);
+      const activeIds = snapshot.current_turn?.active_role_ids ?? [];
+      show = isMidSessionJoiner({
+        sessionState: snapshot.state,
+        iAmActive: activeIds.includes(selfRoleId),
+        messages: snapshot.messages,
+        selfRoleId,
+        selfRoleKind: myRoleHere?.kind,
+        selfIsCreator: myRoleHere?.is_creator ?? false,
+      });
+    }
+    if (show && !wasShowingMidSessionChipRef.current) {
+      console.debug("[play] mid-session-joiner chip on", {
+        session_id: sessionId,
+        role_id: selfRoleId,
+        session_state: snapshot?.state,
+      });
+    } else if (!show && wasShowingMidSessionChipRef.current) {
+      console.debug("[play] mid-session-joiner chip off", {
+        session_id: sessionId,
+        role_id: selfRoleId,
+        session_state: snapshot?.state,
+      });
+    }
+    wasShowingMidSessionChipRef.current = show;
   }, [snapshot, selfRoleId, sessionId]);
 
   // Issue #76 transition cue: detect the SETUP/BRIEFING →
@@ -502,11 +526,15 @@ export function Play({ sessionId, token }: Props) {
   useEffect(() => {
     const isWaitingNow =
       snapshot?.state === "SETUP" || snapshot?.state === "BRIEFING";
-    if (
-      wasWaitingRef.current
-      && !isWaitingNow
-      && Boolean(effectiveDisplayName)
-    ) {
+    const wasWaiting = wasWaitingRef.current;
+    // Always update the ref before any conditional return — pre-fix
+    // the early `return` left ``wasWaitingRef.current`` stuck at
+    // ``true`` after the first flash, so a later state cycle (e.g.
+    // AWAITING_PLAYERS → AI_PROCESSING returning ``isWaitingNow ===
+    // false`` again) could re-trigger the banner. Update first,
+    // then decide whether to fire.
+    wasWaitingRef.current = isWaitingNow;
+    if (wasWaiting && !isWaitingNow && Boolean(effectiveDisplayName)) {
       console.info("[play] session started — exiting waiting variant", {
         session_id: sessionId,
         new_state: snapshot?.state,
@@ -515,7 +543,6 @@ export function Play({ sessionId, token }: Props) {
       const id = window.setTimeout(() => setSessionStartedFlash(false), 4000);
       return () => window.clearTimeout(id);
     }
-    wasWaitingRef.current = isWaitingNow;
     return undefined;
   }, [snapshot?.state, effectiveDisplayName, sessionId]);
 
@@ -1066,8 +1093,11 @@ export function JoinIntro({
   // screen. Cleared on unmount or variant flip so we don't churn
   // setTimeout calls in the form variant. Per-tip dwell scales with
   // tip length — UI/UX review flagged 7s as borderline for the
-  // longest tip; ~25 chars/sec at typical reading speed gives a
-  // floor of 7s and a ceiling of ~10s for the longest tips.
+  // longest tip; the divisor of 14 is "comfortable" reading speed
+  // (~14 chars/sec, accommodating non-native speakers and dyslexic
+  // readers — slower than the 200-250 wpm "fluent silent reading"
+  // benchmark on purpose). With a 7s floor and the current 5-tip
+  // array, dwell ranges 7–10s.
   useEffect(() => {
     if (!isWaitingVariant) return;
     const dwellMs = Math.max(

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -460,13 +460,27 @@ export function Play({ sessionId, token }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverDisplayName, displayName, sessionId, token, myRoleFromSnapshot?.id]);
 
-  if (!effectiveDisplayName) {
+  // Issue #76: a participant who has submitted their display name but
+  // arrived while the creator is still drafting the plan was previously
+  // dropped onto the main page with a blank transcript and a disabled
+  // composer pinned to the bottom — "looks funny with a chat box and
+  // all the blank space" (issue comment). Hold them on JoinIntro
+  // instead, with the form swapped for a "Waiting for the facilitator
+  // to start" panel + tip carousel. Auto-resolves the moment the
+  // session transitions to AWAITING_PLAYERS / AI_PROCESSING / etc.
+  const isWaitingForSessionStart =
+    snapshot?.state === "SETUP" || snapshot?.state === "BRIEFING";
+
+  if (!effectiveDisplayName || isWaitingForSessionStart) {
     // Pre-fix this was a tiny "what's your name?" dialog that operators
     // routinely missed (the user's report — "I'm not sure if Bridget
     // was prompted to enter her name at all"). The intro page now
     // names the role, sets expectations for AI interaction, and
     // posts the entered name to the server so peers see it (was:
-    // localStorage-only, invisible to other clients).
+    // localStorage-only, invisible to other clients). When ``hasName``
+    // is true but the session hasn't started, the form is replaced by
+    // a spinner panel so the user has somewhere friendly to wait
+    // (issue #76).
     return (
       <JoinIntro
         sessionId={sessionId}
@@ -478,6 +492,9 @@ export function Play({ sessionId, token }: Props) {
         sessionState={snapshot?.state}
         snapshotLoaded={snapshot !== null}
         snapshotError={snapshot === null ? error : null}
+        hasName={Boolean(effectiveDisplayName)}
+        joinedDisplayName={effectiveDisplayName}
+        joinedSeatCount={presence.size}
         onRetry={() => {
           setError(null);
           refreshSnapshot();
@@ -836,7 +853,37 @@ interface JoinIntroProps {
   /** Retry handler for the snapshot-error branch. */
   onRetry: () => void;
   onJoined: (name: string) => void;
+  /** Issue #76: the participant has submitted (or already had on the
+   *  server) a display name, so the name+Begin form is unnecessary.
+   *  When this is true AND the session is still SETUP/BRIEFING, we
+   *  swap the form for a "Waiting for the facilitator to start"
+   *  panel with a tip carousel. Otherwise it's the original form. */
+  hasName?: boolean;
+  /** Display name to show in the waiting-panel subhead. Only read
+   *  when ``hasName`` is true. */
+  joinedDisplayName?: string | null;
+  /** Number of *other* roles the WS layer has reported as connected.
+   *  Renders as "N seats joined" momentum cue in the waiting panel.
+   *  Sourced from the parent's presence Set so it auto-updates as
+   *  peers open their tabs. */
+  joinedSeatCount?: number;
 }
+
+/**
+ * Tip carousel content for the "joined, waiting for session to start"
+ * variant of JoinIntro (issue #76). Each tip is short — the panel is
+ * a wait state, not a tutorial — and rotates every ~7 seconds. Order
+ * is intentional: introduces the conversational tone first, then
+ * deepens into mechanics.
+ */
+const WAITING_TIPS: readonly string[] = [
+  "When the AI throws an inject, ask clarifying questions before committing to an action.",
+  "Want logs? Just ask — \"pull the auth logs\" or \"what does Defender show?\". The AI will produce realistic synthetic data.",
+  "Disagree with a teammate? Say so. The AI tracks decisions and dissents in the AAR.",
+  "Out of your lane? \"Loop in Legal\" or \"hand off to Comms\" — the AI will pivot the conversation.",
+  "There's no scoring. The AAR captures decisions and rationale, not right-versus-wrong answers.",
+];
+const WAITING_TIP_ROTATE_MS = 7000;
 
 /**
  * Replaces the prior tiny "what's your name?" dialog. The user reported
@@ -856,7 +903,7 @@ interface JoinIntroProps {
  * ship the participant into the chat as fast as possible while still
  * giving them the prereq context.
  */
-function JoinIntro({
+export function JoinIntro({
   sessionId,
   token,
   roleLabel,
@@ -868,10 +915,41 @@ function JoinIntro({
   snapshotError,
   onRetry,
   onJoined,
+  hasName = false,
+  joinedDisplayName = null,
+  joinedSeatCount = 0,
 }: JoinIntroProps) {
   const [name, setName] = useState(roleExistingDisplayName ?? "");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tip carousel index for the waiting variant (issue #76). Lives at
+  // the top of the component (not inside a conditional) so React's
+  // hook order rule is respected when the user transitions from the
+  // form variant to the waiting variant inside a single mount.
+  const [tipIndex, setTipIndex] = useState(0);
+  const isWaitingVariant =
+    hasName && (sessionState === "SETUP" || sessionState === "BRIEFING");
+  // Log the variant so a "stuck on JoinIntro" report has a clear trail
+  // — the gate decision lives in Play.tsx but it's the effective UI
+  // state here that the user reports.
+  useEffect(() => {
+    console.info("[play] join-intro variant", {
+      session_id: sessionId,
+      session_state: sessionState,
+      has_name: hasName,
+      variant: isWaitingVariant ? "waiting" : "form",
+    });
+  }, [sessionId, sessionState, hasName, isWaitingVariant]);
+  // Rotate the tip carousel only while the waiting variant is on
+  // screen. Cleared on unmount or variant flip so we don't churn
+  // setTimeout calls in the form variant.
+  useEffect(() => {
+    if (!isWaitingVariant) return;
+    const id = setInterval(() => {
+      setTipIndex((i) => (i + 1) % WAITING_TIPS.length);
+    }, WAITING_TIP_ROTATE_MS);
+    return () => clearInterval(id);
+  }, [isWaitingVariant]);
 
   // Pre-fill the entered name from the snapshot when it lands (so a
   // returning player whose name is already on the server doesn't have
@@ -1075,64 +1153,122 @@ function JoinIntro({
           )}
         </section>
 
-        <form onSubmit={submit} className="flex flex-col gap-2">
-          <label
-            htmlFor="display-name"
-            className="text-xs uppercase tracking-widest text-slate-300"
+        {isWaitingVariant ? (
+          /* Issue #76: form is replaced by a waiting panel once the
+             user has a display name but the session hasn't started.
+             Pre-fix the participant was bumped to the main view with
+             a blank transcript and a disabled composer pinned at the
+             bottom. Now they stay on this page with a friendly
+             spinner, the role context they already have, and a
+             rotating tip carousel so they have something to read. */
+          <section
+            aria-labelledby="waiting-heading"
+            data-testid="join-intro-waiting"
+            className="flex flex-col gap-3 rounded border border-emerald-700/40 bg-emerald-950/20 p-4"
+            role="status"
+            aria-live="polite"
           >
-            Your display name (visible to the rest of the team)
-          </label>
-          {roleExistingDisplayName ? (
-            <p className="text-xs text-slate-400">
-              Welcome back — your saved name is pre-filled. Click Begin
-              to rejoin, or edit if you'd like to change it.
-            </p>
-          ) : null}
-          <input
-            id="display-name"
-            // ``autoFocus`` removed: screen-reader users would land
-            // mid-form and miss the heading + "How to play" guide
-            // (which is the whole point of this page). Sighted users
-            // can tab into the input in one keystroke.
-            // ``required`` removed: the JS guard + disabled-Begin
-            // button already cover empty submission, and the browser
-            // tooltip from native required would conflict with our
-            // own error surface.
-            // ``sessionEnded`` does NOT disable the input — the copy
-            // below tells the user they can still join in read-only
-            // mode after entering a name. Disabling the input made
-            // that promise impossible to keep for first-time joiners
-            // of an ENDED session.
-            disabled={submitting}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. Bridget"
-            maxLength={64}
-            className="rounded border border-slate-700 bg-slate-950 p-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
-          />
-          {error ? (
-            <p className="text-sm text-red-400" role="alert">
-              {error}
-            </p>
-          ) : null}
-          {sessionEnded ? (
-            <p className="text-sm text-amber-300" role="status">
-              This session has already ended. You can still join in
-              read-only mode after entering a name, but no new
-              responses will be accepted.
-            </p>
-          ) : null}
-          <button
-            type="submit"
-            disabled={submitting || !name.trim()}
-            // Full-width tap target on mobile (avoids cramped right-
-            // aligned button when the on-screen keyboard pushes the
-            // viewport up); right-aligned on sm+.
-            className="mt-2 self-stretch rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:opacity-60 sm:self-end"
-          >
-            {submitting ? "Joining…" : "Begin"}
-          </button>
-        </form>
+            <div className="flex items-center gap-3">
+              <span
+                aria-hidden="true"
+                className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-emerald-400 border-t-transparent"
+              />
+              <h2
+                id="waiting-heading"
+                className="text-sm font-semibold text-emerald-200"
+              >
+                {sessionState === "BRIEFING"
+                  ? "The AI is preparing the scenario brief…"
+                  : "Waiting for your facilitator to start the scenario…"}
+              </h2>
+            </div>
+            {roleLabel && joinedDisplayName ? (
+              <p className="text-sm text-slate-200">
+                You're seated as{" "}
+                <span className="font-semibold">{roleLabel}</span>{" "}
+                <span className="text-slate-400">({joinedDisplayName})</span>
+                . You'll be brought in automatically when it begins.
+              </p>
+            ) : null}
+            {joinedSeatCount > 0 ? (
+              <p className="text-xs text-slate-400">
+                {joinedSeatCount === 1
+                  ? "1 seat joined so far."
+                  : `${joinedSeatCount} seats joined so far.`}
+              </p>
+            ) : null}
+            <div
+              className="rounded border border-slate-700 bg-slate-950/40 p-3"
+              data-testid="join-intro-tip"
+            >
+              <p className="text-[0.65rem] uppercase tracking-widest text-slate-400">
+                While you wait
+              </p>
+              <p className="mt-1 text-sm leading-relaxed text-slate-200">
+                {WAITING_TIPS[tipIndex]}
+              </p>
+            </div>
+          </section>
+        ) : (
+          <form onSubmit={submit} className="flex flex-col gap-2">
+            <label
+              htmlFor="display-name"
+              className="text-xs uppercase tracking-widest text-slate-300"
+            >
+              Your display name (visible to the rest of the team)
+            </label>
+            {roleExistingDisplayName ? (
+              <p className="text-xs text-slate-400">
+                Welcome back — your saved name is pre-filled. Click Begin
+                to rejoin, or edit if you'd like to change it.
+              </p>
+            ) : null}
+            <input
+              id="display-name"
+              // ``autoFocus`` removed: screen-reader users would land
+              // mid-form and miss the heading + "How to play" guide
+              // (which is the whole point of this page). Sighted users
+              // can tab into the input in one keystroke.
+              // ``required`` removed: the JS guard + disabled-Begin
+              // button already cover empty submission, and the browser
+              // tooltip from native required would conflict with our
+              // own error surface.
+              // ``sessionEnded`` does NOT disable the input — the copy
+              // below tells the user they can still join in read-only
+              // mode after entering a name. Disabling the input made
+              // that promise impossible to keep for first-time joiners
+              // of an ENDED session.
+              disabled={submitting}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Bridget"
+              maxLength={64}
+              className="rounded border border-slate-700 bg-slate-950 p-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            {error ? (
+              <p className="text-sm text-red-400" role="alert">
+                {error}
+              </p>
+            ) : null}
+            {sessionEnded ? (
+              <p className="text-sm text-amber-300" role="status">
+                This session has already ended. You can still join in
+                read-only mode after entering a name, but no new
+                responses will be accepted.
+              </p>
+            ) : null}
+            <button
+              type="submit"
+              disabled={submitting || !name.trim()}
+              // Full-width tap target on mobile (avoids cramped right-
+              // aligned button when the on-screen keyboard pushes the
+              // viewport up); right-aligned on sm+.
+              className="mt-2 self-stretch rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:opacity-60 sm:self-end"
+            >
+              {submitting ? "Joining…" : "Begin"}
+            </button>
+          </form>
+        )}
       </article>
     </main>
   );

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -5,6 +5,7 @@ import { CriticalEventBanner } from "../components/CriticalEventBanner";
 import { RightSidebar } from "../components/RightSidebar";
 import { RoleRoster } from "../components/RoleRoster";
 import { Transcript } from "../components/Transcript";
+import { isMidSessionJoiner } from "../lib/proxy";
 import { useStickyScroll } from "../lib/useStickyScroll";
 import { ServerEvent, WsClient } from "../lib/ws";
 
@@ -673,6 +674,24 @@ export function Play({ sessionId, token }: Props) {
           {otherPending.length > 0
             ? `Waiting on ${otherPending.join(", ")}.`
             : "Waiting for the AI to respond."}
+        </div>
+      ) : isMidSessionJoiner({
+        sessionState: snapshot.state,
+        iAmActive,
+        messages: snapshot.messages,
+        selfRoleId,
+      }) ? (
+        // Issue #80 bonus: cue for a participant whose role was added
+        // mid-session. See ``isMidSessionJoiner`` for the predicate;
+        // here we just render the chip when it's true.
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="mid-session-joiner-chip"
+          className="bg-slate-800 px-4 py-2 text-center text-xs text-slate-200 shadow"
+        >
+          Just joined? You'll be brought into the next turn — sit
+          tight, the current beat is finishing up.
         </div>
       ) : null}
       <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-4 p-4 lg:min-h-0 lg:grid-cols-[220px_1fr_280px] lg:overflow-hidden">

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -82,6 +82,14 @@ export function Play({ sessionId, token }: Props) {
   // backend in-flight gate. Prevents the triple-banner cascade from a
   // double/triple click (issue #63).
   const [forceAdvanceCooldown, setForceAdvanceCooldown] = useState(false);
+  // Issue #76 transition cue: when the participant exits the JoinIntro
+  // waiting variant (state goes SETUP/BRIEFING → AWAITING_PLAYERS) the
+  // page used to hard-cut to the chat layout, leaving a screen-reader
+  // user with no signal that the screen they were on is gone. This
+  // flag drives a transient "Session has started" banner shown for
+  // ~4s on the first render of the main view after the transition.
+  const [sessionStartedFlash, setSessionStartedFlash] = useState(false);
+  const wasWaitingRef = useRef(false);
   const wsRef = useRef<WsClient | null>(null);
   const forceAdvanceTimerRef = useRef<number | null>(null);
 
@@ -461,6 +469,56 @@ export function Play({ sessionId, token }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverDisplayName, displayName, sessionId, token, myRoleFromSnapshot?.id]);
 
+  // Issue #80 bonus: log when the mid-session-joiner chip is on
+  // screen. Pure boundary log — without it, "Bridget got the chip
+  // but shouldn't have" has no telemetry trail. Effect lives ABOVE
+  // the early returns so the hook count is stable across renders;
+  // the predicate guards on snapshot existing.
+  useEffect(() => {
+    if (!snapshot || !selfRoleId) return;
+    const myRoleHere = snapshot.roles.find((r) => r.id === selfRoleId);
+    const activeIds = snapshot.current_turn?.active_role_ids ?? [];
+    const show = isMidSessionJoiner({
+      sessionState: snapshot.state,
+      iAmActive: activeIds.includes(selfRoleId),
+      messages: snapshot.messages,
+      selfRoleId,
+      selfRoleKind: myRoleHere?.kind,
+      selfIsCreator: myRoleHere?.is_creator ?? false,
+    });
+    if (!show) return;
+    console.info("[play] mid-session-joiner chip", {
+      session_id: sessionId,
+      role_id: selfRoleId,
+      session_state: snapshot.state,
+    });
+  }, [snapshot, selfRoleId, sessionId]);
+
+  // Issue #76 transition cue: detect the SETUP/BRIEFING →
+  // AWAITING_PLAYERS flip and surface a transient "Session started"
+  // banner so the participant has an explicit acknowledgement that
+  // their JoinIntro screen was replaced (UI/UX review HIGH: pre-fix
+  // the page hard-cut and a screen-reader user had no signal).
+  useEffect(() => {
+    const isWaitingNow =
+      snapshot?.state === "SETUP" || snapshot?.state === "BRIEFING";
+    if (
+      wasWaitingRef.current
+      && !isWaitingNow
+      && Boolean(effectiveDisplayName)
+    ) {
+      console.info("[play] session started — exiting waiting variant", {
+        session_id: sessionId,
+        new_state: snapshot?.state,
+      });
+      setSessionStartedFlash(true);
+      const id = window.setTimeout(() => setSessionStartedFlash(false), 4000);
+      return () => window.clearTimeout(id);
+    }
+    wasWaitingRef.current = isWaitingNow;
+    return undefined;
+  }, [snapshot?.state, effectiveDisplayName, sessionId]);
+
   // Issue #76: a participant who has submitted their display name but
   // arrived while the creator is still drafting the plan was previously
   // dropped onto the main page with a blank transcript and a disabled
@@ -495,7 +553,14 @@ export function Play({ sessionId, token }: Props) {
         snapshotError={snapshot === null ? error : null}
         hasName={Boolean(effectiveDisplayName)}
         joinedDisplayName={effectiveDisplayName}
-        joinedSeatCount={presence.size}
+        // Subtract the local participant from the count — UI/UX
+        // review: pre-fix "1 seat joined" was just *me*, which read
+        // as lonely on a cue meant to signal "the room is filling
+        // up". Floor at 0 in case presence hasn't yet seen self.
+        joinedSeatCount={Math.max(
+          0,
+          presence.size - (selfRoleId && presence.has(selfRoleId) ? 1 : 0),
+        )}
         onRetry={() => {
           setError(null);
           refreshSnapshot();
@@ -603,6 +668,20 @@ export function Play({ sessionId, token }: Props) {
       : composerEnabled
         ? "Add a comment"
         : "Your message";
+  // Issue #80 bonus: re-derive the mid-session-joiner chip flag for
+  // the render block. The predicate's log breadcrumb fires from a
+  // hook declared *above* the early returns (so the hook count is
+  // stable across renders) — this re-compute is a cheap pure call
+  // that the React reconciler memo-deduplicates.
+  const showMidSessionJoinerChip = isMidSessionJoiner({
+    sessionState: snapshot.state,
+    iAmActive,
+    messages: snapshot.messages,
+    selfRoleId,
+    selfRoleKind: myRole?.kind,
+    selfIsCreator: myRole?.is_creator ?? false,
+  });
+
   // Plain-English placeholder copy — the user-persona review flagged
   // "interject" as jargon that reads as rude. We surface the
   // distinction (counts vs. sidebar) in the label + the post-submit
@@ -623,6 +702,21 @@ export function Play({ sessionId, token }: Props) {
 
   return (
     <main className="flex min-h-screen flex-col lg:h-screen lg:min-h-0 lg:overflow-hidden">
+      {sessionStartedFlash ? (
+        // Issue #76 transition cue (UI/UX review HIGH): the screen
+        // the participant was on (JoinIntro waiting variant) just
+        // unmounted; without this banner SR users had no signal.
+        // ``aria-live="assertive"`` because this announcement
+        // supersedes any ongoing tip-rotation announcement.
+        <div
+          role="status"
+          aria-live="assertive"
+          data-testid="session-started-flash"
+          className="bg-emerald-700 px-4 py-2 text-center text-sm font-semibold text-white shadow-lg"
+        >
+          Session started — you're in.
+        </div>
+      ) : null}
       {criticalBanner ? (
         <CriticalEventBanner
           {...criticalBanner}
@@ -675,21 +769,22 @@ export function Play({ sessionId, token }: Props) {
             ? `Waiting on ${otherPending.join(", ")}.`
             : "Waiting for the AI to respond."}
         </div>
-      ) : isMidSessionJoiner({
-        sessionState: snapshot.state,
-        iAmActive,
-        messages: snapshot.messages,
-        selfRoleId,
-      }) ? (
+      ) : showMidSessionJoinerChip ? (
         // Issue #80 bonus: cue for a participant whose role was added
-        // mid-session. See ``isMidSessionJoiner`` for the predicate;
-        // here we just render the chip when it's true.
+        // mid-session. See ``isMidSessionJoiner`` for the predicate
+        // and the useEffect above for the breadcrumb log. The leading
+        // sky stripe + ⤴ glyph distinguish this from the "Submitted
+        // as …" banner above (UI/UX review: both used the same slate
+        // styling and were indistinguishable).
         <div
           role="status"
           aria-live="polite"
           data-testid="mid-session-joiner-chip"
-          className="bg-slate-800 px-4 py-2 text-center text-xs text-slate-200 shadow"
+          className="border-l-4 border-sky-600 bg-slate-800 px-4 py-2 text-xs text-slate-200 shadow"
         >
+          <span aria-hidden="true" className="mr-1.5 text-sky-400">
+            ⤴
+          </span>
           Just joined? You'll be brought into the next turn — sit
           tight, the current beat is finishing up.
         </div>
@@ -900,7 +995,7 @@ const WAITING_TIPS: readonly string[] = [
   "Want logs? Just ask — \"pull the auth logs\" or \"what does Defender show?\". The AI will produce realistic synthetic data.",
   "Disagree with a teammate? Say so. The AI tracks decisions and dissents in the AAR.",
   "Out of your lane? \"Loop in Legal\" or \"hand off to Comms\" — the AI will pivot the conversation.",
-  "There's no scoring. The AAR captures decisions and rationale, not right-versus-wrong answers.",
+  "Focus on your reasoning — the AAR captures decisions and rationale, not right-vs-wrong scoring.",
 ];
 const WAITING_TIP_ROTATE_MS = 7000;
 
@@ -948,27 +1043,42 @@ export function JoinIntro({
   const [tipIndex, setTipIndex] = useState(0);
   const isWaitingVariant =
     hasName && (sessionState === "SETUP" || sessionState === "BRIEFING");
-  // Log the variant so a "stuck on JoinIntro" report has a clear trail
-  // — the gate decision lives in Play.tsx but it's the effective UI
-  // state here that the user reports.
+  // Log the variant so a "stuck on JoinIntro" report has a clear
+  // trail. ``console.debug`` (not info) so the breadcrumb doesn't
+  // crowd the production console — pair of enter+exit lines keyed
+  // on ``isWaitingVariant`` so the operator can see when the user
+  // *left* the waiting state, not just when they entered it.
   useEffect(() => {
-    console.info("[play] join-intro variant", {
+    console.debug("[play] join-intro variant enter", {
       session_id: sessionId,
       session_state: sessionState,
       has_name: hasName,
       variant: isWaitingVariant ? "waiting" : "form",
     });
+    return () => {
+      console.debug("[play] join-intro variant exit", {
+        session_id: sessionId,
+        was_variant: isWaitingVariant ? "waiting" : "form",
+      });
+    };
   }, [sessionId, sessionState, hasName, isWaitingVariant]);
   // Rotate the tip carousel only while the waiting variant is on
   // screen. Cleared on unmount or variant flip so we don't churn
-  // setTimeout calls in the form variant.
+  // setTimeout calls in the form variant. Per-tip dwell scales with
+  // tip length — UI/UX review flagged 7s as borderline for the
+  // longest tip; ~25 chars/sec at typical reading speed gives a
+  // floor of 7s and a ceiling of ~10s for the longest tips.
   useEffect(() => {
     if (!isWaitingVariant) return;
-    const id = setInterval(() => {
+    const dwellMs = Math.max(
+      WAITING_TIP_ROTATE_MS,
+      Math.ceil(WAITING_TIPS[tipIndex].length / 14) * 1000,
+    );
+    const id = setTimeout(() => {
       setTipIndex((i) => (i + 1) % WAITING_TIPS.length);
-    }, WAITING_TIP_ROTATE_MS);
-    return () => clearInterval(id);
-  }, [isWaitingVariant]);
+    }, dwellMs);
+    return () => clearTimeout(id);
+  }, [isWaitingVariant, tipIndex]);
 
   // Pre-fill the entered name from the snapshot when it lands (so a
   // returning player whose name is already on the server doesn't have
@@ -1179,18 +1289,24 @@ export function JoinIntro({
              a blank transcript and a disabled composer pinned at the
              bottom. Now they stay on this page with a friendly
              spinner, the role context they already have, and a
-             rotating tip carousel so they have something to read. */
+             rotating tip carousel so they have something to read.
+
+             ARIA: ``role="status"`` lives on the section so AT
+             initially announces the variant, but ``aria-live`` is
+             scoped to the rotating tip element only (UI/UX review:
+             putting aria-live on the whole section caused the
+             headline + role + seat count to re-announce on every
+             7-10s tip rotation, which is noise). */
           <section
             aria-labelledby="waiting-heading"
             data-testid="join-intro-waiting"
             className="flex flex-col gap-3 rounded border border-emerald-700/40 bg-emerald-950/20 p-4"
             role="status"
-            aria-live="polite"
           >
             <div className="flex items-center gap-3">
               <span
                 aria-hidden="true"
-                className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-emerald-400 border-t-transparent"
+                className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-emerald-400 border-t-transparent motion-reduce:animate-none"
               />
               <h2
                 id="waiting-heading"
@@ -1198,32 +1314,47 @@ export function JoinIntro({
               >
                 {sessionState === "BRIEFING"
                   ? "The AI is preparing the scenario brief…"
-                  : "Waiting for your facilitator to start the scenario…"}
+                  : joinedDisplayName
+                    ? `Welcome, ${joinedDisplayName} — waiting for your facilitator to start the scenario…`
+                    : "Waiting for your facilitator to start the scenario…"}
               </h2>
             </div>
-            {roleLabel && joinedDisplayName ? (
+            {roleLabel ? (
               <p className="text-sm text-slate-200">
                 You're seated as{" "}
-                <span className="font-semibold">{roleLabel}</span>{" "}
-                <span className="text-slate-400">({joinedDisplayName})</span>
+                <span className="font-semibold">{roleLabel}</span>
+                {joinedDisplayName ? (
+                  <>
+                    {" "}
+                    <span className="text-slate-400">
+                      ({joinedDisplayName})
+                    </span>
+                  </>
+                ) : null}
                 . You'll be brought in automatically when it begins.
               </p>
             ) : null}
             {joinedSeatCount > 0 ? (
               <p className="text-xs text-slate-400">
                 {joinedSeatCount === 1
-                  ? "1 seat joined so far."
-                  : `${joinedSeatCount} seats joined so far.`}
+                  ? "1 other seat is connected."
+                  : `${joinedSeatCount} other seats are connected.`}
               </p>
             ) : null}
             <div
               className="rounded border border-slate-700 bg-slate-950/40 p-3"
               data-testid="join-intro-tip"
             >
-              <p className="text-[0.65rem] uppercase tracking-widest text-slate-400">
-                While you wait
+              <p className="flex items-center justify-between text-[0.65rem] uppercase tracking-widest text-slate-400">
+                <span>While you wait</span>
+                <span aria-hidden="true">
+                  {tipIndex + 1} / {WAITING_TIPS.length}
+                </span>
               </p>
-              <p className="mt-1 text-sm leading-relaxed text-slate-200">
+              <p
+                className="mt-1 text-sm leading-relaxed text-slate-200"
+                aria-live="polite"
+              >
                 {WAITING_TIPS[tipIndex]}
               </p>
             </div>


### PR DESCRIPTION
## Summary

Phase B of the multi-issue plan (`/root/.claude/plans/fluffy-brewing-scott.md`) — two participant-facing affordance fixes plus the review-cycle follow-ups.

- **#76** — A participant who clicked their join link while the creator was still drafting the plan was bounced to a blank chat shell with a disabled composer at the bottom. Now they stay on `JoinIntro` with the form replaced by a green-spinner waiting panel: personalised "Welcome, {name}" headline, role context, "N other seats are connected" momentum cue, and a length-aware "While you wait" tip carousel with a `Tip n / N` indicator. Auto-resolves on `SETUP`/`BRIEFING` → `AWAITING_PLAYERS` with a transient `"Session started — you're in."` banner so the screen-reader user has explicit acknowledgement of the layout flip.
- **#80** — The creator's "Respond as" dropdown now sources from `snapshot.roles` instead of the engine's per-turn `activeRoleIds`. Mid-session role-adds appear in the dropdown immediately. Off-turn roles are flagged via a structured `offTurn` field on `ImpersonateOption`, which the Composer renders as `"Legal — sidebar (off-turn)"` in the option and `"Submitting as Legal (sidebar — not a turn answer)"` in the proxy banner — eliminating the pre-fix `"Legal (off-turn) (proxy)"` double-suffix collision. Spectators are filtered out (the backend rejects spectator proxy submits, so excluding them client-side avoids the dead 409 path).
- **#80 bonus** — A new `isMidSessionJoiner` predicate drives a slate `"Just joined? You'll be brought into the next turn"` chip on the new participant's Play view, distinguished visually from the existing `"Submitted as …"` banner via a sky left-border + ⤴ glyph. Excludes spectators and the creator's own seat (would be a false promise / wrong audience). Logs render via a top-level `useEffect` for telemetry.

The underlying engine question (should mid-added roles join the running turn or wait?) is tracked separately as #90 — closing keywords intentionally omitted, per the CLAUDE.md guidance.

### What's in this PR

| Surface | Change |
|---|---|
| `frontend/src/lib/proxy.ts` (new) | `buildImpersonateOptions` + `isMidSessionJoiner` as pure helpers, fully unit-tested |
| `frontend/src/pages/Play.tsx` | JoinIntro `hasName`/`joinedDisplayName`/`joinedSeatCount` props + waiting variant render + transition flash + mid-session chip + paired enter/exit variant logs |
| `frontend/src/pages/Facilitator.tsx` | Dropdown source switch via `buildImpersonateOptions` |
| `frontend/src/components/Composer.tsx` | Renders the new `offTurn` flag (option label, banner, submit-button label) |
| `frontend/src/__tests__/JoinIntro.waiting.test.tsx` (new) | 11 cases — variant gating, ARIA scope, personalised headline, auto-resolve, tip rotation/wrap, tip n/N |
| `frontend/src/__tests__/proxyAndJoiner.test.tsx` (new) | 18 cases — dropdown filter permutations + predicate truth-table including spectator/creator |

### Sub-agent review pipeline

Six reviewers run per `CLAUDE.md` (QA, Security, UI/UX, Product, User-creator, Prompt Expert). 0 BLOCK / 0 CRITICAL.

The HIGH list returned by the pipeline was addressed in the second commit on this branch (`phase-b: address sub-agent review findings`):

- Spectator + creator-as-participant filtering for both helpers (QA HIGH ×2, Sec LOW-1, UX MEDIUM-7)
- Off-turn label collision fix via structured `ImpersonateOption.offTurn` (UX HIGH-1, User HIGH-2)
- ARIA `aria-live` re-scoped to the rotating tip element only (UX HIGH-2)
- `SETUP→AWAITING_PLAYERS` transition flash (UX HIGH-3)
- Form-to-waiting "Welcome, {name}" personalisation (User HIGH-3)
- Tip n/N indicator + length-scaled dwell + `prefers-reduced-motion` (User HIGH-1, UX MEDIUM-4, UX LOW-10)
- Mid-session-joiner chip telemetry log (QA logging policy)
- Paired enter/exit log on JoinIntro variant flips (QA logging policy)
- Demoted `console.info` → `debug` for variant logs (UX LOW-11)
- Subtract self from `joinedSeatCount` (UX MEDIUM-5)
- "There's no scoring" tip rephrased (User MEDIUM-2)

Deferred LOW items: spectator-flavored tip list, manual carousel pause, ETA on the joiner chip — all in the user's "would mention in feedback" bucket. Tracked informally in the review notes; happy to file follow-ups if any of them prove sticky in QA.

## Test plan

- [x] `cd frontend && npm test -- --run` — 95/95 (was 86 pre-Phase-B; +9 new cases)
- [x] `cd frontend && npm run lint && npm run typecheck` — clean
- [x] `cd backend && pytest -q` — 287 passed, 16 skipped
- [x] `cd backend && ruff check . && mypy app` — clean
- [ ] Manual QA path:
  - [ ] Open creator on Facilitator (state `SETUP`), participant on Play with their token. Participant sees the green-spinner waiting panel with the personalised "Welcome, {name}" headline and the rotating tip carousel.
  - [ ] Creator approves the plan; participant sees the transient "Session started — you're in." banner and the chat layout swaps in.
  - [ ] Creator adds a "Legal" role mid-turn. Their proxy dropdown lists `Legal — sidebar (off-turn)`. Selecting it shows the amber `Submitting as Legal (sidebar — not a turn answer)` banner.
  - [ ] Open the new role's join URL in a third tab. The new participant sees the slate `Just joined? You'll be brought into the next turn` chip; chip auto-dismisses when the next turn rolls them into the active set.
  - [ ] Spectator role: dropdown does NOT list them; Play view never shows the joiner chip.
  - [ ] Creator's own Play view does NOT show the joiner chip (creator authored the session, not a guest).

Closes #76
Closes #80

Tracked separately as #90 (closing keywords intentionally omitted) — engine-side question of whether mid-added roles should retroactively join the running turn.

https://claude.ai/code/session_0122qBQpK5Nwt7rBctwK4de5

---
_Generated by [Claude Code](https://claude.ai/code/session_0122qBQpK5Nwt7rBctwK4de5)_