### PR TITLE
devcontainer: drop stale yarn apt source so docker-in-docker installs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+# Extends the prebuilt Python 3.12 devcontainer image to drop a stale Yarn apt
+# source. The upstream image ships /etc/apt/sources.list.d/yarn.list pointing at
+# dl.yarnpkg.com, but Yarn rotated their signing key (62D54FD4003F6525) and the
+# image hasn't been rebuilt with the new one. Any feature that runs apt-get
+# update (e.g. docker-in-docker) then fails with NO_PUBKEY. Removing the file
+# is safe — nothing in this repo uses Yarn, and the Node devcontainer feature
+# can install it on demand.
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+RUN rm -f /etc/apt/sources.list.d/yarn.list

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,13 @@
   // 3.11 in apt, so the python feature falls back to a from-source build that fetches
   // the Python release-signing GPG key from public hkp keyservers. Codespaces egress
   // can't reach those keyservers and the build hangs. See PR #100.
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+  //
+  // We extend the image via Dockerfile to drop a stale Yarn apt source whose key was
+  // rotated (NO_PUBKEY 62D54FD4003F6525); without that, any feature running apt-get
+  // update (e.g. docker-in-docker) fails. See .devcontainer/Dockerfile.
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"


### PR DESCRIPTION
## Summary

After PR #100 (switch to prebuilt Python image) merged, Codespace creation got further but now fails on the **docker-in-docker** feature install:

```
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease:
   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
ERROR: Feature "Docker (Docker-in-Docker)" failed to install!
```

## Root cause

The prebuilt `mcr.microsoft.com/devcontainers/python:1-3.12-bookworm` image ships `/etc/apt/sources.list.d/yarn.list` pointing at `dl.yarnpkg.com`. Yarn rotated their signing key (`62D54FD4003F6525`) and the upstream image hasn't been rebuilt with the new key. Any feature that runs `apt-get update` during install (docker-in-docker does) fails on the unverified repo.

## Fix

Switch from `"image": "..."` to `"build": {"dockerfile": "Dockerfile"}` and have a tiny `.devcontainer/Dockerfile` `rm -f /etc/apt/sources.list.d/yarn.list` before features run.

Removing the file is safe:
- Nothing in this repo uses Yarn (frontend uses npm; `npm ci` in `post-create.sh`).
- The Node devcontainer feature can install Yarn on demand if ever needed.

## Test plan

- [ ] Rebuild Codespace from this branch — verify `docker-in-docker` feature install completes
- [ ] Confirm `python --version` still reports 3.12.x
- [ ] Confirm `node --version` reports 20.x (Node feature)
- [ ] Confirm `docker version` works inside the container (DinD)
- [ ] Confirm `post-create.sh` completes
- [ ] Confirm `uvicorn app.main:app --reload --app-dir backend` starts

https://claude.ai/code/session_01DUNWZiwNv7D3pj2qHqQP5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUNWZiwNv7D3pj2qHqQP5w)_