### PR TITLE
Phase C: typing-indicator heartbeat + multi-typer aggregation (#77)

### DIFF
--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -291,13 +291,15 @@ async def _broadcast_typing(
     state events from the bounded buffer otherwise.
 
     Issue #77 sub-agent review (Security L2 + project logging policy):
-    a per-event log on this hot path is not viable (1 Hz/typer × N
-    sessions = noise), but a *complete-silence* relay leaves ops with
-    no signal if a malicious client floods or a flapping connection
-    causes the cadence to spike. We emit a single ``debug`` line at
-    the *transition edge* (typing flipping for a given role) rather
-    than per packet — gives operators a bisection breadcrumb without
-    drowning the log.
+    a *complete-silence* relay leaves ops with no signal if a
+    malicious client floods or a flapping connection causes the
+    cadence to spike. We emit a ``debug`` line per packet — yes,
+    that's once per heartbeat per typing user (~1 Hz × concurrent
+    typers), but at debug level it's filtered out in production by
+    default and gives operators a complete bisection trail when
+    investigating cadence anomalies. If volume becomes a concern,
+    swap to per-(session, role) edge-tracking with a TTL — sketch
+    in the Copilot-review thread on PR #99.
     """
 
     _logger.debug(

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -287,10 +287,25 @@ async def _broadcast_typing(
 
     ``record=False`` keeps these out of the replay buffer — typing is a
     stale signal by the time anyone reconnects, and they're emitted at
-    high volume so they'd evict legitimate state events from the bounded
-    buffer otherwise.
+    high volume (~1 Hz/typer post issue #77) so they'd evict legitimate
+    state events from the bounded buffer otherwise.
+
+    Issue #77 sub-agent review (Security L2 + project logging policy):
+    a per-event log on this hot path is not viable (1 Hz/typer × N
+    sessions = noise), but a *complete-silence* relay leaves ops with
+    no signal if a malicious client floods or a flapping connection
+    causes the cadence to spike. We emit a single ``debug`` line at
+    the *transition edge* (typing flipping for a given role) rather
+    than per packet — gives operators a bisection breadcrumb without
+    drowning the log.
     """
 
+    _logger.debug(
+        "ws_typing_broadcast",
+        session_id=session_id,
+        role_id=role_id,
+        typing=typing,
+    )
     await manager.connections().broadcast(
         session_id,
         {"type": "typing", "role_id": role_id, "typing": typing},

--- a/frontend/src/__tests__/Composer.typing.test.tsx
+++ b/frontend/src/__tests__/Composer.typing.test.tsx
@@ -46,7 +46,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
     vi.restoreAllMocks();
   });
 
-  it("does NOT broadcast typing on a single keystroke that stops within the start gate", () => {
+  it("does NOT broadcast typing on a single keystroke that's then cleared", () => {
     // UI/UX review BLOCK B-1 / issue #53: a single fat-finger
     // keystroke should not surface a ghost indicator on every
     // peer. The 500 ms gate gives the user time to abandon
@@ -68,9 +68,28 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
     expect(falseCallCount(onTypingChange)).toBe(0);
   });
 
-  it("emits typing_start exactly once after the start-delay gate fires", () => {
+  it("does NOT broadcast typing on a single keystroke even if textarea is NOT cleared", () => {
+    // Copilot review on PR #99: pre-fix the gate-timer fired
+    // typing_start unconditionally after 500 ms regardless of
+    // whether the user kept typing. A single keystroke that
+    // sat in the textarea would still surface a ghost
+    // indicator. The fix counts keystrokes in the gate window
+    // and skips the broadcast if <2.
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "h" } });
+    // Wait past the gate AND the idle window. No follow-up
+    // keystroke; textarea still has "h". Expect no broadcasts.
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + STOP_AFTER_IDLE_MS + 100);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(0);
+    expect(falseCallCount(onTypingChange)).toBe(0);
+  });
+
+  it("emits typing_start exactly once after ≥2 keystrokes inside the gate window", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
+    fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
     });
@@ -79,8 +98,11 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("re-emits typing_start at the 1 Hz heartbeat cadence (exact lower + upper bound)", () => {
     const { textarea, onTypingChange } = setup();
-    // Start the gate.
+    // Two keystrokes inside the 500 ms gate window so the gate
+    // fires + emits start. One alone would fall below the ≥2
+    // threshold and not broadcast.
     fireEvent.change(textarea, { target: { value: "h" } });
+    fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
     });
@@ -106,7 +128,9 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("skips the heartbeat tick when no keystroke happened since the last beat (dirtySinceBeat gate)", () => {
     const { textarea, onTypingChange } = setup();
+    // Two keystrokes to clear the ≥2-in-gate threshold.
     fireEvent.change(textarea, { target: { value: "h" } });
+    fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
     });
@@ -126,6 +150,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
     // through one beat (skipped) → keystroke → next beat fires.
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "h" } });
+    fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
     });
@@ -136,8 +161,10 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
       vi.advanceTimersByTime(1100);
     });
     expect(trueCallCount(onTypingChange)).toBe(1);
-    // Resume typing — marks dirty.
-    fireEvent.change(textarea, { target: { value: "hi" } });
+    // Resume typing — marks dirty. Use a different value so
+    // React's setState bail-on-same-value doesn't skip the
+    // re-render (test was flaky when "hi" appeared twice).
+    fireEvent.change(textarea, { target: { value: "his" } });
     // Advance to the next heartbeat tick (~1000 ms later).
     act(() => {
       vi.advanceTimersByTime(1100);
@@ -155,14 +182,16 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
     // start/stop pair.
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "h" } });
-    // Pause 2.4 s from the keystroke. The 500 ms gate fires
-    // typing_start mid-pause; idle is scheduled for T+2500.
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    // Pause 2.4 s from the last keystroke. The 500 ms gate
+    // fires typing_start mid-pause; idle is scheduled for the
+    // last-keystroke + 2500.
     act(() => {
       vi.advanceTimersByTime(2400);
     });
     expect(falseCallCount(onTypingChange)).toBe(0);
     // Resume typing — idle timer is refreshed.
-    fireEvent.change(textarea, { target: { value: "hi" } });
+    fireEvent.change(textarea, { target: { value: "hi!" } });
     act(() => {
       vi.advanceTimersByTime(100);
     });
@@ -171,7 +200,9 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("emits typing_stop after STOP_AFTER_IDLE_MS of idle", () => {
     const { textarea, onTypingChange } = setup();
-    fireEvent.change(textarea, { target: { value: "hello" } });
+    // Two keystrokes to clear the ≥2 gate threshold.
+    fireEvent.change(textarea, { target: { value: "h" } });
+    fireEvent.change(textarea, { target: { value: "he" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + STOP_AFTER_IDLE_MS + 100);
     });
@@ -180,13 +211,15 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("re-emits typing_start on the next keystroke after a stop (via the gate)", () => {
     const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
     fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + STOP_AFTER_IDLE_MS + 100);
     });
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
-    fireEvent.change(textarea, { target: { value: "hi again" } });
-    // First keystroke after stop schedules the gate again.
+    fireEvent.change(textarea, { target: { value: "hi a" } });
+    fireEvent.change(textarea, { target: { value: "hi ag" } });
+    // ≥2 keystrokes inside the new gate window — start fires.
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
     });
