### PR TITLE
chore: add Copilot code-review custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# Copilot code review instructions
+
+Review the diff and report **issues only** — no praise, no summaries. Format:
+
+`[SEVERITY] file:line — issue — fix`
+
+Severities: **BLOCK** (must fix), **HIGH** (this PR), **MEDIUM** (soon), **LOW** (nit). Skip below LOW. Clean category → say "clean".
+
+Be specific. Quote the offending line. Group findings with one root cause. Path-specific rules in `.github/instructions/` also apply.
+
+## 1. Correctness
+- Off-by-one, null/undefined, unhandled empty cases, inverted conditions
+- Race conditions, missing `await`, shared mutable state
+- Swallowed exceptions, bare `except`, retries without backoff
+- Resource leaks (unclosed files/sockets, missing `with`/`using`)
+
+## 2. Security
+- Injection: SQL, command, shell, XSS, template, **prompt injection** — any user/model output flowing back into a prompt or tool call
+- AuthN/AuthZ: missing checks, IDOR (fetching by id without owner check), trust-boundary violations
+- Secrets in code, logs, URLs, or env files
+- Boundary input validation (HTTP, WS, file upload, deserialization); SSRF; path traversal; open redirect
+- Crypto: weak hashes, MD5/SHA1 for security, non-constant-time compare, predictable randomness for security
+- CORS, CSRF, missing rate limits on expensive endpoints, unbounded request bodies
+- New deps: known CVEs, >12mo unmaintained, copyleft license — **BLOCK** without justification in the PR body
+
+## 3. Code smells
+- Duplicated logic (>3 similar blocks), long functions (>~50 lines), nesting >3, god objects
+- Magic numbers/strings, dead code, commented-out code, unused imports
+- Premature abstraction (interface with one impl), speculative generality
+- Dense one-liners, nested ternaries, regex without explanation
+- Comments restating *what* instead of *why*; comments referencing the current task/PR (rot fast)
+- Inconsistent naming; mixed I/O + logic + formatting in one function
+- Backwards-compat shims for code with no callers; `_var` renames for "unused" params; `// removed` placeholders
+
+## 4. Performance
+- N+1 queries, missing indexes implied by new query patterns, full-table scans
+- Blocking I/O on async paths, sync calls inside loops, missing pagination
+- Unbounded loops/recursion, O(n²) over user-controlled n, large in-memory accumulations
+
+## 5. API & contract
+- Breaking changes to public APIs/types/DB schema without migration path
+- Inconsistent error shapes, missing status codes, internals leaking in error messages
+- New endpoints missing auth, validation, or rate limiting
+
+## 6. Tests
+- New logic without tests; happy-path-only coverage; missing negative/edge cases
+- Tests asserting implementation instead of behavior; flaky time/random/network deps
+- Snapshot tests committed without reviewing the snapshot
+- Skipped tests (`@pytest.mark.skip`, `it.skip`) without a tracking issue
+
+## 7. Observability
+- New external call without start/end log line at the boundary
+- Swallowed exception without log
+- Log line missing IDs needed to debug it (`request_id`, `session_id`, `role_id`, `turn_id`)
+- Logging secrets, tokens, full payloads, or PII
+- Frontend `console.*` without a `[module]` prefix
+
+## 8. Docs & migrations
+- Public API/behavior change without README/CHANGELOG/comment update
+- DB migration without rollback or without considering existing rows
+- New env var added without entry in `docs/configuration.md`
+
+## 9. PR body
+- Comma-list closing keyword (`Closes #1, #2, #3`) — only `#1` auto-closes. Repeat per issue.
+- Closing keyword next to an issue number you don't want to close (negation, rhetorical question) → **BLOCK**. GitHub's parser ignores surrounding context.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Review the diff and report **issues only** — no praise, no summaries. Format:
 
 `[SEVERITY] file:line — issue — fix`
 
