### PR TITLE
backend: fix flaky test_ws_rejects_bad_token_with_4401

### DIFF
--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -749,7 +749,19 @@ def test_ws_rejects_bad_token_with_4401(client: TestClient) -> None:
 
     seats = _create_and_seat(client, role_count=2)
     sid = seats["session_id"]
-    bad = seats["creator_token"][:-1] + "X"
+    # Corrupt a character in the *middle* of the signature, not the
+    # final char. itsdangerous signs with HMAC-SHA256 (256 bits)
+    # encoded as 43 url-safe base64 chars — the trailing char only
+    # carries 4 meaningful bits, with 2 unused bits at the end. Each
+    # valid last-char has 3 base64 "siblings" that decode to the same
+    # signature, so swapping just ``token[-1]`` to ``"X"`` left the
+    # signature byte-identical ~6 % of the time (whenever the original
+    # ended in ``U``) and the test flaked with ``DID NOT RAISE``.
+    token = seats["creator_token"]
+    sig = token.rsplit(".", 1)[1]
+    mid = len(token) - len(sig) + len(sig) // 2
+    swap = "X" if token[mid] != "X" else "Y"
+    bad = token[:mid] + swap + token[mid + 1 :]
 
     with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect(f"/ws/sessions/{sid}?token={bad}"):


### PR DESCRIPTION
## Summary

`test_ws_rejects_bad_token_with_4401` was flaking on CI roughly 1 in 16 runs with `Failed: DID NOT RAISE <class 'starlette.websockets.WebSocketDisconnect'>`. Example: [run 25196774895](https://github.com/nebriv/ai-tabletop-facilitator/actions/runs/25196774895/job/73879068514#step:7:1).

## Root cause

The test corrupted the join token by swapping its **last** character with `"X"`:

```python
bad = seats["creator_token"][:-1] + "X"
```

itsdangerous's URL-safe signature is HMAC-SHA256 (256 bits) base64url-encoded into 43 chars. The 43rd char only carries **4 meaningful bits** — its low 2 bits are unused padding. So each valid trailing char has 3 base64 "siblings" that decode to the **same** signature bytes.

Empirically (`SESSION_SECRET="x"*32`, 1000 mints):
- 935/1000 corruptions correctly invalidated the token
- **65/1000 corruptions still verified** — every token whose original last char was `U` (the sibling of `X`)

When that happened, the WS handler accepted the connection, no close fired, `pytest.raises(WebSocketDisconnect)` saw nothing, test failed.

1/16 ≈ 6.25 % matches the observed flake rate.

## Fix

Flip a character in the **middle** of the signature, where all 6 bits are meaningful. Verified 0/2000 false-verify rate on the new strategy.

## Test plan

- [x] `pytest tests/test_e2e_session.py::test_ws_rejects_bad_token_with_4401` — passes 5/5 runs
- [x] `pytest tests/test_e2e_session.py` — full file passes (83/83)
- [x] Empirical sweep: 0/2000 corrupted tokens verify under the new strategy

https://claude.ai/code/session_01SmL1A3DsAYDj4czfnRaxJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmL1A3DsAYDj4czfnRaxJJ)_