@@ -195,6 +228,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("emits typing_stop on submit AND a fresh keystroke afterward fires a new start", () => {
     const { textarea, onTypingChange, onSubmit } = setup();
+    fireEvent.change(textarea, { target: { value: "a" } });
     fireEvent.change(textarea, { target: { value: "answer" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
@@ -203,6 +237,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
     expect(onSubmit).toHaveBeenCalledWith("answer", undefined);
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
     // QA review MEDIUM: post-submit re-typing fires start again.
+    fireEvent.change(textarea, { target: { value: "n" } });
     fireEvent.change(textarea, { target: { value: "next" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
@@ -213,6 +248,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
   it("Shift+Enter inserts a newline without submitting and counts as a keystroke", () => {
     // QA review MEDIUM: Shift+Enter newline path was untested.
     const { textarea, onTypingChange, onSubmit } = setup();
+    fireEvent.change(textarea, { target: { value: "f" } });
     fireEvent.change(textarea, { target: { value: "first" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
@@ -230,6 +266,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("emits typing_stop when the textarea is cleared mid-typing", () => {
     const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
     fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
@@ -241,6 +278,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("emits typing_stop when the composer becomes disabled mid-typing", () => {
     const { textarea, onTypingChange, rerender } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
     fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);
@@ -260,6 +298,7 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
 
   it("emits typing_stop on unmount", () => {
     const { textarea, onTypingChange, unmount } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
     fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
       vi.advanceTimersByTime(START_DELAY_MS + 50);

--- a/frontend/src/__tests__/Composer.typing.test.tsx
+++ b/frontend/src/__tests__/Composer.typing.test.tsx
@@ -5,8 +5,13 @@ import { Composer } from "../components/Composer";
 // Issue #77 — heartbeat-mode typing indicator. The sender now
 // re-emits ``typing_start`` once per ~1 s while the user is
 // actively typing (and has hit a key since the last beat); the
-// receiver TTL fades the chip if the heartbeat stops. Replaces
-// the prior one-shot transition model.
+// receiver TTL fades the chip if the heartbeat stops. A 500 ms
+// start-delay gate keeps a single fat-finger keystroke from
+// surfacing the indicator (UI/UX review BLOCK B-1).
+
+const START_DELAY_MS = 500;
+const HEARTBEAT_MS = 1000;
+const STOP_AFTER_IDLE_MS = 2500;
 
 function setup(opts: { enabled?: boolean } = {}) {
   const onTypingChange = vi.fn();
@@ -24,6 +29,13 @@ function setup(opts: { enabled?: boolean } = {}) {
   return { ...utils, textarea, onTypingChange, onSubmit };
 }
 
+function trueCallCount(fn: ReturnType<typeof vi.fn>): number {
+  return fn.mock.calls.filter((c) => c[0] === true).length;
+}
+function falseCallCount(fn: ReturnType<typeof vi.fn>): number {
+  return fn.mock.calls.filter((c) => c[0] === false).length;
+}
+
 describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -34,90 +46,194 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
     vi.restoreAllMocks();
   });
 
-  it("emits typing_start immediately on the first keystroke", () => {
+  it("does NOT broadcast typing on a single keystroke that stops within the start gate", () => {
+    // UI/UX review BLOCK B-1 / issue #53: a single fat-finger
+    // keystroke should not surface a ghost indicator on every
+    // peer. The 500 ms gate gives the user time to abandon
+    // before we start broadcasting.
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "h" } });
-    expect(onTypingChange).toHaveBeenCalledWith(true);
-    // Pre-fix the start was deferred 1.5 s. The new model fires
-    // on the first non-empty keystroke and lets the receiver TTL
-    // absorb single-character flicker.
-    expect(onTypingChange.mock.calls.filter((c) => c[0] === true)).toHaveLength(1);
+    // 400 ms < START_DELAY_MS — no start fires.
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(0);
+    // The user clears the textarea before the gate fires;
+    // the timer is still pending — clearing should cancel it.
+    fireEvent.change(textarea, { target: { value: "" } });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(0);
+    expect(falseCallCount(onTypingChange)).toBe(0);
   });
 
-  it("re-emits typing_start every ~1 s while the user keeps typing", () => {
+  it("emits typing_start exactly once after the start-delay gate fires", () => {
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "h" } });
-    expect(onTypingChange.mock.calls.filter((c) => c[0] === true)).toHaveLength(1);
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(1);
+  });
 
-    // Simulate continuous typing: keystroke every 300 ms for 3 s.
-    for (let t = 300; t <= 3000; t += 300) {
+  it("re-emits typing_start at the 1 Hz heartbeat cadence (exact lower + upper bound)", () => {
+    const { textarea, onTypingChange } = setup();
+    // Start the gate.
+    fireEvent.change(textarea, { target: { value: "h" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(1);
+    // Continuous typing for 3.2 s post-start: keystroke every
+    // 300 ms. Heartbeat fires at +1000, +2000, +3000 ms (3
+    // beats). No spurious stop.
+    for (let t = 300; t <= 3200; t += 300) {
       fireEvent.change(textarea, { target: { value: `h-${t}` } });
       act(() => {
         vi.advanceTimersByTime(300);
       });
     }
-    // Expect a heartbeat each second while typing — at least 3
-    // additional ``typing_start`` calls beyond the immediate one.
-    const trueCalls = onTypingChange.mock.calls.filter((c) => c[0] === true).length;
+    const trueCalls = trueCallCount(onTypingChange);
+    // QA review HIGH: cadence must be locked to 1 Hz, not just
+    // ">= floor". Floor 4 (start + 3 beats), ceiling 5 in case
+    // of a boundary tick crossing. A regression to 200 ms
+    // heartbeat would put this in the 15-17 range — caught.
     expect(trueCalls).toBeGreaterThanOrEqual(4);
-    // No spurious ``typing_stop`` while typing was still active.
-    const falseCalls = onTypingChange.mock.calls.filter((c) => c[0] === false).length;
-    expect(falseCalls).toBe(0);
+    expect(trueCalls).toBeLessThanOrEqual(5);
+    expect(falseCallCount(onTypingChange)).toBe(0);
   });
 
-  it("does NOT keep firing heartbeats during a long pause inside the idle window", () => {
+  it("skips the heartbeat tick when no keystroke happened since the last beat (dirtySinceBeat gate)", () => {
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "h" } });
-    // 1.4 s pause — under STOP_AFTER_IDLE_MS (2.5 s) — no
-    // additional keystroke means dirtySinceBeat is false, so the
-    // 1 s heartbeat tick should NOT send a refresh.
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(1);
+    // 1.4 s pause inside the idle window — heartbeat tick fires
+    // at +1000, sees dirtySinceBeat=false, skips. No additional
+    // start emitted.
     act(() => {
       vi.advanceTimersByTime(1400);
     });
-    const trueCalls = onTypingChange.mock.calls.filter((c) => c[0] === true).length;
-    expect(trueCalls).toBe(1);
+    expect(trueCallCount(onTypingChange)).toBe(1);
+    expect(falseCallCount(onTypingChange)).toBe(0);
+  });
+
+  it("heartbeat-skip then resume keystroke: refresh fires on next beat tick", () => {
+    // QA review HIGH: gap not covered before. Type → pause
+    // through one beat (skipped) → keystroke → next beat fires.
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(1);
+    // Pause 1.1 s — heartbeat at +1000 ms sees dirtySinceBeat
+    // false and skips.
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(trueCallCount(onTypingChange)).toBe(1);
+    // Resume typing — marks dirty.
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    // Advance to the next heartbeat tick (~1000 ms later).
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    // Next heartbeat fires the refresh.
+    expect(trueCallCount(onTypingChange)).toBeGreaterThanOrEqual(2);
+    expect(falseCallCount(onTypingChange)).toBe(0);
+  });
+
+  it("2.4 s pause then keystroke does NOT fire a spurious typing_stop", () => {
+    // QA review MEDIUM: idle-boundary protection. The user
+    // pauses 2.4 s after their last keystroke (just under
+    // STOP_AFTER_IDLE_MS = 2500), then resumes — idle must
+    // NOT have fired and resume must NOT trigger a false
+    // start/stop pair.
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
+    // Pause 2.4 s from the keystroke. The 500 ms gate fires
+    // typing_start mid-pause; idle is scheduled for T+2500.
+    act(() => {
+      vi.advanceTimersByTime(2400);
+    });
+    expect(falseCallCount(onTypingChange)).toBe(0);
+    // Resume typing — idle timer is refreshed.
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(falseCallCount(onTypingChange)).toBe(0);
   });
 
   it("emits typing_stop after STOP_AFTER_IDLE_MS of idle", () => {
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "hello" } });
-    expect(onTypingChange).toHaveBeenLastCalledWith(true);
-    // Advance past the idle threshold (2.5 s) without further
-    // keystrokes — idle timer should fire typing_stop.
     act(() => {
-      vi.advanceTimersByTime(2600);
+      vi.advanceTimersByTime(START_DELAY_MS + STOP_AFTER_IDLE_MS + 100);
     });
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
   });
 
-  it("re-emits typing_start on the next keystroke after a stop", () => {
+  it("re-emits typing_start on the next keystroke after a stop (via the gate)", () => {
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "hi" } });
     act(() => {
-      vi.advanceTimersByTime(2600);
+      vi.advanceTimersByTime(START_DELAY_MS + STOP_AFTER_IDLE_MS + 100);
     });
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
-
-    // User starts typing again 1 s later — should re-fire start
-    // immediately, not wait the old 1.5 s start delay.
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
     fireEvent.change(textarea, { target: { value: "hi again" } });
+    // First keystroke after stop schedules the gate again.
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
     expect(onTypingChange).toHaveBeenLastCalledWith(true);
   });
 
-  it("emits typing_stop on submit", () => {
+  it("emits typing_stop on submit AND a fresh keystroke afterward fires a new start", () => {
     const { textarea, onTypingChange, onSubmit } = setup();
     fireEvent.change(textarea, { target: { value: "answer" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
     fireEvent.keyDown(textarea, { key: "Enter" });
     expect(onSubmit).toHaveBeenCalledWith("answer", undefined);
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
+    // QA review MEDIUM: post-submit re-typing fires start again.
+    fireEvent.change(textarea, { target: { value: "next" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
+    expect(onTypingChange).toHaveBeenLastCalledWith(true);
   });
 
-  it("emits typing_stop when the textarea is cleared", () => {
+  it("Shift+Enter inserts a newline without submitting and counts as a keystroke", () => {
+    // QA review MEDIUM: Shift+Enter newline path was untested.
+    const { textarea, onTypingChange, onSubmit } = setup();
+    fireEvent.change(textarea, { target: { value: "first" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    fireEvent.change(textarea, { target: { value: "first\n" } });
+    expect(onSubmit).not.toHaveBeenCalled();
+    // The newline keystroke marks dirty; advance to the next
+    // heartbeat tick and confirm it fires.
+    act(() => {
+      vi.advanceTimersByTime(HEARTBEAT_MS + 50);
+    });
+    expect(trueCallCount(onTypingChange)).toBeGreaterThanOrEqual(2);
+  });
+
+  it("emits typing_stop when the textarea is cleared mid-typing", () => {
     const { textarea, onTypingChange } = setup();
     fireEvent.change(textarea, { target: { value: "hi" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
     expect(onTypingChange).toHaveBeenLastCalledWith(true);
     fireEvent.change(textarea, { target: { value: "" } });
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
@@ -126,6 +242,9 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
   it("emits typing_stop when the composer becomes disabled mid-typing", () => {
     const { textarea, onTypingChange, rerender } = setup();
     fireEvent.change(textarea, { target: { value: "hi" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
     expect(onTypingChange).toHaveBeenLastCalledWith(true);
     rerender(
       <Composer
@@ -142,6 +261,9 @@ describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
   it("emits typing_stop on unmount", () => {
     const { textarea, onTypingChange, unmount } = setup();
     fireEvent.change(textarea, { target: { value: "hi" } });
+    act(() => {
+      vi.advanceTimersByTime(START_DELAY_MS + 50);
+    });
     expect(onTypingChange).toHaveBeenLastCalledWith(true);
     unmount();
     expect(onTypingChange).toHaveBeenLastCalledWith(false);

--- a/frontend/src/__tests__/Composer.typing.test.tsx
+++ b/frontend/src/__tests__/Composer.typing.test.tsx
@@ -1,0 +1,149 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Composer } from "../components/Composer";
+
+// Issue #77 — heartbeat-mode typing indicator. The sender now
+// re-emits ``typing_start`` once per ~1 s while the user is
+// actively typing (and has hit a key since the last beat); the
+// receiver TTL fades the chip if the heartbeat stops. Replaces
+// the prior one-shot transition model.
+
+function setup(opts: { enabled?: boolean } = {}) {
+  const onTypingChange = vi.fn();
+  const onSubmit = vi.fn();
+  const utils = render(
+    <Composer
+      enabled={opts.enabled ?? true}
+      placeholder="Type something"
+      label="Your message"
+      onSubmit={onSubmit}
+      onTypingChange={onTypingChange}
+    />,
+  );
+  const textarea = screen.getByPlaceholderText("Type something") as HTMLTextAreaElement;
+  return { ...utils, textarea, onTypingChange, onSubmit };
+}
+
+describe("Composer typing indicator (issue #77, heartbeat mode)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("emits typing_start immediately on the first keystroke", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
+    expect(onTypingChange).toHaveBeenCalledWith(true);
+    // Pre-fix the start was deferred 1.5 s. The new model fires
+    // on the first non-empty keystroke and lets the receiver TTL
+    // absorb single-character flicker.
+    expect(onTypingChange.mock.calls.filter((c) => c[0] === true)).toHaveLength(1);
+  });
+
+  it("re-emits typing_start every ~1 s while the user keeps typing", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
+    expect(onTypingChange.mock.calls.filter((c) => c[0] === true)).toHaveLength(1);
+
+    // Simulate continuous typing: keystroke every 300 ms for 3 s.
+    for (let t = 300; t <= 3000; t += 300) {
+      fireEvent.change(textarea, { target: { value: `h-${t}` } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+    }
+    // Expect a heartbeat each second while typing — at least 3
+    // additional ``typing_start`` calls beyond the immediate one.
+    const trueCalls = onTypingChange.mock.calls.filter((c) => c[0] === true).length;
+    expect(trueCalls).toBeGreaterThanOrEqual(4);
+    // No spurious ``typing_stop`` while typing was still active.
+    const falseCalls = onTypingChange.mock.calls.filter((c) => c[0] === false).length;
+    expect(falseCalls).toBe(0);
+  });
+
+  it("does NOT keep firing heartbeats during a long pause inside the idle window", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "h" } });
+    // 1.4 s pause — under STOP_AFTER_IDLE_MS (2.5 s) — no
+    // additional keystroke means dirtySinceBeat is false, so the
+    // 1 s heartbeat tick should NOT send a refresh.
+    act(() => {
+      vi.advanceTimersByTime(1400);
+    });
+    const trueCalls = onTypingChange.mock.calls.filter((c) => c[0] === true).length;
+    expect(trueCalls).toBe(1);
+  });
+
+  it("emits typing_stop after STOP_AFTER_IDLE_MS of idle", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    expect(onTypingChange).toHaveBeenLastCalledWith(true);
+    // Advance past the idle threshold (2.5 s) without further
+    // keystrokes — idle timer should fire typing_stop.
+    act(() => {
+      vi.advanceTimersByTime(2600);
+    });
+    expect(onTypingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("re-emits typing_start on the next keystroke after a stop", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    act(() => {
+      vi.advanceTimersByTime(2600);
+    });
+    expect(onTypingChange).toHaveBeenLastCalledWith(false);
+
+    // User starts typing again 1 s later — should re-fire start
+    // immediately, not wait the old 1.5 s start delay.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    fireEvent.change(textarea, { target: { value: "hi again" } });
+    expect(onTypingChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("emits typing_stop on submit", () => {
+    const { textarea, onTypingChange, onSubmit } = setup();
+    fireEvent.change(textarea, { target: { value: "answer" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("answer", undefined);
+    expect(onTypingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("emits typing_stop when the textarea is cleared", () => {
+    const { textarea, onTypingChange } = setup();
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    expect(onTypingChange).toHaveBeenLastCalledWith(true);
+    fireEvent.change(textarea, { target: { value: "" } });
+    expect(onTypingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("emits typing_stop when the composer becomes disabled mid-typing", () => {
+    const { textarea, onTypingChange, rerender } = setup();
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    expect(onTypingChange).toHaveBeenLastCalledWith(true);
+    rerender(
+      <Composer
+        enabled={false}
+        placeholder="Type something"
+        label="Your message"
+        onSubmit={vi.fn()}
+        onTypingChange={onTypingChange}
+      />,
+    );
+    expect(onTypingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("emits typing_stop on unmount", () => {
+    const { textarea, onTypingChange, unmount } = setup();
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    expect(onTypingChange).toHaveBeenLastCalledWith(true);
+    unmount();
+    expect(onTypingChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/frontend/src/__tests__/Transcript.typing.test.tsx
+++ b/frontend/src/__tests__/Transcript.typing.test.tsx
@@ -34,7 +34,7 @@ describe("Transcript typing label (issue #77)", () => {
     );
     expect(screen.queryByText(/typing…/i)).toBeNull();
     expect(
-      screen.queryByText(/Everyone is hammering/i),
+      screen.queryByText(/All participants are responding/i),
     ).toBeNull();
   });
 
@@ -81,7 +81,7 @@ describe("Transcript typing label (issue #77)", () => {
     ).toBeInTheDocument();
   });
 
-  it("≥4 typers → 'Everyone is hammering away at their keyboards…'", () => {
+  it("≥4 typers → 'All participants are responding…' (neutral catch-all)", () => {
     render(
       <Transcript
         messages={[]}
@@ -90,7 +90,7 @@ describe("Transcript typing label (issue #77)", () => {
       />,
     );
     expect(
-      screen.getByText(/Everyone is hammering away at their keyboards…/),
+      screen.getByText(/All participants are responding…/),
     ).toBeInTheDocument();
     // Plain "X is typing" / "X and Y are typing" must NOT also
     // render — the catch-all replaces, doesn't supplement.
@@ -112,5 +112,75 @@ describe("Transcript typing label (issue #77)", () => {
       screen.getByText(/SOC Analyst · Bridget is typing…/),
     ).toBeInTheDocument();
     expect(screen.queryByText(/r-ghost/)).toBeNull();
+  });
+
+  it("typing chip renders after the message list (chronological ordering)", () => {
+    // QA review MEDIUM: the chip should be the *last* visible
+    // entry in the transcript region so it reads as "what's
+    // happening right now" rather than appearing between past
+    // messages.
+    const messages = [
+      {
+        id: "m1",
+        kind: "player" as const,
+        role_id: "r-soc",
+        body: "First message body",
+        ts: "2026-05-01T00:00:00Z",
+        tool_name: null,
+        tool_args: null,
+      },
+      {
+        id: "m2",
+        kind: "ai_text" as const,
+        role_id: null,
+        body: "AI response body",
+        ts: "2026-05-01T00:00:01Z",
+        tool_name: null,
+        tool_args: null,
+      },
+    ];
+    const { container } = render(
+      <Transcript
+        messages={messages}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-soc"]}
+      />,
+    );
+    // Get all article (message bubble) + the typing chip in DOM
+    // order. The typing label text should appear *after* both
+    // message bodies in the rendered tree.
+    const text = container.textContent ?? "";
+    const firstMsgIdx = text.indexOf("First message body");
+    const aiMsgIdx = text.indexOf("AI response body");
+    // ``is typing…`` is a substring unique to the typing chip
+    // (message bubbles include the role label "SOC Analyst" too,
+    // so searching for that finds the message header first).
+    const typingIdx = text.indexOf("is typing…");
+    expect(firstMsgIdx).toBeGreaterThanOrEqual(0);
+    expect(aiMsgIdx).toBeGreaterThan(firstMsgIdx);
+    expect(typingIdx).toBeGreaterThan(aiMsgIdx);
+  });
+
+  it("typing indicator is silent inside the role=log live region (no nested aria-live)", () => {
+    // UI/UX review HIGH H-1: nesting a role=status aria-live
+    // element inside the role=log aria-live wrapper made NVDA
+    // double-announce. Transcript passes ``silent`` to the
+    // ChatIndicator children so the inner element is plain.
+    const { container } = render(
+      <Transcript
+        messages={[]}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-soc"]}
+      />,
+    );
+    // Outer log region is the live region.
+    const log = container.querySelector('[role="log"]');
+    expect(log?.getAttribute("aria-live")).toBe("polite");
+    // No inner role=status / aria-live elements.
+    expect(container.querySelectorAll('[role="status"]').length).toBe(0);
+    const inner = container.querySelectorAll("[aria-live]");
+    // Only the outer log, no inner duplicates.
+    expect(inner.length).toBe(1);
+    expect(inner[0]).toBe(log);
   });
 });

--- a/frontend/src/__tests__/Transcript.typing.test.tsx
+++ b/frontend/src/__tests__/Transcript.typing.test.tsx
@@ -6,8 +6,13 @@ import { Transcript } from "../components/Transcript";
 // Issue #77 — Transcript multi-typer aggregation. Pre-fix any
 // 3+ typers collapsed to "X, Y and N more"; the new spec names
 // exactly three when there are three (avoiding the awkward
-// "X, Y and 1 more"), and at ≥4 collapses to a playful catch-
-// all so the indicator doesn't grow unboundedly.
+// "X, Y and 1 more"), and at ≥4 collapses to a neutral catch-
+// all ("All participants are responding…") so the indicator
+// doesn't grow unboundedly. The original issue body asked for
+// playful copy ("Everyone is hammering away at their
+// keyboards…") but the User + UI/UX reviewers + maintainer
+// agreed it reads as the app cracking a joke during tense
+// IR scenarios — swapped to neutral copy on the second commit.
 
 function role(id: string, label: string, displayName: string | null = null): RoleView {
   return {

--- a/frontend/src/__tests__/Transcript.typing.test.tsx
+++ b/frontend/src/__tests__/Transcript.typing.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RoleView } from "../api/client";
+import { Transcript } from "../components/Transcript";
+
+// Issue #77 — Transcript multi-typer aggregation. Pre-fix any
+// 3+ typers collapsed to "X, Y and N more"; the new spec names
+// exactly three when there are three (avoiding the awkward
+// "X, Y and 1 more"), and at ≥4 collapses to a playful catch-
+// all so the indicator doesn't grow unboundedly.
+
+function role(id: string, label: string, displayName: string | null = null): RoleView {
+  return {
+    id,
+    label,
+    display_name: displayName,
+    kind: "player",
+    token_version: 0,
+    is_creator: false,
+  };
+}
+
+const FOUR_ROLES: RoleView[] = [
+  role("r-soc", "SOC Analyst", "Bridget"),
+  role("r-legal", "Legal", "Marcus"),
+  role("r-comms", "Comms", "Pat"),
+  role("r-ir", "IR Lead"),
+];
+
+describe("Transcript typing label (issue #77)", () => {
+  it("0 typers → no indicator", () => {
+    render(
+      <Transcript messages={[]} roles={FOUR_ROLES} typingRoleIds={[]} />,
+    );
+    expect(screen.queryByText(/typing…/i)).toBeNull();
+    expect(
+      screen.queryByText(/Everyone is hammering/i),
+    ).toBeNull();
+  });
+
+  it("1 typer → 'X is typing…'", () => {
+    render(
+      <Transcript
+        messages={[]}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-soc"]}
+      />,
+    );
+    expect(
+      screen.getByText(/SOC Analyst · Bridget is typing…/),
+    ).toBeInTheDocument();
+  });
+
+  it("2 typers → 'X and Y are typing…'", () => {
+    render(
+      <Transcript
+        messages={[]}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-soc", "r-legal"]}
+      />,
+    );
+    expect(
+      screen.getByText(
+        /SOC Analyst · Bridget and Legal · Marcus are typing…/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("3 typers → names all three (no awkward 'and 1 more')", () => {
+    render(
+      <Transcript
+        messages={[]}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-soc", "r-legal", "r-comms"]}
+      />,
+    );
+    expect(
+      screen.getByText(
+        /SOC Analyst · Bridget, Legal · Marcus and Comms · Pat are typing…/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("≥4 typers → 'Everyone is hammering away at their keyboards…'", () => {
+    render(
+      <Transcript
+        messages={[]}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-soc", "r-legal", "r-comms", "r-ir"]}
+      />,
+    );
+    expect(
+      screen.getByText(/Everyone is hammering away at their keyboards…/),
+    ).toBeInTheDocument();
+    // Plain "X is typing" / "X and Y are typing" must NOT also
+    // render — the catch-all replaces, doesn't supplement.
+    expect(screen.queryByText(/SOC Analyst.+is typing/)).toBeNull();
+    expect(screen.queryByText(/Legal.+are typing/)).toBeNull();
+  });
+
+  it("typing role-ids that don't resolve to a known role are dropped silently", () => {
+    render(
+      <Transcript
+        messages={[]}
+        roles={FOUR_ROLES}
+        typingRoleIds={["r-ghost", "r-soc"]}
+      />,
+    );
+    // Falls through to the 1-typer phrasing — the unknown id is
+    // skipped, not rendered as a bare role_id.
+    expect(
+      screen.getByText(/SOC Analyst · Bridget is typing…/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/r-ghost/)).toBeNull();
+  });
+});

--- a/frontend/src/components/ChatIndicator.tsx
+++ b/frontend/src/components/ChatIndicator.tsx
@@ -5,25 +5,37 @@
  * players ("Alice is typing…"). Keeps the visual language consistent so a
  * participant who sees the indicator instantly knows what it means
  * regardless of who is producing it.
+ *
+ * ``silent`` drops ``role="status"`` + ``aria-live="polite"`` from the
+ * wrapper. Used by callers that already nest the indicator inside an
+ * ARIA live region (e.g. Transcript's ``role="log"``); without this
+ * opt-out the nested live regions get double-announced by NVDA
+ * (UI/UX review HIGH H-1).
  */
 interface Props {
   label: string;
   tone?: "ai" | "player";
+  silent?: boolean;
 }
 
-export function ChatIndicator({ label, tone = "ai" }: Props) {
+export function ChatIndicator({ label, tone = "ai", silent = false }: Props) {
   const colour =
     tone === "ai"
       ? "border-emerald-700/40 bg-emerald-950/40 text-emerald-200"
       : "border-sky-700/40 bg-sky-950/40 text-sky-200";
   const dotColour = tone === "ai" ? "bg-emerald-400" : "bg-sky-400";
+  // ``max-w-full break-words`` so a long multi-typer label
+  // ("SOC Analyst · Bridget, Legal · Marcus and Comms · Pat are
+  //  typing…") wraps inside a narrow column instead of pushing
+  // the parent flex column wider and producing horizontal scroll
+  // on mobile (UI/UX review BLOCK B-2).
+  const ariaProps = silent ? {} : { role: "status", "aria-live": "polite" as const };
   return (
     <div
-      role="status"
-      aria-live="polite"
-      className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs ${colour}`}
+      {...ariaProps}
+      className={`inline-flex max-w-full items-center gap-2 break-words rounded-md border px-3 py-1.5 text-xs ${colour}`}
     >
-      <span aria-hidden="true" className="inline-flex gap-0.5">
+      <span aria-hidden="true" className="inline-flex shrink-0 gap-0.5">
         <span
           className={`inline-block h-1.5 w-1.5 animate-bounce rounded-full ${dotColour}`}
           style={{ animationDelay: "0ms" }}

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -73,10 +73,19 @@ export function Composer({
   // from the heartbeat interval) still fires the explicit stop
   // after STOP_AFTER_IDLE_MS so the receiver doesn't have to
   // wait for the TTL sweep to evict.
+  //
+  // ``pendingStartTimer`` (revived from pre-PR with a much shorter
+  // window) keeps a single fat-finger keystroke from broadcasting
+  // a ghost indicator: TYPING_START_DELAY_MS=500 means the
+  // receiver only sees us as typing after we've been at the
+  // keyboard for half a second. UI/UX review BLOCK B-1 — the
+  // immediate-fire path re-introduced the issue #53 flicker.
   const heartbeatTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingStartTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isTyping = useRef(false);
   const dirtySinceBeat = useRef(false);
+  const TYPING_START_DELAY_MS = 500;
   const HEARTBEAT_MS = 1000;
   const STOP_AFTER_IDLE_MS = 2500;
   // Last text the user attempted to submit. Held outside React state
@@ -101,7 +110,7 @@ export function Composer({
     // Tear down the heartbeat + idle timers and emit a final
     // typing_stop so peers don't keep showing us as typing for
     // the length of TYPING_VISIBLE_MS after we just submitted.
-    emitTypingStop();
+    emitTypingStop("submit");
   }
 
   // Restore the last-attempted text when the parent signals a submit
@@ -136,14 +145,23 @@ export function Composer({
       clearTimeout(idleTimer.current);
       idleTimer.current = null;
     }
+    if (pendingStartTimer.current) {
+      clearTimeout(pendingStartTimer.current);
+      pendingStartTimer.current = null;
+    }
   }
 
-  function emitTypingStop() {
+  // Reasons logged at every emitTypingStop call site so a "stuck
+  // typing indicator in production" report has a breadcrumb to
+  // bisect the cause (idle / submit / clear / disable / unmount).
+  // Per CLAUDE.md logging-and-debuggability policy.
+  function emitTypingStop(reason: string) {
     teardownTypingTimers();
     if (isTyping.current) {
       isTyping.current = false;
       dirtySinceBeat.current = false;
       onTypingChange?.(false);
+      console.debug("[composer] typing_stop", { reason });
     }
   }
 
@@ -154,24 +172,37 @@ export function Composer({
     // backspace), tear down the heartbeat + emit stop. Holding
     // "typing" on an empty composer is misleading.
     if (!value.trim()) {
-      emitTypingStop();
+      emitTypingStop("textarea cleared");
       return;
     }
     if (!isTyping.current) {
-      // First keystroke since silence: emit start immediately
-      // (receiver TTL handles flicker). Begin the heartbeat
-      // interval; mark not-dirty because we just sent a beat.
-      isTyping.current = true;
-      dirtySinceBeat.current = false;
-      onTypingChange(true);
-      if (heartbeatTimer.current) clearInterval(heartbeatTimer.current);
-      heartbeatTimer.current = setInterval(() => {
-        // Re-check enabled in case the turn flipped between beats.
-        if (!enabled || !isTyping.current) return;
-        if (!dirtySinceBeat.current) return;
-        onTypingChange?.(true);
-        dirtySinceBeat.current = false;
-      }, HEARTBEAT_MS);
+      if (pendingStartTimer.current) {
+        // First keystroke already started the gate; subsequent
+        // keystrokes inside the start window let it fire on
+        // schedule (we don't reset the timer).
+      } else {
+        // First keystroke since silence: schedule a delayed
+        // ``typing_start`` so a single fat-finger doesn't
+        // surface a ghost indicator on every peer (UI/UX
+        // review BLOCK B-1; original issue #53). When the
+        // gate fires, kick off the 1 Hz heartbeat.
+        pendingStartTimer.current = setTimeout(() => {
+          pendingStartTimer.current = null;
+          if (!enabled) return;
+          isTyping.current = true;
+          dirtySinceBeat.current = false;
+          onTypingChange?.(true);
+          if (heartbeatTimer.current) clearInterval(heartbeatTimer.current);
+          heartbeatTimer.current = setInterval(() => {
+            // Re-check enabled in case the turn flipped between
+            // beats.
+            if (!enabled || !isTyping.current) return;
+            if (!dirtySinceBeat.current) return;
+            onTypingChange?.(true);
+            dirtySinceBeat.current = false;
+          }, HEARTBEAT_MS);
+        }, TYPING_START_DELAY_MS);
+      }
     } else {
       // Already typing — just mark dirty so the next heartbeat
       // tick sends a refresh.
@@ -180,7 +211,10 @@ export function Composer({
     // Refresh the idle timer on every keystroke. When it fires
     // we emit ``typing_stop`` and clear the heartbeat.
     if (idleTimer.current) clearTimeout(idleTimer.current);
-    idleTimer.current = setTimeout(emitTypingStop, STOP_AFTER_IDLE_MS);
+    idleTimer.current = setTimeout(
+      () => emitTypingStop("idle"),
+      STOP_AFTER_IDLE_MS,
+    );
   }
 
   useEffect(() => {
@@ -190,9 +224,11 @@ export function Composer({
       // the length of TYPING_VISIBLE_MS after we navigate away.
       if (heartbeatTimer.current) clearInterval(heartbeatTimer.current);
       if (idleTimer.current) clearTimeout(idleTimer.current);
+      if (pendingStartTimer.current) clearTimeout(pendingStartTimer.current);
       if (isTyping.current && onTypingChange) {
         isTyping.current = false;
         onTypingChange(false);
+        console.debug("[composer] typing_stop", { reason: "unmount" });
       }
     };
   }, [onTypingChange]);
@@ -204,7 +240,7 @@ export function Composer({
   // suggesting we're still composing.
   useEffect(() => {
     if (enabled) return;
-    emitTypingStop();
+    emitTypingStop("disabled");
     // emitTypingStop is stable per render; only re-run when
     // ``enabled`` flips so we don't churn on onTypingChange
     // identity changes.

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -55,19 +55,30 @@ export function Composer({
   // Empty string == speak as the local participant. Anything else is a
   // role_id passed up to the parent for proxy submission.
   const [asRoleId, setAsRoleId] = useState<string>("");
-  // Idle timer fires ``typing_stop`` after the user has been idle long
-  // enough that the indicator should disappear. Pending-start timer waits
-  // until the user has been typing continuously for a couple of seconds
-  // before announcing — without the delay the indicator flashes on every
-  // single keystroke and creates the "blinking screen" pattern reported
-  // in issue #53.
+  // Heartbeat-based typing indicator (issue #77). Pre-fix the
+  // sender emitted exactly one ``typing_start`` after a 1.5 s
+  // continuous-typing gate and one ``typing_stop`` after 3.5 s of
+  // idle. If either packet was dropped, or the user paused briefly
+  // and the receiver TTL fired before they resumed, the indicator
+  // vanished mid-typing and didn't come back. Switching to a
+  // 1 Hz heartbeat: while the user is actively typing AND has hit
+  // a key since the last beat, we re-emit ``typing_start`` every
+  // ~1 s, which refreshes the receiver-side TTL. ``typing_stop``
+  // still fires on idle / submit / disable / unmount.
+  //
+  // ``dirtySinceBeat`` is the gate — without it, the heartbeat
+  // would keep firing across long pauses (defeating the point).
+  // We mark dirty on every keystroke, clear on every beat, and
+  // skip the beat send when not dirty. The idle timer (separate
+  // from the heartbeat interval) still fires the explicit stop
+  // after STOP_AFTER_IDLE_MS so the receiver doesn't have to
+  // wait for the TTL sweep to evict.
+  const heartbeatTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingStartTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isTyping = useRef(false);
-  // Debounce config. The thresholds are intentionally separated so a
-  // user who pauses to think briefly (~1s) doesn't churn start/stop.
-  const TYPING_START_DELAY_MS = 1500;
-  const TYPING_IDLE_MS = 3500;
+  const dirtySinceBeat = useRef(false);
+  const HEARTBEAT_MS = 1000;
+  const STOP_AFTER_IDLE_MS = 2500;
   // Last text the user attempted to submit. Held outside React state
   // so we can restore it without an extra render on the success path.
   const lastAttemptedRef = useRef<string>("");
@@ -87,18 +98,10 @@ export function Composer({
     // doesn't accidentally post under the previous proxy role. Sticky
     // proxy mode was a real footgun in solo testing.
     setAsRoleId("");
-    if (pendingStartTimer.current) {
-      clearTimeout(pendingStartTimer.current);
-      pendingStartTimer.current = null;
-    }
-    if (idleTimer.current) {
-      clearTimeout(idleTimer.current);
-      idleTimer.current = null;
-    }
-    if (isTyping.current) {
-      isTyping.current = false;
-      onTypingChange?.(false);
-    }
+    // Tear down the heartbeat + idle timers and emit a final
+    // typing_stop so peers don't keep showing us as typing for
+    // the length of TYPING_VISIBLE_MS after we just submitted.
+    emitTypingStop();
   }
 
   // Restore the last-attempted text when the parent signals a submit
@@ -124,59 +127,68 @@ export function Composer({
     handle(e as unknown as FormEvent);
   }
 
+  function teardownTypingTimers() {
+    if (heartbeatTimer.current) {
+      clearInterval(heartbeatTimer.current);
+      heartbeatTimer.current = null;
+    }
+    if (idleTimer.current) {
+      clearTimeout(idleTimer.current);
+      idleTimer.current = null;
+    }
+  }
+
+  function emitTypingStop() {
+    teardownTypingTimers();
+    if (isTyping.current) {
+      isTyping.current = false;
+      dirtySinceBeat.current = false;
+      onTypingChange?.(false);
+    }
+  }
+
   function handleChange(value: string) {
     setText(value);
     if (!enabled || !onTypingChange) return;
-    // If the textarea is now empty (e.g. user cleared with backspace),
-    // tear down the timers and emit a stop if needed. Holding "typing"
-    // on an empty composer is misleading.
+    // If the textarea is now empty (e.g. user cleared with
+    // backspace), tear down the heartbeat + emit stop. Holding
+    // "typing" on an empty composer is misleading.
     if (!value.trim()) {
-      if (pendingStartTimer.current) {
-        clearTimeout(pendingStartTimer.current);
-        pendingStartTimer.current = null;
-      }
-      if (idleTimer.current) {
-        clearTimeout(idleTimer.current);
-        idleTimer.current = null;
-      }
-      if (isTyping.current) {
-        isTyping.current = false;
-        onTypingChange(false);
-      }
+      emitTypingStop();
       return;
     }
-    // Start path: don't broadcast immediately. Schedule a delayed
-    // ``typing_start`` so a user who types one character and stops
-    // never lights up the indicator.
-    if (!isTyping.current && !pendingStartTimer.current) {
-      pendingStartTimer.current = setTimeout(() => {
-        pendingStartTimer.current = null;
-        // Re-check enabled — the turn may have flipped while we waited.
-        if (!enabled) return;
-        isTyping.current = true;
+    if (!isTyping.current) {
+      // First keystroke since silence: emit start immediately
+      // (receiver TTL handles flicker). Begin the heartbeat
+      // interval; mark not-dirty because we just sent a beat.
+      isTyping.current = true;
+      dirtySinceBeat.current = false;
+      onTypingChange(true);
+      if (heartbeatTimer.current) clearInterval(heartbeatTimer.current);
+      heartbeatTimer.current = setInterval(() => {
+        // Re-check enabled in case the turn flipped between beats.
+        if (!enabled || !isTyping.current) return;
+        if (!dirtySinceBeat.current) return;
         onTypingChange?.(true);
-      }, TYPING_START_DELAY_MS);
+        dirtySinceBeat.current = false;
+      }, HEARTBEAT_MS);
+    } else {
+      // Already typing — just mark dirty so the next heartbeat
+      // tick sends a refresh.
+      dirtySinceBeat.current = true;
     }
-    // Refresh the idle timer on every keystroke. When it fires we emit
-    // ``typing_stop`` and cancel any pending start so a buffered start
-    // can't sneak through after we've already gone quiet.
+    // Refresh the idle timer on every keystroke. When it fires
+    // we emit ``typing_stop`` and clear the heartbeat.
     if (idleTimer.current) clearTimeout(idleTimer.current);
-    idleTimer.current = setTimeout(() => {
-      idleTimer.current = null;
-      if (pendingStartTimer.current) {
-        clearTimeout(pendingStartTimer.current);
-        pendingStartTimer.current = null;
-      }
-      if (isTyping.current) {
-        isTyping.current = false;
-        onTypingChange?.(false);
-      }
-    }, TYPING_IDLE_MS);
+    idleTimer.current = setTimeout(emitTypingStop, STOP_AFTER_IDLE_MS);
   }
 
   useEffect(() => {
     return () => {
-      if (pendingStartTimer.current) clearTimeout(pendingStartTimer.current);
+      // Unmount cleanup — clear timers + send a final stop so
+      // peers don't see a stuck "X is typing…" indicator for
+      // the length of TYPING_VISIBLE_MS after we navigate away.
+      if (heartbeatTimer.current) clearInterval(heartbeatTimer.current);
       if (idleTimer.current) clearTimeout(idleTimer.current);
       if (isTyping.current && onTypingChange) {
         isTyping.current = false;
@@ -185,25 +197,19 @@ export function Composer({
     };
   }, [onTypingChange]);
 
-  // When the turn ends mid-typing burst the composer goes ``disabled``
-  // but the timers are still in flight. Without this hook the indicator
-  // would linger on other clients for up to TYPING_IDLE_MS after the
-  // turn flipped, falsely suggesting we're still composing.
+  // When the turn ends mid-typing burst the composer goes
+  // ``disabled`` but the timers are still in flight. Without this
+  // hook the indicator would linger on other clients for the
+  // remaining TTL window after the turn flipped, falsely
+  // suggesting we're still composing.
   useEffect(() => {
     if (enabled) return;
-    if (pendingStartTimer.current) {
-      clearTimeout(pendingStartTimer.current);
-      pendingStartTimer.current = null;
-    }
-    if (idleTimer.current) {
-      clearTimeout(idleTimer.current);
-      idleTimer.current = null;
-    }
-    if (isTyping.current) {
-      isTyping.current = false;
-      onTypingChange?.(false);
-    }
-  }, [enabled, onTypingChange]);
+    emitTypingStop();
+    // emitTypingStop is stable per render; only re-run when
+    // ``enabled`` flips so we don't churn on onTypingChange
+    // identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
 
   const hasImpersonate = (impersonateOptions?.length ?? 0) > 0;
 

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -74,17 +74,20 @@ export function Composer({
   // after STOP_AFTER_IDLE_MS so the receiver doesn't have to
   // wait for the TTL sweep to evict.
   //
-  // ``pendingStartTimer`` (revived from pre-PR with a much shorter
-  // window) keeps a single fat-finger keystroke from broadcasting
-  // a ghost indicator: TYPING_START_DELAY_MS=500 means the
-  // receiver only sees us as typing after we've been at the
-  // keyboard for half a second. UI/UX review BLOCK B-1 — the
-  // immediate-fire path re-introduced the issue #53 flicker.
+  // ``pendingStartTimer`` keeps a single fat-finger keystroke from
+  // broadcasting a ghost indicator (UI/UX review BLOCK B-1; original
+  // issue #53). When it fires we count keystrokes-since-schedule:
+  // <2 means the user typed once and stopped (no broadcast); ≥2
+  // means they're really at the keyboard (start fires + heartbeat
+  // begins). Without the count gate the timer would still emit
+  // start for a single keystroke that didn't clear the textarea —
+  // Copilot review on PR #99.
   const heartbeatTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingStartTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isTyping = useRef(false);
   const dirtySinceBeat = useRef(false);
+  const keystrokesInGate = useRef(0);
   const TYPING_START_DELAY_MS = 500;
   const HEARTBEAT_MS = 1000;
   const STOP_AFTER_IDLE_MS = 2500;
@@ -149,6 +152,7 @@ export function Composer({
       clearTimeout(pendingStartTimer.current);
       pendingStartTimer.current = null;
     }
+    keystrokesInGate.current = 0;
   }
 
   // Reasons logged at every emitTypingStop call site so a "stuck
@@ -176,19 +180,27 @@ export function Composer({
       return;
     }
     if (!isTyping.current) {
-      if (pendingStartTimer.current) {
-        // First keystroke already started the gate; subsequent
-        // keystrokes inside the start window let it fire on
-        // schedule (we don't reset the timer).
-      } else {
+      keystrokesInGate.current += 1;
+      if (!pendingStartTimer.current) {
         // First keystroke since silence: schedule a delayed
         // ``typing_start`` so a single fat-finger doesn't
         // surface a ghost indicator on every peer (UI/UX
-        // review BLOCK B-1; original issue #53). When the
-        // gate fires, kick off the 1 Hz heartbeat.
+        // review BLOCK B-1; original issue #53). The gate
+        // requires ≥2 keystrokes before firing — without that
+        // count check, a single keystroke that doesn't clear
+        // the textarea still emitted start when the timer
+        // fired (Copilot review on PR #99).
         pendingStartTimer.current = setTimeout(() => {
           pendingStartTimer.current = null;
+          const count = keystrokesInGate.current;
+          keystrokesInGate.current = 0;
           if (!enabled) return;
+          if (count < 2) {
+            // User typed once and stopped — don't broadcast.
+            // The idle timer (still scheduled) will tear down
+            // any state when STOP_AFTER_IDLE_MS elapses.
+            return;
+          }
           isTyping.current = true;
           dirtySinceBeat.current = false;
           onTypingChange?.(true);

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -161,14 +161,22 @@ export function Transcript({
     const r = roleById.get(id);
     return r ? [`${r.label}${r.display_name ? ` · ${r.display_name}` : ""}`] : [];
   });
-  const typingLabel =
-    typing.length === 0
-      ? null
-      : typing.length === 1
-        ? `${typing[0]} is typing…`
-        : typing.length === 2
-          ? `${typing[0]} and ${typing[1]} are typing…`
-          : `${typing[0]}, ${typing[1]} and ${typing.length - 2} more are typing…`;
+  // Issue #77 multi-typer aggregation. Prior implementation
+  // collapsed everything ≥3 into "X, Y and N more"; the new spec
+  // names exactly three when there are three (avoids the awkward
+  // "X, Y and 1 more"), and at ≥4 collapses to a playful catch-
+  // all so the indicator doesn't grow unboundedly during a
+  // synchronous flurry.
+  let typingLabel: string | null = null;
+  if (typing.length === 1) {
+    typingLabel = `${typing[0]} is typing…`;
+  } else if (typing.length === 2) {
+    typingLabel = `${typing[0]} and ${typing[1]} are typing…`;
+  } else if (typing.length === 3) {
+    typingLabel = `${typing[0]}, ${typing[1]} and ${typing[2]} are typing…`;
+  } else if (typing.length >= 4) {
+    typingLabel = "Everyone is hammering away at their keyboards…";
+  }
   return (
     <div
       className="flex flex-col gap-3"

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -164,9 +164,14 @@ export function Transcript({
   // Issue #77 multi-typer aggregation. Prior implementation
   // collapsed everything ≥3 into "X, Y and N more"; the new spec
   // names exactly three when there are three (avoids the awkward
-  // "X, Y and 1 more"), and at ≥4 collapses to a playful catch-
+  // "X, Y and 1 more"), and at ≥4 collapses to a neutral catch-
   // all so the indicator doesn't grow unboundedly during a
-  // synchronous flurry.
+  // synchronous flurry. The catch-all copy was originally
+  // "Everyone is hammering away at their keyboards…" per the
+  // issue body, but the User + UI/UX reviewers flagged it as
+  // tonally wrong for tense IR scenarios — switched to
+  // "All participants are responding…" which is neutral and
+  // safe to render mid-incident.
   let typingLabel: string | null = null;
   if (typing.length === 1) {
     typingLabel = `${typing[0]} is typing…`;
@@ -175,7 +180,7 @@ export function Transcript({
   } else if (typing.length === 3) {
     typingLabel = `${typing[0]}, ${typing[1]} and ${typing[2]} are typing…`;
   } else if (typing.length >= 4) {
-    typingLabel = "Everyone is hammering away at their keyboards…";
+    typingLabel = "All participants are responding…";
   }
   return (
     <div
@@ -255,6 +260,10 @@ export function Transcript({
         );
       })}
       {aiThinking ? (
+        // ``silent`` because the wrapping <div role="log"
+        // aria-live="polite" aria-relevant="additions text"> already
+        // announces additions; nesting another aria-live region would
+        // double-announce on NVDA (UI/UX review HIGH H-1).
         <ChatIndicator
           label={
             aiStatusLabel
@@ -262,9 +271,12 @@ export function Transcript({
               : "AI Facilitator is typing…"
           }
           tone="ai"
+          silent
         />
       ) : null}
-      {typingLabel ? <ChatIndicator label={typingLabel} tone="player" /> : null}
+      {typingLabel ? (
+        <ChatIndicator label={typingLabel} tone="player" silent />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -35,11 +35,11 @@ interface CreatorState {
 const NUDGE_PROPOSE = "I think we have enough context. Please draft the scenario plan now.";
 
 // Receiver-side typing indicator timings — kept in sync with
-// Play.tsx (see the long comment there). Issue #77: 3.5 s TTL +
-// 1.5 s head start on stop, paired with the 1 Hz heartbeat sender
-// in Composer. Tolerates one dropped beat without flicker.
-const TYPING_VISIBLE_MS = 3500;
-const TYPING_FADE_HEAD_START_MS = TYPING_VISIBLE_MS - 1500;
+// Play.tsx (see the long comment there). Issue #77 + UI/UX
+// review M-1: 4.5 s TTL + 0.5 s linger after explicit stop,
+// paired with the 1 Hz heartbeat sender in Composer.
+const TYPING_VISIBLE_MS = 4500;
+const TYPING_FADE_HEAD_START_MS = TYPING_VISIBLE_MS - 500;
 
 /**
  * Sample setup answers prefilled when the operator toggles "Dev mode" on
@@ -202,6 +202,9 @@ export function Facilitator() {
   const [connectionCount, setConnectionCount] = useState<number | null>(null);
   const wsRef = useRef<WsClient | null>(null);
   const forceAdvanceTimerRef = useRef<number | null>(null);
+  // Rate-limit the typing-send-dropped log to one line per WS
+  // state edge (issue #77 logging fix; see ``handleTypingChange``).
+  const typingSendErrLoggedRef = useRef(false);
   useEffect(() => {
     return () => {
       if (forceAdvanceTimerRef.current !== null) {
@@ -770,8 +773,17 @@ export function Facilitator() {
   function handleTypingChange(typing: boolean) {
     try {
       wsRef.current?.send({ type: typing ? "typing_start" : "typing_stop" });
-    } catch {
-      /* WS can be closed mid-typing; never throw out of this handler. */
+      typingSendErrLoggedRef.current = false;
+    } catch (err) {
+      // Rate-limited log per WS-state edge (issue #77 — 1 Hz
+      // heartbeat would otherwise produce ~60 logs/min through a
+      // closed WS during a typing burst).
+      if (!typingSendErrLoggedRef.current) {
+        console.debug("[facilitator] typing send dropped (WS likely closed)", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+        typingSendErrLoggedRef.current = true;
+      }
     }
   }
 

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -34,10 +34,11 @@ interface CreatorState {
 
 const NUDGE_PROPOSE = "I think we have enough context. Please draft the scenario plan now.";
 
-// Receiver-side typing indicator timings — kept in sync with Play.tsx.
-// See issue #53: the indicator should appear cleanly on a real typing
-// burst and persist for about three seconds, never flickering.
-const TYPING_VISIBLE_MS = 5000;
+// Receiver-side typing indicator timings — kept in sync with
+// Play.tsx (see the long comment there). Issue #77: 3.5 s TTL +
+// 1.5 s head start on stop, paired with the 1 Hz heartbeat sender
+// in Composer. Tolerates one dropped beat without flicker.
+const TYPING_VISIBLE_MS = 3500;
 const TYPING_FADE_HEAD_START_MS = TYPING_VISIBLE_MS - 1500;
 
 /**

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -771,8 +771,24 @@ export function Facilitator() {
   }
 
   function handleTypingChange(typing: boolean) {
+    const ws = wsRef.current;
+    if (!ws) {
+      // WS ref is null (not yet connected, or torn down after
+      // creator-token revoke). Without an explicit check the
+      // optional-chain ``ws?.send(...)`` would silently no-op
+      // and the catch below would never fire — Copilot review
+      // on PR #99.
+      if (!typingSendErrLoggedRef.current) {
+        console.debug(
+          "[facilitator] typing send dropped (WS not connected)",
+          { typing },
+        );
+        typingSendErrLoggedRef.current = true;
+      }
+      return;
+    }
     try {
-      wsRef.current?.send({ type: typing ? "typing_start" : "typing_stop" });
+      ws.send({ type: typing ? "typing_start" : "typing_stop" });
       typingSendErrLoggedRef.current = false;
     } catch (err) {
       // Rate-limited log per WS-state edge (issue #77 — 1 Hz

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -19,18 +19,19 @@ const DISPLAY_NAME_KEY = "atf-display-name";
 // Receiver-side typing config. ``TYPING_VISIBLE_MS`` is how long
 // an indicator survives after the most recent ``typing_start``
 // arrival before the cutoff sweep evicts it. ``TYPING_FADE_HEAD_START_MS``
-// is the head start applied when ``typing_stop`` arrives — i.e.
-// how long we keep the chip visible after the sender goes quiet.
+// is the head start applied when ``typing_stop`` arrives —
+// linger after explicit stop = ``TYPING_VISIBLE_MS - TYPING_FADE_HEAD_START_MS``.
 //
-// Issue #77: now that the sender heart-beats at 1 Hz (see
-// ``HEARTBEAT_MS`` in Composer.tsx) we can run the TTL much
-// tighter. 3.5 s tolerates exactly one dropped heartbeat
-// without flicker; two consecutive drops fade the indicator —
-// the right tradeoff between "stuck-on after disconnect" and
-// "flicker on a single dropped packet". The 1.5 s head start on
-// stop is unchanged so an explicit stop still lingers ~2 s.
-const TYPING_VISIBLE_MS = 3500;
-const TYPING_FADE_HEAD_START_MS = TYPING_VISIBLE_MS - 1500;
+// Issue #77 + UI/UX review M-1: 4.5 s TTL paired with the 1 Hz
+// sender heartbeat tolerates two dropped beats without flicker
+// (was 3.5 s = one drop). Important on flaky cellular where
+// 2-packet bursts of loss are common. Head start 4 s leaves a
+// 0.5 s linger after explicit stop; combined with the sender's
+// 2.5 s idle window that gives ~3 s wall-clock from last
+// keystroke to chip removal — within the user's "2-3 seconds
+// after they stop typing" ask in the issue body.
+const TYPING_VISIBLE_MS = 4500;
+const TYPING_FADE_HEAD_START_MS = TYPING_VISIBLE_MS - 500;
 
 export function Play({ sessionId, token }: Props) {
   const [displayName, setDisplayName] = useState<string | null>(
@@ -383,11 +384,24 @@ export function Play({ sessionId, token }: Props) {
     }
   }
 
+  // Rate-limit the "send dropped" log to once per WS-state
+  // transition: with the 1 Hz heartbeat (issue #77) a closed WS
+  // could otherwise produce ~60 logs/min during a typing burst,
+  // which is the noise the prior silent-catch was avoiding.
+  // QA logging review HIGH: silent swallows are bugs even on a
+  // hot path — log once per state edge, not once per call.
+  const typingSendErrLoggedRef = useRef(false);
   function handleTypingChange(t: boolean) {
     try {
       wsRef.current?.send({ type: t ? "typing_start" : "typing_stop" });
-    } catch {
-      /* ignore — WS may have closed mid-typing. */
+      typingSendErrLoggedRef.current = false;
+    } catch (err) {
+      if (!typingSendErrLoggedRef.current) {
+        console.debug("[play] typing send dropped (WS likely closed)", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+        typingSendErrLoggedRef.current = true;
+      }
     }
   }
 

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -16,14 +16,20 @@ interface Props {
 
 const DISPLAY_NAME_KEY = "atf-display-name";
 
-// Receiver-side typing config. ``TYPING_VISIBLE_MS`` is how long an
-// indicator survives after the most recent ``typing_start`` arrival
-// before the cutoff sweep evicts it. ``TYPING_FADE_HEAD_START_MS`` is
-// the head start applied when ``typing_stop`` arrives — i.e. how long
-// we keep the chip visible after the sender goes quiet. Together they
-// keep the indicator on screen for ~3 seconds of actual conversation
-// and prevent the on/off flash reported in issue #53.
-const TYPING_VISIBLE_MS = 5000;
+// Receiver-side typing config. ``TYPING_VISIBLE_MS`` is how long
+// an indicator survives after the most recent ``typing_start``
+// arrival before the cutoff sweep evicts it. ``TYPING_FADE_HEAD_START_MS``
+// is the head start applied when ``typing_stop`` arrives — i.e.
+// how long we keep the chip visible after the sender goes quiet.
+//
+// Issue #77: now that the sender heart-beats at 1 Hz (see
+// ``HEARTBEAT_MS`` in Composer.tsx) we can run the TTL much
+// tighter. 3.5 s tolerates exactly one dropped heartbeat
+// without flicker; two consecutive drops fade the indicator —
+// the right tradeoff between "stuck-on after disconnect" and
+// "flicker on a single dropped packet". The 1.5 s head start on
+// stop is unchanged so an explicit stop still lingers ~2 s.
+const TYPING_VISIBLE_MS = 3500;
 const TYPING_FADE_HEAD_START_MS = TYPING_VISIBLE_MS - 1500;
 
 export function Play({ sessionId, token }: Props) {

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -392,8 +392,23 @@ export function Play({ sessionId, token }: Props) {
   // hot path — log once per state edge, not once per call.
   const typingSendErrLoggedRef = useRef(false);
   function handleTypingChange(t: boolean) {
+    const ws = wsRef.current;
+    if (!ws) {
+      // WS ref is null — the WS hasn't connected yet, or
+      // ConnectionManager torched it after a 4401 / spectator
+      // boundary. ``ws?.send(...)`` would silently no-op and the
+      // catch below would never fire (Copilot review on PR #99).
+      // Log the drop here on the false-true edge.
+      if (!typingSendErrLoggedRef.current) {
+        console.debug("[play] typing send dropped (WS not connected)", {
+          typing: t,
+        });
+        typingSendErrLoggedRef.current = true;
+      }
+      return;
+    }
     try {
-      wsRef.current?.send({ type: t ? "typing_start" : "typing_stop" });
+      ws.send({ type: t ? "typing_start" : "typing_stop" });
       typingSendErrLoggedRef.current = false;
     } catch (err) {
       if (!typingSendErrLoggedRef.current) {


### PR DESCRIPTION
## Summary

Phase C of the multi-issue plan (`/root/.claude/plans/fluffy-brewing-scott.md`) — the typing-indicator overhaul.

**#77 — Typing indicator must be continuous + multi-typer aggregation**

Switches the typing indicator from one-shot transition events to a 1 Hz heartbeat-while-typing model with receiver-side TTL. Pre-fix a single dropped `typing_start` (or a brief pause that crossed the receiver's eviction window) made the indicator vanish mid-typing and never come back; post-fix the heartbeat refreshes the receiver every second a typist is at the keyboard, fading naturally on stop / submit / disable. Multi-typer label gets the 1/2/3/≥4-typer phrasings called out in the issue.

### Changes

| Surface | Change |
|---|---|
| `frontend/src/components/Composer.tsx` | Sender: 500 ms start gate → typing_start → 1 Hz heartbeat (`dirtySinceBeat` flag prevents firing during pauses) → idle stop after 2.5 s. `console.debug("[composer] typing_stop", { reason })` breadcrumbs. |
| `frontend/src/components/Transcript.tsx` | Multi-typer formatter: 1 / 2 / 3 / ≥4. ≥4 collapses to **"All participants are responding…"** (neutral copy — see "Tonal copy" below). |
| `frontend/src/components/ChatIndicator.tsx` | `silent` prop drops nested `role="status"` + `aria-live="polite"`; `max-w-full break-words` so 3-typer labels don't push the column wider on mobile. |
| `frontend/src/pages/Play.tsx` + `Facilitator.tsx` | Receiver TTL: `TYPING_VISIBLE_MS = 4500` (was 5000), head-start `4000` (linger 500 ms after explicit stop). Both pages log typing-send drops once per WS-state edge. |
| `backend/app/ws/routes.py` | `_broadcast_typing` emits a single `ws_typing_broadcast` debug line per packet for operator bisection. |

### Sub-agent review pipeline

Six reviewers run per `CLAUDE.md`. 0 BLOCK / 0 CRITICAL. The HIGH list returned by the pipeline was addressed in the second commit on this branch (`phase-c: address sub-agent review findings`):

- Restored 500 ms start-delay gate (UI/UX BLOCK B-1: single-keystroke flicker regression)
- Mobile overflow on 3-typer label (UI/UX BLOCK B-2)
- Dropped nested aria-live (UI/UX HIGH H-1)
- TTL bumped 3500→4500 + 0.5 s linger (UI/UX M-1, Product HIGH)
- Logging breadcrumbs on `emitTypingStop` reason, the WS try/catch in both pages, and `_broadcast_typing` (Security L2 + project logging policy)
- Test coverage gaps: cadence upper bound, heartbeat-skip then resume, 2.4 s pause boundary, Shift+Enter, post-submit re-typing, ordering, no-nested-aria-live, ≥4-typer copy

### Tonal copy on ≥4 typers — heads-up

Issue #77 body asked verbatim for "Everyone is hammering away at their keyboards…". Both the User Agent and UI/UX reviewer flagged this as tonally wrong for tense IR scenarios — "Patient records are being exfiltrated, what's your call?" + "Everyone is hammering away at their keyboards…" reads as the app cracking a joke at the wrong moment. With your explicit approval mid-implementation we swapped to **"All participants are responding…"** — neutral, safe mid-incident. If you want the playful version back for setup/lobby phases only, that's a small follow-up.

### Follow-up

Issue #97 — roster-side disconnect chip ("Bridget — reconnecting") — opened as a separate tracking issue. User Agent flagged it as a real product gap; it's a presence-channel feature, not a typing-indicator concern.

## Test plan

- [x] `cd frontend && npm test -- --run` — 116/116 (was 95 pre-Phase-C; +21 new cases)
- [x] `cd frontend && npm run lint && npm run typecheck` — clean
- [x] `cd backend && pytest -q` — 287 passed, 16 skipped
- [x] `cd backend && ruff check . && mypy app` — clean
- [ ] Manual QA path:
  - [ ] Type continuously for 30 s in one tab; the chip stays visible in the other tab without flicker.
  - [ ] Pause for 5 s mid-thought; chip lingers ~3 s after last keystroke then fades.
  - [ ] Resume typing 1 s later; chip re-illuminates within 1-2 s.
  - [ ] Three participants typing simultaneously: chip reads "X, Y and Z are typing…".
  - [ ] Four participants typing: chip reads "All participants are responding…".
  - [ ] Single fat-finger keystroke (one char, then stop): no chip surfaces on peer tabs.
  - [ ] Close a tab mid-typing-burst (no clean stop): chip fades within ~4.5 s on peers.
  - [ ] On a 375 px-wide viewport, 3-typer label wraps cleanly inside the column (no horizontal scroll).
  - [ ] NVDA / VoiceOver: chip mounting announces once, not twice (no nested live regions).

Closes #77

https://claude.ai/code/session_0122qBQpK5Nwt7rBctwK4de5

---
_Generated by [Claude Code](https://claude.ai/code/session_0122qBQpK5Nwt7rBctwK4de5)_