### PR TITLE
ui(title): pending dot + session-state in browser tab title

### DIFF
--- a/frontend/public/favicon/favicon-pending.svg
+++ b/frontend/public/favicon/favicon-pending.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="3" y="3" width="94" height="94" rx="22" ry="22" fill="#0A0D13" stroke="#DCE2EE" stroke-width="3"></rect>
+  <line x1="14" y1="52" x2="86" y2="52" stroke="#DCE2EE" stroke-opacity="0.18" stroke-width="0.8" stroke-dasharray="2 2"></line>
+  <circle cx="22" cy="40" r="3.4" fill="none" stroke="#DCE2EE" stroke-width="1.6"></circle>
+  <circle cx="33" cy="40" r="3.4" fill="none" stroke="#DCE2EE" stroke-width="1.6"></circle>
+  <circle cx="44" cy="40" r="4.0" fill="none" stroke="#DCE2EE" stroke-width="2.0"></circle>
+  <circle cx="55" cy="40" r="3.4" fill="none" stroke="#DCE2EE" stroke-width="1.6"></circle>
+  <circle cx="66" cy="40" r="3.4" fill="none" stroke="#DCE2EE" stroke-width="1.6"></circle>
+  <g stroke="#5EA6EA" stroke-width="2.4" stroke-linecap="round">
+    <line x1="46" y1="56" x2="54" y2="64"></line><line x1="54" y1="56" x2="46" y2="64"></line>
+  </g>
+  <path d="M 22 36 C 18 26, 14 20, 22 16" fill="none" stroke="#DCE2EE" stroke-width="1.6" stroke-linecap="round"></path>
+  <path d="M 66 36 C 70 26, 74 20, 78 16" fill="none" stroke="#DCE2EE" stroke-width="1.6" stroke-linecap="round"></path>
+  <path d="M 52 60 C 50 50, 60 42, 76 36" fill="none" stroke="#5EA6EA" stroke-width="1.6" stroke-linecap="round"></path>
+  <!-- Pending badge: amber circle in the top-right.
+
+       Color: fill ``#EAB23F`` is the sRGB approximation of ``--warn``
+       per BRAND.md (medium severity / pending). SVG ``fill`` can't
+       resolve CSS custom properties, so the hex literal is the right
+       call — keep it in sync if ``--warn`` shifts in tokens.css. Kept
+       distinct from ``--crit`` (red, reserved for actual
+       inject_critical_event surfaces) so the badge doesn't dilute
+       the meaning of true critical-event UIs.
+
+       Geometry: cx=78, cy=22, r=12, stroke=3. The die has rounded
+       corners (rx=22) — earlier r=18 stuck out past the rounded
+       corner at the top-right diagonal. r=12 with 3px stroke keeps
+       the entire badge inside the die silhouette while staying
+       visible at 16×16 (~2.4 px filled disc + 0.5 px ring). The
+       right "horn" arc terminus around (78,16) is obscured when
+       pending — this is the intended overlay-badge behaviour
+       (Slack / Gmail mirror this on their own marks). -->
+  <circle cx="78" cy="22" r="12" fill="#EAB23F" stroke="#0A0D13" stroke-width="3"></circle>
+</svg>

--- a/frontend/src/__tests__/useSessionTitle.test.tsx
+++ b/frontend/src/__tests__/useSessionTitle.test.tsx
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildSessionTitle,
   DEFAULT_TITLE,
+  FAVICON_DEFAULT_HREF,
+  FAVICON_PENDING_HREF,
   PENDING_MARKER,
+  setFaviconPending,
   useSessionTitle,
 } from "../lib/useSessionTitle";
 