-Severities: **BLOCK** (must fix), **HIGH** (this PR), **MEDIUM** (soon), **LOW** (nit). Skip below LOW. Clean category → say "clean".
+Severities: **BLOCK** (must fix), **HIGH** (this PR), **MEDIUM** (soon), **LOW** (nit). Skip below LOW. Report only categories with findings; if there are zero findings overall, say "no issues" once. Do not emit per-category headers for clean categories.
 
 Be specific. Quote the offending line. Group findings with one root cause. Path-specific rules in `.github/instructions/` also apply.
 

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,38 @@
+---
+applyTo: "backend/**"
+---
+
+# Backend (Python) review
+
+## Logging (`structlog`)
+- `print` or `import logging` in business code → **BLOCK**. Use `from app.logging_setup import get_logger`.
+- `event=` kwarg passed to a log call → **HIGH**. `event` is reserved by structlog (the message key). Use `audit_kind`, `tool_name`, etc.
+- Re-passing fields already bound by middleware (`request_id`, `session_id`, `turn_id`, `role_id`) → **LOW**. They're inherited automatically.
+- New external boundary without `*_start` + `*_complete` / `*_failed` log lines → **HIGH**. LLM calls, DB calls, WS connect/disconnect, tool dispatch, and extension dispatch already do this — match the pattern.
+- `try/except` catching a broad exception without logging it before re-raising or swallowing → **BLOCK**. Silent swallows are bugs.
+- Logging `SESSION_SECRET`, `ANTHROPIC_API_KEY`, raw join tokens, or full participant message bodies (>120 char preview) → **BLOCK**
+- Wide payload logged without the `_is_oversized` helper from `sessions/manager.py` → **HIGH**
+- Any review finding that calls out a swallowed exception, missing log at a meaningful boundary, silent fallback path, or anything else that hinders production debugging → **HIGH** even if it would otherwise be MEDIUM/LOW. Logging gaps are not "nits" — they're the difference between a 5-minute and a 5-hour diagnose.
+
+## Config & types
+- Hardcoded config value that should be env-driven via `pydantic-settings` → **HIGH**
+- New env var without an entry in `docs/configuration.md` → **HIGH**
+- `# type: ignore` without a one-line explanation → **MEDIUM**
+- `ruff` violations → **MEDIUM**
+
+## Async
+- Sync I/O on an async path → **BLOCK**
+- Global lock instead of per-session lock → **HIGH**
+- New endpoint synchronously awaiting an LLM call (>2s upstream) without an async-then-poll fallback → **HIGH**. Use the long-running-endpoint pattern from `CLAUDE.md`:
+  - `POST` → 200 immediately, sets `*_status="pending"`, kicks `asyncio.create_task(...)`
+  - `GET` → 425 (Retry-After) while pending/generating, 200 when ready, 500 on fail (status revealed in a header)
+  - Optional WS event nudges polling clients to re-fetch
+
+## Auth & WebSocket
+- New WS endpoint without origin + token check → **BLOCK**
+- New HTTP endpoint without rate-limiting on an LLM-bearing path → **HIGH**
+- Authorization done by trusting a client-supplied `role_id` / `session_id` instead of resolving from the auth context → **BLOCK**
+
+## Extensions
+- New extension handler that isn't `templated_text` or `static_text` → **BLOCK** (declarative handlers only, per `docs/extensions.md`)
+- Extension content flowing into the model as system content instead of `tool_result` → **BLOCK** (prompt-injection guardrail)

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -5,7 +5,7 @@ applyTo: "backend/**"
 # Backend (Python) review
 
 ## Logging (`structlog`)
-- `print` or `import logging` in business code → **BLOCK**. Use `from app.logging_setup import get_logger`.
+- `print` or `import logging` in business code → **BLOCK**. Use `get_logger` from the package's `logging_setup` module (match the surrounding file's import style — relative `from ..logging_setup import get_logger` is the common form).
 - `event=` kwarg passed to a log call → **HIGH**. `event` is reserved by structlog (the message key). Use `audit_kind`, `tool_name`, etc.
 - Re-passing fields already bound by middleware (`request_id`, `session_id`, `turn_id`, `role_id`) → **LOW**. They're inherited automatically.
 - New external boundary without `*_start` + `*_complete` / `*_failed` log lines → **HIGH**. LLM calls, DB calls, WS connect/disconnect, tool dispatch, and extension dispatch already do this — match the pattern.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,45 @@
