### PR TITLE
devcontainer: switch to prebuilt python:3.12 image to fix Codespace builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
   "name": "ai-tabletop-facilitator",
+  // Use the prebuilt Python image instead of base+python-feature: bookworm only ships
+  // 3.11 in apt, so the python feature falls back to a from-source build that fetches
+  // the Python release-signing GPG key from public hkp keyservers. Codespaces egress
+  // can't reach those keyservers and the build hangs. See PR #100.
   "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
   "name": "ai-tabletop-facilitator",
-  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.12",
-      "installTools": true
-    },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"
     },


### PR DESCRIPTION
## Summary

Codespace / devcontainer builds were hanging in the `ghcr.io/devcontainers/features/python:1` install step with:

```
(*) Keyserver hkp://keyserver.ubuntu.com is not reachable.
(*) Keyserver hkp://keyserver.pgp.com is not reachable.
gpg: keyserver receive failed: No data
(*) Failed getting key, retrying in 10s...
```

## Root cause

- Base image was `mcr.microsoft.com/devcontainers/base:bookworm`. Bookworm only ships Python 3.11 in apt.
- The python feature was asked for 3.12, so it fell back to a from-source build.
- That build path verifies the Python release-signing GPG key against public hkp keyservers (`keyserver.ubuntu.com`, `keyserver.pgp.com`).
- The Codespace builder's egress can't reach those keyservers, so it loops on retries until the build dies.

This started failing recently without any local changes — the python feature's source-build path appears to have added/tightened the GPG verification step.

## Fix

Switch to the prebuilt `mcr.microsoft.com/devcontainers/python:1-3.12-bookworm` image, which already has Python 3.12 installed. No source build, no keyserver fetch. The python devcontainer feature is dropped because it's now redundant.

`python` on `PATH` and `/usr/local/python/current/bin/python` both still resolve, so:
- `.devcontainer/post-create.sh` (uses `python -m pip ...`) keeps working.
- The VS Code `python.defaultInterpreterPath` setting keeps working.

Backend `pyproject.toml` requires `>=3.12`, so downgrading to 3.11 (the alternative fix) wasn't an option.

## Test plan

- [ ] Rebuild the Codespace from this branch and confirm the container builds without keyserver retries
- [ ] Confirm `python --version` reports 3.12.x inside the container
- [ ] Confirm `post-create.sh` completes (backend `pip install -e backend[dev]` + `npm ci`)
- [ ] Confirm `uvicorn app.main:app --reload --app-dir backend` starts
- [ ] Confirm the VS Code Python extension picks up the interpreter

https://claude.ai/code/session_01DUNWZiwNv7D3pj2qHqQP5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUNWZiwNv7D3pj2qHqQP5w)_