@@ -145,5 +148,163 @@ describe("useSessionTitle (hook integration)", () => {
   it("collapses to just the brand when state is null and nothing pending", () => {
     render(<Harness pending={false} state={null} />);
     expect(document.title).toBe(DEFAULT_TITLE);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Favicon swap — the SVG ``link[rel=icon]`` href should toggle between
+// the default mark and the amber-badge variant in lockstep with
+// ``pending``. Test the helper directly + integration through the hook.
+
+function installFaviconLink(initialHref: string): HTMLLinkElement {
+  // jsdom doesn't honour index.html — every test installs its own
+  // fake link so the helper has something to query.
+  const existing = document.querySelector<HTMLLinkElement>(
+    'link[rel="icon"][type="image/svg+xml"]',
+  );
+  if (existing) existing.remove();
+  const link = document.createElement("link");
+  link.rel = "icon";
+  link.type = "image/svg+xml";
+  link.href = initialHref;
+  document.head.appendChild(link);
+  return link;
+}
+
+function removeFaviconLink(): void {
+  const link = document.querySelector<HTMLLinkElement>(
+    'link[rel="icon"][type="image/svg+xml"]',
+  );
+  if (link) link.remove();
+}
+
+function currentFaviconHref(): string | null {
+  const link = document.querySelector<HTMLLinkElement>(
+    'link[rel="icon"][type="image/svg+xml"]',
+  );
+  if (!link) return null;
+  // ``link.href`` is the resolved absolute URL — pull the path so the
+  // assertion is host-agnostic.
+  return new URL(link.href).pathname;
+}
+
+describe("setFaviconPending", () => {
+  beforeEach(() => {
+    installFaviconLink(FAVICON_DEFAULT_HREF);
+  });
+  afterEach(() => {
+    removeFaviconLink();
+  });
+
+  it("swaps the SVG favicon href to the pending variant", () => {
+    setFaviconPending(true);
+    expect(currentFaviconHref()).toBe(FAVICON_PENDING_HREF);
+  });
+
+  it("restores the default SVG favicon when pending=false", () => {
+    setFaviconPending(true);
+    setFaviconPending(false);
+    expect(currentFaviconHref()).toBe(FAVICON_DEFAULT_HREF);
+  });
+
+  it("no-ops when the SVG link element is absent", () => {
+    // Test environment without the index.html: the helper must not
+    // throw — a missing favicon is a soft failure (PNGs / .ico still
+    // render fine, just without the badge).
+    removeFaviconLink();
+    expect(() => setFaviconPending(true)).not.toThrow();
+    expect(() => setFaviconPending(false)).not.toThrow();
+    expect(currentFaviconHref()).toBeNull();
+  });
+
+  it("skips the DOM write when the href is already the requested value", () => {
+    // Cheap repaint guard for the rapid-state-thrash case (chunk
+    // boundaries flipping pending on/off). We can't observe browser
+    // repaints in jsdom, so we observe that ``link.href`` isn't
+    // re-assigned by spying on the setter. The instance-level
+    // ``Object.defineProperty`` shadows the prototype ``href``
+    // descriptor on this one element only — no global state to
+    // restore (the link is removed in ``afterEach``).
+    const link = installFaviconLink(FAVICON_DEFAULT_HREF);
+    let writeCount = 0;
+    Object.defineProperty(link, "href", {
+      configurable: true,
+      get() {
+        return `http://localhost${FAVICON_DEFAULT_HREF}`;
+      },
+      set() {
+        writeCount += 1;
+      },
+    });
+    setFaviconPending(false);
+    expect(writeCount).toBe(0);
+  });
+});
+
+describe("useSessionTitle (favicon integration)", () => {
+  let savedTitle: string;
+  beforeEach(() => {
+    savedTitle = document.title;
+    installFaviconLink(FAVICON_DEFAULT_HREF);
+  });
+  afterEach(() => {
+    // Reset title and link so this suite doesn't bleed state into
+    // other test files that read ``document.title`` or the favicon.
+    document.title = savedTitle;
+    removeFaviconLink();
+  });
+
+  it("swaps the favicon when pending fires", () => {
+    const { rerender } = render(
+      <Harness pending={false} state="AI thinking" />,
+    );
+    expect(currentFaviconHref()).toBe(FAVICON_DEFAULT_HREF);
+    rerender(<Harness pending={true} state="Your turn" />);
+    expect(currentFaviconHref()).toBe(FAVICON_PENDING_HREF);
+  });
+
+  it("sets the pending favicon when mounted already pending", () => {
+    // Real Play.tsx mount with cached state hits this — the user's
+    // first paint after a refresh is on a turn already waiting on
+    // them. The ``false→true`` test above doesn't cover the
+    // initial-mount-with-pending=true path.
+    render(<Harness pending={true} state="Your turn" />);
+    expect(currentFaviconHref()).toBe(FAVICON_PENDING_HREF);
+  });
+
+  it("doesn't re-write the favicon when only the state label changes", () => {
+    // The hook's effect deps include ``opts.state``, so a state-only
+    // change re-runs the effect. The helper's
+    // ``link.href.endsWith(href)`` guard should keep this from
+    // touching the DOM. This regression test catches a future change
+    // that drops the guard at the helper layer.
+    const { rerender } = render(<Harness pending={true} state="Your turn" />);
+    const link = document.querySelector<HTMLLinkElement>(
+      'link[rel="icon"][type="image/svg+xml"]',
+    );
+    if (!link) throw new Error("test setup: favicon link missing");
+    let writeCount = 0;
+    Object.defineProperty(link, "href", {
+      configurable: true,
+      get() {
+        return `http://localhost${FAVICON_PENDING_HREF}`;
+      },
+      set() {
+        writeCount += 1;
+      },
+    });
+    // State changes but pending stays true — favicon should not be
+    // re-written even though the effect re-runs.
+    rerender(<Harness pending={true} state="Submitted" />);
+    expect(writeCount).toBe(0);
+  });
+
+  it("restores the default favicon on unmount", () => {
+    const { unmount } = render(
+      <Harness pending={true} state="Your turn" />,
+    );
+    expect(currentFaviconHref()).toBe(FAVICON_PENDING_HREF);
+    unmount();
+    expect(currentFaviconHref()).toBe(FAVICON_DEFAULT_HREF);
   });
 });

--- a/frontend/src/__tests__/useSessionTitle.test.tsx
+++ b/frontend/src/__tests__/useSessionTitle.test.tsx
@@ -1,0 +1,149 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildSessionTitle,
+  DEFAULT_TITLE,
+  PENDING_MARKER,
+  useSessionTitle,
+} from "../lib/useSessionTitle";
+
+// The hook drives ``document.title`` — a pure-function compositor
+// (``buildSessionTitle``) is the load-bearing primitive; the hook
+// just calls it inside a React effect. We test the pure function
+// thoroughly + a few render-time integration cases for the hook.
+
+describe("buildSessionTitle", () => {
+  it("returns just the brand when nothing is pending and no state", () => {
+    expect(buildSessionTitle({ pending: false, state: null })).toBe(
+      DEFAULT_TITLE,
+    );
+    expect(buildSessionTitle({ pending: false, state: undefined })).toBe(
+      DEFAULT_TITLE,
+    );
+  });
+
+  it("prepends the marker when pending without a state label", () => {
+    // Edge case — should still surface the dot so a backgrounded tab
+    // can see "you owe an action" even when we don't have a state
+    // label to show.
+    expect(buildSessionTitle({ pending: true, state: null })).toBe(
+      `${PENDING_MARKER} ${DEFAULT_TITLE}`,
+    );
+  });
+
+  it("renders state — brand without a marker when not pending", () => {
+    expect(buildSessionTitle({ pending: false, state: "AI thinking" })).toBe(
+      `AI thinking — ${DEFAULT_TITLE}`,
+    );
+  });
+
+  it("renders marker + state — brand when pending with a label", () => {
+    // The canonical "your turn" form: dot first so it's visible in
+    // truncated tab titles, label second, brand last.
+    expect(buildSessionTitle({ pending: true, state: "Your turn" })).toBe(
+      `${PENDING_MARKER} Your turn — ${DEFAULT_TITLE}`,
+    );
+  });
+
+  it("uses U+25CF for the marker (renders consistently across platform fonts)", () => {
+    // Lock the marker codepoint — substituting a fancy glyph would
+    // tofu on default Linux fonts, defeating the cue.
+    expect(PENDING_MARKER).toBe("●");
+  });
+
+  it("treats empty-string state as no state (collapses to brand)", () => {
+    // A future caller passing an empty string from a falsy branch
+    // shouldn't render a stray dash.
+    expect(buildSessionTitle({ pending: false, state: "" })).toBe(
+      DEFAULT_TITLE,
+    );
+    expect(buildSessionTitle({ pending: true, state: "" })).toBe(
+      `${PENDING_MARKER} ${DEFAULT_TITLE}`,
+    );
+  });
+
+  it("locks the canonical state-label literals (regression net for silent rewrites)", () => {
+    // These labels are read aloud by screen readers on tab-title-change
+    // and visible in the OS tab strip — a silent rewrite ("Setup" →
+    // "Brief") would land without test failure unless the literals are
+    // pinned somewhere. The set below is the union of state labels
+    // emitted by Play.tsx and Facilitator.tsx (see ``titleSignal`` in
+    // each).
+    const labels = [
+      "Your turn",
+      "AI thinking",
+      "Submitted",
+      "Briefing",
+      "Setup",
+      "Setup · AI thinking",
+      "Ready",
+      "Ready to start",
+      "Waiting on roles",
+      "Initializing",
+      "Ended",
+    ];
+    for (const label of labels) {
+      expect(buildSessionTitle({ pending: false, state: label })).toBe(
+        `${label} — ${DEFAULT_TITLE}`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------
+// Hook integration tests — render a tiny component that calls the hook
+// and assert on ``document.title`` after each render.
+
+interface HarnessProps {
+  pending: boolean;
+  state?: string | null;
+}
+
+function Harness({ pending, state }: HarnessProps) {
+  useSessionTitle({ pending, state });
+  return <div data-testid="probe">probe</div>;
+}
+
+describe("useSessionTitle (hook integration)", () => {
+  let originalTitle: string;
+  beforeEach(() => {
+    originalTitle = document.title;
+    document.title = "";
+  });
+  afterEach(() => {
+    document.title = originalTitle;
+  });
+
+  it("sets the title on initial mount", () => {
+    render(<Harness pending={true} state="Your turn" />);
+    expect(document.title).toBe(`${PENDING_MARKER} Your turn — ${DEFAULT_TITLE}`);
+  });
+
+  it("updates the title when pending flips", () => {
+    const { rerender } = render(<Harness pending={false} state="AI thinking" />);
+    expect(document.title).toBe(`AI thinking — ${DEFAULT_TITLE}`);
+    rerender(<Harness pending={true} state="Your turn" />);
+    expect(document.title).toBe(`${PENDING_MARKER} Your turn — ${DEFAULT_TITLE}`);
+  });
+
+  it("updates the title when state changes", () => {
+    const { rerender } = render(<Harness pending={false} state="Setup" />);
+    expect(document.title).toBe(`Setup — ${DEFAULT_TITLE}`);
+    rerender(<Harness pending={false} state="Briefing" />);
+    expect(document.title).toBe(`Briefing — ${DEFAULT_TITLE}`);
+  });
+
+  it("restores the default title on unmount", () => {
+    // A route change (Play → Home) shouldn't leave a stale "● Your
+    // turn" hanging in the tab. Cleanup must reset to the brand.
+    const { unmount } = render(<Harness pending={true} state="Your turn" />);
+    expect(document.title).toBe(`${PENDING_MARKER} Your turn — ${DEFAULT_TITLE}`);
+    unmount();
+    expect(document.title).toBe(DEFAULT_TITLE);
+  });
+
+  it("collapses to just the brand when state is null and nothing pending", () => {
+    render(<Harness pending={false} state={null} />);
+    expect(document.title).toBe(DEFAULT_TITLE);
+  });
+});

--- a/frontend/src/lib/useSessionTitle.ts
+++ b/frontend/src/lib/useSessionTitle.ts
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+
+/**
+ * The product brand name. Mirrors ``frontend/index.html``'s ``<title>``
+ * so a remount or unmount restores exactly what the static markup
+ * shipped with — no flash of "Crittable - Crittable" on hot-reload.
+ */
+export const DEFAULT_TITLE = "Crittable";
+
+/**
+ * Marker prepended to the tab title when the viewer's input is what's
+ * holding the exercise up. Reads as a notification dot when the tab is
+ * backgrounded — the operator can alt-tab away to email and still see
+ * "● Your turn — Crittable" in the OS tab strip without needing sound
+ * or browser notifications.
+ *
+ * U+25CF (BLACK CIRCLE) renders consistently across platform fonts and
+ * doesn't fall back to a tofu glyph the way decorative symbols do.
+ */
+export const PENDING_MARKER = "●";
+
+export interface SessionTitleOpts {
+  /** True when the user must take an action (their turn, AI awaits reply). */
+  pending: boolean;
+  /** Short status label, e.g. "Your turn", "Setup", "Ended". Optional. */
+  state?: string | null;
+}
+
+/**
+ * Compose the tab title from a pending flag + optional state label.
+ * Pure function so render-equality tests can assert on the exact string
+ * without standing up a DOM.
+ *
+ * Examples:
+ *   {pending: true,  state: "Your turn"} → "● Your turn — Crittable"
+ *   {pending: false, state: "AI thinking"} → "AI thinking — Crittable"
+ *   {pending: false, state: null}        → "Crittable"
+ *   {pending: true,  state: null}        → "● Crittable"
+ */
+export function buildSessionTitle({ pending, state }: SessionTitleOpts): string {
+  const marker = pending ? `${PENDING_MARKER} ` : "";
+  if (!state) return `${marker}${DEFAULT_TITLE}`;
+  return `${marker}${state} — ${DEFAULT_TITLE}`;
+}
+
+/**
+ * Drives ``document.title`` from session state. The pending marker is
+ * the primary signal — a backgrounded tab still surfaces "you're being
+ * waited on" via the OS tab strip. The state label adds context for
+ * the foregrounded case ("Setup", "Briefing", "Ended").
+ *
+ * On unmount the title resets to ``DEFAULT_TITLE`` so a route change
+ * (Play → Home) doesn't leave a stale "● Your turn" hanging in the
+ * tab.
+ *
+ * Logs every title change at ``debug`` so a "tab title is stuck"
+ * report has a transcript trail; the prefix is greppable per the
+ * project's logging convention.
+ */
+export function useSessionTitle(opts: SessionTitleOpts): void {
+  const title = buildSessionTitle(opts);
+  useEffect(() => {
+    console.debug("[title]", { title, pending: opts.pending, state: opts.state ?? null });
+    document.title = title;
+  }, [title, opts.pending, opts.state]);
+  useEffect(() => {
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, []);
+}

--- a/frontend/src/lib/useSessionTitle.ts
+++ b/frontend/src/lib/useSessionTitle.ts
@@ -19,6 +19,43 @@ export const DEFAULT_TITLE = "Crittable";
  */
 export const PENDING_MARKER = "●";
 
+/**
+ * Favicon variants. The SVG ``link[rel=icon][type="image/svg+xml"]`` is
+ * the master — modern browsers (Chrome/Firefox/Safari/Edge) prefer it
+ * over the PNG fallbacks so swapping just the SVG is enough for the
+ * tab-strip badge to fire on every browser that surfaces favicons
+ * prominently. Older browsers that fall back to ``favicon-*.png`` /
+ * ``.ico`` won't see the badge — acceptable trade-off vs. shipping
+ * eight PNG variants of the pending mark.
+ *
+ * The pending variant adds an amber corner dot (``--warn`` per
+ * ``design/handoff/BRAND.md`` — "medium severity / pending"). Crit-red
+ * is intentionally NOT used here so the badge doesn't dilute the
+ * meaning of ``inject_critical_event`` surfaces.
+ */
+export const FAVICON_DEFAULT_HREF = "/favicon/favicon.svg";
+export const FAVICON_PENDING_HREF = "/favicon/favicon-pending.svg";
+
+/**
+ * Swap the SVG favicon's ``href`` on the live ``<link>`` element. Modern
+ * browsers re-fetch + re-render the favicon as soon as the attribute
+ * changes; no DOM rebuild needed.
+ *
+ * No-ops if the element doesn't exist (test environment without the
+ * static index.html, SSR pre-hydrate, etc.) and if the href is already
+ * the requested value — saves a redundant browser repaint when state
+ * thrashes.
+ */
+export function setFaviconPending(pending: boolean): void {
+  const href = pending ? FAVICON_PENDING_HREF : FAVICON_DEFAULT_HREF;
+  const link = document.querySelector<HTMLLinkElement>(
+    'link[rel="icon"][type="image/svg+xml"]',
+  );
+  if (!link) return;
+  if (link.href.endsWith(href)) return;
+  link.href = href;
+}
+
 export interface SessionTitleOpts {
   /** True when the user must take an action (their turn, AI awaits reply). */
   pending: boolean;
@@ -44,14 +81,16 @@ export function buildSessionTitle({ pending, state }: SessionTitleOpts): string 
 }
 
 /**
- * Drives ``document.title`` from session state. The pending marker is
- * the primary signal — a backgrounded tab still surfaces "you're being
- * waited on" via the OS tab strip. The state label adds context for
- * the foregrounded case ("Setup", "Briefing", "Ended").
+ * Drives ``document.title`` AND the favicon from session state. The
+ * pending marker (title) + amber favicon badge are the primary signals
+ * — a backgrounded tab still surfaces "you're being waited on" via the
+ * OS tab strip even when the title is truncated to just the favicon
+ * (the Slack/Gmail pattern). The state label adds context for the
+ * foregrounded case ("Setup", "Briefing", "Ended").
  *
- * On unmount the title resets to ``DEFAULT_TITLE`` so a route change
- * (Play → Home) doesn't leave a stale "● Your turn" hanging in the
- * tab.
+ * On unmount the title resets to ``DEFAULT_TITLE`` and the favicon
+ * resets to the default mark so a route change (Play → Home) doesn't
+ * leave a stale "● Your turn" or amber badge hanging in the tab.
  *
  * Logs every title change at ``debug`` so a "tab title is stuck"
  * report has a transcript trail; the prefix is greppable per the
@@ -62,10 +101,12 @@ export function useSessionTitle(opts: SessionTitleOpts): void {
   useEffect(() => {
     console.debug("[title]", { title, pending: opts.pending, state: opts.state ?? null });
     document.title = title;
+    setFaviconPending(opts.pending);
   }, [title, opts.pending, opts.state]);
   useEffect(() => {
     return () => {
       document.title = DEFAULT_TITLE;
+      setFaviconPending(false);
     };
   }, []);
 }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -346,11 +346,14 @@ export function Facilitator() {
       creatorRoleId !== null && submittedIds.includes(creatorRoleId);
     const myTurn = iAmActive && !iHaveSubmitted && !aiThinking;
     if (myTurn) return { pending: true, state: "Your turn" };
-    if (aiThinking) return { pending: false, state: "AI thinking" };
-    if (iHaveSubmitted) return { pending: false, state: "Submitted" };
+    // BRIEFING is a sub-state of aiThinking (the AI is composing the
+    // briefing) — surface the more specific label before the generic
+    // "AI thinking" branch, otherwise the BRIEFING case is dead code.
     if (snapshot.state === "BRIEFING") {
       return { pending: false, state: "Briefing" };
     }
+    if (aiThinking) return { pending: false, state: "AI thinking" };
+    if (iHaveSubmitted) return { pending: false, state: "Submitted" };
     if (snapshot.state === "AWAITING_PLAYERS") {
       return { pending: false, state: "Waiting on roles" };
     }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -29,6 +29,7 @@ import {
   buildImpersonateOptions,
   countUnjoinedImpersonateOptions,
 } from "../lib/proxy";
+import { useSessionTitle } from "../lib/useSessionTitle";
 import { useStickyScroll } from "../lib/useStickyScroll";
 import { useTabFocusReporter } from "../lib/useTabFocusReporter";
 import { HighlightActionPopover } from "../components/HighlightActionPopover";
@@ -284,6 +285,78 @@ export function Facilitator() {
   useEffect(() => {
     if (error) console.warn("[facilitator] error surfaced", error);
   }, [error]);
+
+  // Browser-tab title cue. The pending dot lights up only when the
+  // creator is the one holding the exercise up:
+  //   - SETUP: AI just asked a question (last note is from "ai") and
+  //     the creator hasn't answered yet (``!busy`` so we don't blink
+  //     the dot during the in-flight POST).
+  //   - READY: the plan is finalised and the creator must press Start.
+  //   - PLAY: the creator's role is on the active set and the AI
+  //     isn't already drafting.
+  // The state label adds context for the foregrounded case ("Setup",
+  // "Ready", "Briefing", "AI thinking", "Ended"). Hook is called
+  // unconditionally above the early returns so the hook count is
+  // stable across phase transitions; ``snapshot === null`` (intro
+  // page) collapses to just ``Crittable``.
+  const titleSignal = useMemo(() => {
+    if (!snapshot) return { pending: false, state: null as string | null };
+    const aiThinking =
+      snapshot.state !== "ENDED" &&
+      snapshot.current_turn?.status !== "errored" &&
+      (aiCalls.size > 0 ||
+        streamingActive ||
+        snapshot.state === "AI_PROCESSING" ||
+        snapshot.state === "BRIEFING" ||
+        snapshot.current_turn?.status === "processing");
+    if (snapshot.state === "ENDED") {
+      return { pending: false, state: "Ended" };
+    }
+    if (snapshot.state === "CREATED") {
+      // Pre-SETUP transient — covers the brief gap between session
+      // create and the first AI question landing.
+      return { pending: false, state: "Initializing" };
+    }
+    if (snapshot.state === "SETUP") {
+      const notes = snapshot.setup_notes ?? [];
+      const last = notes[notes.length - 1];
+      const awaitingReply =
+        notes.length > 0 && last?.speaker === "ai" && !busy && !aiThinking;
+      // Sub-segment with "·" rather than another em-dash so we don't
+      // render "Setup — AI thinking — Crittable" (two dashes).
+      return {
+        pending: awaitingReply,
+        state: aiThinking ? "Setup · AI thinking" : "Setup",
+      };
+    }
+    if (snapshot.state === "READY") {
+      // Player view labels this same SessionState as "Ready" — keep
+      // creator's longer "Ready to start" because the creator is the
+      // one who must press the button, but stay in the same word
+      // family so a player watching over the creator's shoulder sees
+      // a consistent vocabulary.
+      return { pending: !busy, state: "Ready to start" };
+    }
+    const activeIds = snapshot.current_turn?.active_role_ids ?? [];
+    const submittedIds = snapshot.current_turn?.submitted_role_ids ?? [];
+    const creatorRoleId = state?.creatorRoleId ?? null;
+    const iAmActive =
+      creatorRoleId !== null && activeIds.includes(creatorRoleId);
+    const iHaveSubmitted =
+      creatorRoleId !== null && submittedIds.includes(creatorRoleId);
+    const myTurn = iAmActive && !iHaveSubmitted && !aiThinking;
+    if (myTurn) return { pending: true, state: "Your turn" };
+    if (aiThinking) return { pending: false, state: "AI thinking" };
+    if (iHaveSubmitted) return { pending: false, state: "Submitted" };
+    if (snapshot.state === "BRIEFING") {
+      return { pending: false, state: "Briefing" };
+    }
+    if (snapshot.state === "AWAITING_PLAYERS") {
+      return { pending: false, state: "Waiting on roles" };
+    }
+    return { pending: false, state: null };
+  }, [snapshot, state?.creatorRoleId, busy, aiCalls.size, streamingActive]);
+  useSessionTitle(titleSignal);
 
   // ----------------------------------------------------- create session
   async function handleCreate(e: FormEvent) {

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -651,16 +651,20 @@ export function Play({ sessionId, token }: Props) {
     const pending = iAmActive && !iHaveSubmitted && !aiThinking;
     let state: string | null = null;
     // Order matters: check ENDED first (terminal), then "your turn"
-    // (highest-priority foreground signal), then AI thinking, then
-    // post-submit waiting, then phase-specific labels. Every backend
-    // SessionState (CREATED / SETUP / READY / BRIEFING /
-    // AWAITING_PLAYERS / AI_PROCESSING / ENDED) is covered so a fresh
-    // session doesn't fall through to a bare "Crittable".
+    // (highest-priority foreground signal), then phase-specific labels
+    // that are MORE specific than "AI thinking" (BRIEFING is a
+    // sub-state of aiThinking but the label is more informative),
+    // then generic AI thinking, then post-submit waiting, then the
+    // remaining phase fallbacks. Every backend SessionState
+    // (CREATED / SETUP / READY / BRIEFING / AWAITING_PLAYERS /
+    // AI_PROCESSING / ENDED) gets a label so a fresh session doesn't
+    // fall through to a bare "Crittable".
     if (snapshot.state === "ENDED") state = "Ended";
     else if (pending) state = "Your turn";
+    else if (snapshot.state === "BRIEFING") state = "Briefing";
     else if (aiThinking) state = "AI thinking";
     else if (iHaveSubmitted) state = "Submitted";
-    else if (snapshot.state === "BRIEFING") state = "Briefing";
+    else if (snapshot.state === "AWAITING_PLAYERS") state = "Waiting on roles";
     else if (snapshot.state === "SETUP") state = "Setup";
     else if (snapshot.state === "READY") state = "Ready";
     else if (snapshot.state === "CREATED") state = "Initializing";

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -11,6 +11,7 @@ import { DieLoader } from "../components/brand/DieLoader";
 import { HudGauges } from "../components/brand/HudGauges";
 import { confirmLeaveSession } from "../lib/leaveGuard";
 import { isMidSessionJoiner } from "../lib/proxy";
+import { useSessionTitle } from "../lib/useSessionTitle";
 import { useStickyScroll } from "../lib/useStickyScroll";
 import { useTabFocusReporter } from "../lib/useTabFocusReporter";
 import { ServerEvent, WsClient } from "../lib/ws";
@@ -624,6 +625,48 @@ export function Play({ sessionId, token }: Props) {
     }
     return undefined;
   }, [snapshot?.state, effectiveDisplayName, sessionId]);
+
+  // Browser-tab title cue. The pending dot lights up only when the
+  // local participant is the one holding the exercise up — backgrounded
+  // tabs surface that via the OS tab strip without sound or browser
+  // notifications. The state label adds context for the foregrounded
+  // case ("Briefing", "AI thinking", "Ended"). Derived unconditionally
+  // above the early returns so the hook count is stable across renders;
+  // ``snapshot === null`` collapses to just ``Crittable``.
+  const titleSignal = useMemo(() => {
+    if (!snapshot) return { pending: false, state: null as string | null };
+    const activeIds = snapshot.current_turn?.active_role_ids ?? [];
+    const submittedIds = snapshot.current_turn?.submitted_role_ids ?? [];
+    const iAmActive = selfRoleId !== null && activeIds.includes(selfRoleId);
+    const iHaveSubmitted =
+      selfRoleId !== null && submittedIds.includes(selfRoleId);
+    const aiThinking =
+      snapshot.state !== "ENDED" &&
+      snapshot.current_turn?.status !== "errored" &&
+      (aiCalls.size > 0 ||
+        streamingActive ||
+        snapshot.state === "AI_PROCESSING" ||
+        snapshot.state === "BRIEFING" ||
+        snapshot.current_turn?.status === "processing");
+    const pending = iAmActive && !iHaveSubmitted && !aiThinking;
+    let state: string | null = null;
+    // Order matters: check ENDED first (terminal), then "your turn"
+    // (highest-priority foreground signal), then AI thinking, then
+    // post-submit waiting, then phase-specific labels. Every backend
+    // SessionState (CREATED / SETUP / READY / BRIEFING /
+    // AWAITING_PLAYERS / AI_PROCESSING / ENDED) is covered so a fresh
+    // session doesn't fall through to a bare "Crittable".
+    if (snapshot.state === "ENDED") state = "Ended";
+    else if (pending) state = "Your turn";
+    else if (aiThinking) state = "AI thinking";
+    else if (iHaveSubmitted) state = "Submitted";
+    else if (snapshot.state === "BRIEFING") state = "Briefing";
+    else if (snapshot.state === "SETUP") state = "Setup";
+    else if (snapshot.state === "READY") state = "Ready";
+    else if (snapshot.state === "CREATED") state = "Initializing";
+    return { pending, state };
+  }, [snapshot, selfRoleId, aiCalls.size, streamingActive]);
+  useSessionTitle(titleSignal);
 
   // Issue #76: a participant who has submitted their display name but
   // arrived while the creator is still drafting the plan was previously


### PR DESCRIPTION
## Summary

Browser tab title + SVG favicon now surface session state with a leading "●" pending marker (title) **and** an amber corner badge (favicon) when the local viewer is the one holding the exercise up. An alt-tabbed operator sees `● Your turn — Crittable` in the OS tab strip without needing sound or browser notifications, and pinned tabs / narrow tab strips still get the cue via the favicon badge even when the title is fully truncated.

Implements the user request: "Webapp title bar should show state, at least some sort of indicator to show it is pending your response."

### Pending-dot logic

- **Player** (`Play.tsx`): role on active set + hasn't submitted + AI not currently thinking.
- **Creator (SETUP)**: last note is from `"ai"` + `!busy` + `!aiThinking`.
- **Creator (READY)**: plan finalised, creator must press Start.
- **Creator (PLAY)**: same as player.

The `useSessionTitle` hook is called unconditionally above all early returns in both pages so the React hook count stays stable across JoinIntro / SetupWizard transitions.

### Favicon badge

`frontend/public/favicon/favicon-pending.svg` — the existing brand mark plus an amber corner dot. Color is `--warn` (`oklch(0.82 0.16 75)` ≈ `#EAB23F`) per BRAND.md "medium severity / pending" — kept distinct from `--crit` (red, reserved for `inject_critical_event` surfaces) so the badge doesn't dilute the meaning of true critical-event UIs. Modern browsers (Chrome/Firefox/Safari/Edge) prefer the SVG link over PNG fallbacks; older browsers see the unbadged PNG fallback (acceptable degradation vs. shipping eight pending PNG variants).

### Sub-agent reviews — addressed in this PR

8 of 9 sub-agent passes ran across the three commits (Prompt Expert N/A — no LLM call site touched). Must-fix items addressed:

- **Product MEDIUM / UI/UX L4** — `console.debug("[title] ...")` log on every change so a "title is stuck" report has a transcript trail.
- **UI/UX M2** — handle the `CREATED` SessionState (was falling through to a bare `Crittable` during the brief pre-SETUP window).
- **UI/UX L2** — standardised `"Lobby"` → `"Ready"` so the same backend state doesn't render two different operator-voice labels.
- **UI/UX HIGH H1 (favicon)** — badge geometry shrunk from r=18 to r=12 so the entire badge (including 3-px stroke) stays inside the die's rounded-corner silhouette.
- **QA MEDIUM (favicon)** — fixed `HTMLAnchorElement` → `HTMLLinkElement` prototype-reference typo in the idempotency test.
- **QA LOW** — empty-string state is treated as no state.
- **QA MINOR** — lock-test pinning the canonical state-label literals + sRGB approximation comment for `--warn` hex.
- **Copilot review (round 1)** — `BRIEFING` was unreachable in both files (the generic `aiThinking` branch ran first); fixed by checking `BRIEFING` before `aiThinking`. `AWAITING_PLAYERS` had no fall-through label in `Play.tsx`; added `"Waiting on roles"` arm.

### Deferred (worth a follow-up issue)

- **User HIGH** — surface `aiStatus.recovery` (`"Retrying 2/3"`) in the title so a backgrounded creator sees the strict-retry loop.
- **UI/UX L1** — debounce rapid SETUP-phase title flips.
- **UI/UX M1** — screen-reader verbosity of `"●"` glyph announcement (`"black circle"`) — documented but not changed.
- **UI/UX MEDIUM M2 (favicon)** — pre-existing brand drift: `favicon.svg` ships the encounter mark instead of face/01 at tiny sizes per BRAND.md §1. The pending variant inherits the drift but doesn't introduce it. Worth a separate PR with a face/01-based favicon pair.

## Test plan

- [x] `npm test -- --run` — 160 tests pass (20 in `useSessionTitle.test.tsx`)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (favicon-pending.svg in dist)
- [ ] Manual smoke: open Play view as player, alt-tab away during AI think, verify title + favicon swap when AI yields
- [ ] Manual smoke: open Facilitator view, verify dot during SETUP after AI question, before pressing Start in READY, and on creator's turn in PLAY
- [ ] Manual smoke: route Play → Home, verify title resets to `Crittable` and favicon resets to default
- [ ] Manual smoke: verify amber corner dot is visible on a pinned-tab favicon (16x16) in Chrome and Safari