+---
+applyTo: "frontend/**"
+---
+
+# Frontend / UI-UX review
+
+Read `design/handoff/BRAND.md` and `design/handoff/HANDOFF.md` before reviewing UI changes. The "Don't" lists in BRAND.md are load-bearing.
+
+## Design system
+- Ad-hoc inline styles instead of design tokens (`var(--ink-*)`, `var(--paper-*)`, `var(--signal-*)`, `var(--crit-*)`, `var(--warn-*)`, `var(--info-*)`) → **HIGH**
+- Re-derived chrome instead of brand components from `frontend/src/components/brand/` (`<SiteHeader>`, `<StatusChip>`, `<RailHeader>`, `<Eyebrow>`, `<HudGauges>`, `<TurnStateRail>`, `<DieLoader>`, `<BottomActionBar>`) → **HIGH**
+- Fonts loaded from Google Fonts CDN or any other external runtime asset → **BLOCK** (security-team deployments are often air-gapped / strict-CSP). Use the bundled `@fontsource-variable/*` imports.
+- Recoloring the brand mark, marketer-fluff voice, stock photography, emoji as decoration → **BLOCK** (BRAND.md "Don't" list)
+- Marketer voice in user-facing copy. Operator voice. Prefer "Run the inject. Ship the AAR." over "Empower your team to respond."
+- Autoplay of the animated mark on the product side (only marketing). The `<DieLoader>` is the documented exception.
+- New component re-implementing a pattern already in `design/handoff/source/app-screens.jsx` instead of lifting it → **HIGH**
+
+## Interaction (BLOCK by default)
+Mentally walk every phase view through SETUP → READY → PLAY → ENDED at common viewport sizes (mobile, 1080p, 1440p) and report:
+- Content unreachable on a 1080p / 1440p / mobile viewport
+- Primary CTA in any phase not reachable
+- Primary affordances hidden behind clipped overflow or under fixed elements
+- Layout regressions where a previously-reachable control becomes unreachable
+
+## States
+- Missing loading, empty, error, disabled, success states for any new async surface → **HIGH**
+- Blocking spinners on fast operations; missing skeleton on slow ones
+- Form: no inline validation, errors disappear on retype, submit doesn't disable, no optimistic feedback
+
+## Accessibility
+- Missing ARIA labels on icon-only buttons, role mismatches → **HIGH**
+- Color contrast < 4.5:1 against background → **HIGH**
+- Keyboard nav: tab order, focus trap in modals, visible focus ring, Esc to close
+- Focus management on route/modal change
+
+## Logging
+- New API call bypassing `lib/api/client.ts` (loses the `[api]` log wrapper) → **HIGH**
+- Direct `new WebSocket(...)` outside `lib/ws.ts` → **HIGH**
+- `setError(...)` without a matching `console.warn` carrying the same context → **MEDIUM**
+- `console.*` without a `[module]` prefix (`[ws]`, `[api]`, `[facilitator]`, `[play]`) → **LOW**
+- Logging the join token (the URL token on `/play/:id/:token`) anywhere outside the route handler → **BLOCK**
+
+## Communication transport
+- New synchronous POST wrapping an LLM call (>2s upstream) without an async-then-poll fallback → **HIGH** (see the "POST 200 → poll 425/200" pattern in `CLAUDE.md`)
+- Pushing a heavy payload (>~5 KB) via WebSocket instead of a polled HTTP endpoint → **HIGH**

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -34,8 +34,8 @@ Mentally walk every phase view through SETUP → READY → PLAY → ENDED at com
 - Focus management on route/modal change
 
 ## Logging
-- New API call bypassing `lib/api/client.ts` (loses the `[api]` log wrapper) → **HIGH**
-- Direct `new WebSocket(...)` outside `lib/ws.ts` → **HIGH**
+- New API call bypassing `frontend/src/api/client.ts` (loses the `[api]` log wrapper) → **HIGH**
+- Direct `new WebSocket(...)` outside `frontend/src/lib/ws.ts` → **HIGH**
 - `setError(...)` without a matching `console.warn` carrying the same context → **MEDIUM**
 - `console.*` without a `[module]` prefix (`[ws]`, `[api]`, `[facilitator]`, `[play]`) → **LOW**
 - Logging the join token (the URL token on `/play/:id/:token`) anywhere outside the route handler → **BLOCK**

