### PR TITLE
license: switch from MIT to FSL-1.1-ALv2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,75 @@
-MIT License
+# Functional Source License, Version 1.1, ALv2 Future License
 
-Copyright (c) 2026 nebriv
+## Abbreviation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+FSL-1.1-ALv2
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Notice
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright 2026 nebriv
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under these Terms and Conditions, as indicated by our inclusion of these Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents, Redistribution and Trademark clauses below, we hereby grant you the right to use, copy, modify, create derivative works, publicly perform, publicly display and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use means making the Software available to others in a commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our patents, the license grant above includes a license under our patents. If you make a claim against any party that the Software infringes or contributes to the infringement of any patent, then your patent license to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software, you must include a copy of or a link to these Terms and Conditions and not remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of the Software, you have no right under these Terms and Conditions to use our trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under the Apache License, Version 2.0 that is effective on the second anniversary of the date we make the Software available. On or after that date, you may use the Software under the Apache License, Version 2.0, in which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -136,4 +136,7 @@ Phase-2 acceptance gates are exercised by `backend/tests/test_e2e_session.py`
 
 ## License
 
-MIT — see [`LICENSE`](LICENSE).
+[Functional Source License, Version 1.1, ALv2 Future License](LICENSE)
+(FSL-1.1-ALv2). Free for any non-competing use — including self-hosting,
+internal use, education, and research. Each release converts to Apache
+License 2.0 on the second anniversary of its release date.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ name = "ai-tabletop-facilitator-backend"
 version = "0.0.1"
 description = "Backend for the AI Cybersecurity Tabletop Facilitator."
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = { text = "FSL-1.1-ALv2" }
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -461,7 +461,10 @@ OAuth/SSO authentication, persistent repository (SQLite then Postgres), tenant/o
 
 ## Open Items to Confirm at Approval
 
-- License (recommend MIT).
+- License: FSL-1.1-ALv2 (Functional Source License with Apache-2.0 future grant).
+  Free for any non-competing use; converts to Apache-2.0 two years after each
+  release. Chosen to preserve the option of running a hosted SaaS without
+  closing the source.
 - GHCR image name (`ghcr.io/nebriv/ai-tabletop-facilitator`?).
 - Whether to file the Phase 1/2/3 issue stubs immediately on plan approval, or as the first commit on the development branch.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "ai-tabletop-facilitator-frontend",
   "private": true,
   "version": "0.0.1",
+  "license": "SEE LICENSE IN ../LICENSE",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Replaces the MIT license with the **Functional Source License v1.1, Apache-2.0 Future License** (`FSL-1.1-ALv2`).

The FSL is a source-available license that:

- Grants free use for **any non-competing purpose** — self-hosting, internal use, education, research, professional services.
- Disallows running a **competing commercial SaaS** on top of the code.
- **Auto-converts each release to Apache-2.0** on the second anniversary of that release's date. So v1.0 shipped on 2026-05-01 becomes Apache-2.0 on 2028-05-01, etc. The conversion is irrevocable and baked into the license text — nothing has to be done to trigger it.

The motivation is to preserve the option of running a hosted SaaS at some point without closing the source. If that never happens, the license auto-converts to Apache-2.0 on a rolling 2-year window anyway, so the project ends up effectively permissive whether or not the SaaS path is taken.

## Caveats worth surfacing

- **Not OSI-approved.** "Source available," not "open source" by the OSI definition. Contributors who require OSI status will not contribute.
- **Most of the codebase is AI-generated**, which means the underlying copyright claim is thinner than for hand-written code. The license is still useful as a deterrent and a signal of intent, but realistic enforcement tops out at "send a strongly-worded email."
- **The dep-intake checklist in `CLAUDE.md` is unchanged.** It still requires deps to be MIT / BSD / Apache-2 / ISC — that rule is about *dependency* license compatibility, not the project's own license, and FSL is compatible with all of those incoming.

## Files changed

- `LICENSE` — replaced MIT text with the canonical FSL-1.1-ALv2 template (copyright 2026 nebriv).
- `backend/pyproject.toml` — `license = { text = "FSL-1.1-ALv2" }`.
- `frontend/package.json` — added `"license": "SEE LICENSE IN ../LICENSE"`.
- `README.md` — License section now describes FSL-1.1-ALv2 and the 2-year Apache-2.0 future grant.
- `docs/PLAN.md` — Open-item updated from "recommend MIT" to FSL-1.1-ALv2 with rationale.

## Test plan

- [ ] Confirm `LICENSE` file at repo root renders the FSL text (GitHub auto-detects FSL and labels the repo accordingly).
- [ ] `cd backend && python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['license'])"` returns `{'text': 'FSL-1.1-ALv2'}`.
- [ ] `README.md` License section reads correctly.
- [ ] No CI / lint regressions (license change is metadata-only; no code paths touched).

https://claude.ai/code/session_01A2Ah6y2W26KTsT6BWdkEpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2Ah6y2W26KTsT6BWdkEpx)_