--- a/.github/instructions/llm-prompts.instructions.md
+++ b/.github/instructions/llm-prompts.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "backend/app/llm/**,backend/app/sessions/turn_validator.py,backend/app/sessions/turn_driver.py,backend/app/sessions/phase_policy.py,backend/app/sessions/slots.py"
+---
+
+# LLM prompt & tool review (brittle surface)
+
+Findings here are **BLOCK** by default; require PR-body justification to downgrade. Read `docs/tool-design.md` and `docs/turn-lifecycle.md` first.
+
+## Prompts (`prompts.py`, tool descriptions, recovery directives, kickoff messages)
+- **Phantom tools** — backticked snake_case name in any model-facing string not in that tier's palette (`SETUP_TOOLS` / `PLAY_TOOLS` / `AAR_TOOL`). Model can't call it; confuses routing, wastes tokens. **BLOCK**.
+- **Removal protocol**: drop from palette → add to `HISTORICAL_REMOVED_*` in `backend/tests/test_prompt_tool_consistency.py` → grep backticks → run consistency test. Any step missed → **BLOCK**.
+- **Conflicts** across blocks (e.g. "must yield" vs "yield when ready"). Quote both lines.
+- **Ambiguity** — vague modals ("should", "may"), missing stop conditions for tool loops, unclear success criteria
+- **Token waste** — restatements across blocks, verbose preambles, instructions duplicated in system + tool description
+- **Missing guardrails** — jailbreak resistance, refusal-style boundaries, plan-disclosure prevention (model must not leak future inject plan)
+- **Roster scaling** — small/medium/large blocks adapt to actual roster, not a fixed N
+- **Best practice** — XML tags, examples-then-task, explicit success criteria, negative examples for known failure modes
+- **Voice boundary** — system prompts use descriptive language ("AI cybersecurity tabletop facilitator"), NOT brand voice. Do not flag prompts for sounding unbranded.
+
+## Tools (`tools.py` and tier palettes)
+- Flag tools violating the five trap patterns in `docs/tool-design.md`
+- New/renamed tools: was `pytest backend/tests/test_prompt_tool_consistency.py` run? Was `pytest backend/tests/live/ -v` run against a real `ANTHROPIC_API_KEY`? Mandatory if diff touches `tools.py`, Block 6 of `prompts.py`, or any recovery directive. Absence → **BLOCK**.
+- New tool in a tier without updating `phase_policy.POLICIES` and `ALLOWED_*_TOOL_NAMES` → **BLOCK** (filtered from API; model hallucinates)
+- New input field appearing in prompt copy (e.g. `share_data`'s `label`) — added to `_NON_TOOL_ALLOWLIST` in the consistency test?
+- Description tells the model *how* instead of *when*. Descriptions are dispatch hints, not docs.
+
+## Phase policy & dispatch
+- New LLM call site without `assert_state(tier, session.state)` at entry → **BLOCK**
+- Dispatch silently dropping a forbidden call instead of returning `is_error=True` `tool_result` → **BLOCK** (model gets stuck retrying)
+- Extension tool names not passed to `filter_allowed_tools` on play tier → extensions disappear from palette → **BLOCK**
+
+## Model-output trust boundary (`backend/app/llm/export.py::_extract_report` is the reference)
+- Identity values (`role_id`, `turn_id`, `session_id`, `message_id`) accepted from the model without validating against our state → **BLOCK**. Identity is ours; canonical IDs go in the prompt as a `## ... (canonical IDs)` block; unmatched echoed IDs are **dropped** (not repaired) with a `WARNING` log carrying `dropped_count`, `kept_count`, rejected ids.
+- Shape coercion (string → `[string]`) added in a route or React component instead of the extractor → **BLOCK**. One sanitization point per call site.
+- Numeric fields not clamped to documented range (AAR sub-scores 0–5, etc.) → **HIGH**
+- Drops/coercions/clamps without WARNING logs sufficient to debug a prompt regression from the audit log → **HIGH**
+- New LLM feature taking user/role/turn refs without passing canonical IDs into the prompt → **HIGH**
+
+## Turn lifecycle
+Diff touching `turn_validator.py`, `turn_driver.py`, `slots.py`, or `dispatch.py` → PR body must reference the corresponding `docs/turn-lifecycle.md` section. Missing → **HIGH**.


### PR DESCRIPTION
## Summary

Configure GitHub Copilot code review (per [the docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review#customizing-copilots-reviews-with-custom-instructions)) so reviews flag the categories that have actually bitten this repo: classic correctness/security/smell/perf/test/observability hits **plus** the brittle LLM-prompt-and-tool surface and the design-system / interaction rules from `BRAND.md` and `HANDOFF.md`.

Split across four files because Copilot code review only reads the **first 4,000 characters** of any custom instruction file. Each file stays under that limit; path-scoped files only fire when matching files are in the diff.

| File | Chars | `applyTo` |
|---|---:|---|
| `.github/copilot-instructions.md` | 3,635 | (all files — repo-wide) |
| `.github/instructions/backend.instructions.md` | 2,776 | `backend/**` |
| `.github/instructions/frontend.instructions.md` | 3,057 | `frontend/**` |
| `.github/instructions/llm-prompts.instructions.md` | 3,996 | `backend/app/llm/**` + turn-engine paths |

### What each file covers

- **Repo-wide** — issues-only output format with severity tiers (BLOCK/HIGH/MEDIUM/LOW); correctness, security (incl. prompt injection), smells, perf, API/contract, tests, observability, docs/migrations, PR-body issue-closing keywords.
- **Backend** — `structlog` rules (no `print`, `event=` reserved, bound-context inheritance), boundary log lines, `_is_oversized` for wide payloads, `pydantic-settings`, async I/O, per-session locks, async-then-poll pattern for >2s LLM endpoints, WS origin/token, declarative-only extension handlers.
- **Frontend** — design tokens, brand components from `frontend/src/components/brand/`, no Google Fonts CDN (air-gapped deploys), operator voice, the SETUP→READY→PLAY→ENDED interaction walkthrough at mobile/1080p/1440p with unreachable-CTA findings as **BLOCK**, async states, ARIA/contrast, `lib/api/client.ts` and `lib/ws.ts` log wrappers, never log the join token.
- **LLM prompts & tools** — phantom tools (backticked names not in the tier palette), tool-removal protocol (palette → `HISTORICAL_REMOVED_*` → grep → consistency test), conflicting/ambiguous instructions, token waste, plan-disclosure prevention, roster scaling, voice boundary (system prompts ≠ brand voice), mandatory `pytest backend/tests/test_prompt_tool_consistency.py` + `backend/tests/live/` runs for tool changes, `phase_policy` updates, `assert_state` at every LLM call site, no silent forbidden-tool drops, model-output trust boundary (identity validation, drop-don't-repair, schema coercion at the extractor only, numeric clamping, WARNING logs).

The LLM file mirrors the **Prompt Expert** sub-agent rubric in `CLAUDE.md` and the **model-output trust boundary** section, so the same standards apply whether Copilot or a sub-agent does the review.

## Test plan

- [ ] Confirm files are under 4,000 chars each (`wc -c .github/copilot-instructions.md .github/instructions/*.instructions.md`)
- [ ] After merge, request a Copilot review on a PR that touches `backend/app/llm/prompts.py` and verify the LLM-specific instructions trigger
- [ ] Request a Copilot review on a PR that touches `frontend/src/**` and verify the UI/UX checklist triggers
- [ ] Spot-check that Copilot's first review on a non-trivial PR uses the `[SEVERITY] file:line — issue — fix` format
- [ ] If Copilot ignores categories, check whether content past the 4k limit is being truncated and split further if needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9RkhsqR8d9WfiPCr8uZYc)_