### PR TITLE
notepad: fix cursor block, markdown rendering, drag-select, and pin-to-notes

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -788,20 +788,11 @@ def register_api_routes(app: FastAPI) -> None:
                 length=len(sanitized),
                 source_message_id=body.source_message_id,
             )
-        # Tell every connected client to add the line to their local Yjs
-        # editor's Timeline section. The message body has already been
-        # sanitized, but clients still treat it as text (they don't
-        # parse markdown from server pushes).
-        await manager.connections().broadcast(
-            session_id,
-            {
-                "type": "notepad_pin_appended",
-                "text": sanitized,
-                "source_message_id": body.source_message_id,
-                "by_role_id": role_id,
-            },
-            record=False,
-        )
+        # The originating tab inserts the snippet locally on POST
+        # success and Yjs collab fans the resulting transaction to
+        # every peer; no separate WS broadcast is required, so we
+        # don't emit one (it would only encourage every recipient to
+        # double-insert).
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.post(

--- a/backend/app/sessions/notepad.py
+++ b/backend/app/sessions/notepad.py
@@ -244,23 +244,31 @@ class NotepadService:
         leading list/blockquote/heading markers from text that came
         from a chat selection. Prevents a player from smuggling
         clickable links or formatting into the Timeline (which feeds
-        into the AAR generation prompt). The link / image regex is
-        applied **until fixed-point** so nested markup like
-        ``[![img](x)](http://evil.com)`` collapses fully."""
+        into the AAR generation prompt). Each tag-stripping pass runs
+        until fixed-point so nested markup like
+        ``[![img](x)](http://evil.com)`` or ``<scr<script>ipt>``
+        (which collapses to ``<script>`` after one pass) gets fully
+        stripped — single-pass ``re.sub`` left residue that the
+        client-side mirror in ``frontend/src/lib/notepad.ts`` was
+        flagged for by CodeQL's incomplete-multi-character-
+        sanitisation rule."""
 
-        out = raw
+        def _replace_until_stable(
+            pattern: re.Pattern[str], replacement: str, source: str, *, limit: int = 8
+        ) -> str:
+            current = source
+            for _ in range(limit):
+                next_value = pattern.sub(replacement, current)
+                if next_value == current:
+                    return next_value
+                current = next_value
+            return current
+
         # Strip code fences first so backticks inside them don't escape
         # the fence-stripping pass.
-        out = cls._PIN_FENCE_RE.sub("", out)
-        # Loop image/link strip until stable — single-pass
-        # ``re.sub`` keeps the inner alt-text of nested markdown links
-        # which can itself be a link/image.
-        for _ in range(8):
-            new = cls._PIN_LINK_RE.sub(lambda m: m.group(1), out)
-            if new == out:
-                break
-            out = new
-        out = cls._PIN_HTML_RE.sub("", out)
+        out = _replace_until_stable(cls._PIN_FENCE_RE, "", raw)
+        out = _replace_until_stable(cls._PIN_LINK_RE, r"\1", out)
+        out = _replace_until_stable(cls._PIN_HTML_RE, "", out)
         out = cls._PIN_BACKTICK_RE.sub("", out)
         out = cls._PIN_LEADING_RE.sub("", out)
         return out.strip()

--- a/backend/tests/test_notepad.py
+++ b/backend/tests/test_notepad.py
@@ -180,6 +180,20 @@ def test_sanitize_pin_text_strips_markdown_html_and_leading_markers() -> None:
     assert not out.startswith(("#", "-", ">", " "))
 
 
+def test_sanitize_pin_text_nested_html_tags_strip_to_fixed_point() -> None:
+    # CodeQL incomplete-multi-character-sanitisation regression. A
+    # single-pass ``re.sub`` over ``<[^>]+>`` collapses
+    # ``<scr<script>ipt>`` to ``<script>`` — still a script tag in
+    # the output. Fixed-point loop must strip until stable.
+    raw = "<scr<script>ipt>alert(1)</scr</script>ipt>"
+    out = NotepadService.sanitize_pin_text(raw)
+    assert "<script" not in out.lower()
+    assert "</script" not in out.lower()
+    # The visible-text content survives (matches the existing test's
+    # contract — sanitiser strips markup, not the words).
+    assert "alert(1)" in out
+
+
 # ----------------------------------------------------------- AAR ingestion
 
 

--- a/frontend/src/__tests__/CollapsibleRailPanel.test.tsx
+++ b/frontend/src/__tests__/CollapsibleRailPanel.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Component tests for the right-rail collapsible wrapper.
+ *
+ * Pins the contract callers depend on: title is always visible, body
+ * shows/hides on toggle, ``aria-expanded`` reflects state, and the
+ * ``persistKey`` survives a remount (so a user's "I don't want to see
+ * the placeholder HUD" preference doesn't reset on every page nav).
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
+
+describe("CollapsibleRailPanel", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders title and body when expanded by default", () => {
+    render(
+      <CollapsibleRailPanel title="HUD">
+        <div data-testid="body">body content</div>
+      </CollapsibleRailPanel>,
+    );
+    expect(screen.getByText("HUD")).toBeInTheDocument();
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+  });
+
+  it("hides body when defaultCollapsed is true", () => {
+    render(
+      <CollapsibleRailPanel title="HUD" defaultCollapsed>
+        <div data-testid="body">body content</div>
+      </CollapsibleRailPanel>,
+    );
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("toggles body visibility on header click and reflects aria-expanded", () => {
+    render(
+      <CollapsibleRailPanel title="HUD">
+        <div data-testid="body">body content</div>
+      </CollapsibleRailPanel>,
+    );
+    const button = screen.getByRole("button", { name: /HUD/ });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("body")).toBeNull();
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+  });
+
+  it("persists collapsed state to localStorage when persistKey is set", () => {
+    const key = "crittable.test.rail.collapsed";
+    const { unmount } = render(
+      <CollapsibleRailPanel title="HUD" persistKey={key}>
+        <div data-testid="body">x</div>
+      </CollapsibleRailPanel>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /HUD/ }));
+    expect(window.localStorage.getItem(key)).toBe("1");
+    unmount();
+    // Remount — should pick up the stored "collapsed" state.
+    render(
+      <CollapsibleRailPanel title="HUD" persistKey={key}>
+        <div data-testid="body">x</div>
+      </CollapsibleRailPanel>,
+    );
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("renders subtitle in warn tone when subtitleTone='warn'", () => {
+    render(
+      <CollapsibleRailPanel title="HUD" subtitle="placeholder" subtitleTone="warn">
+        <div>body</div>
+      </CollapsibleRailPanel>,
+    );
+    const subtitle = screen.getByText("placeholder");
+    expect(subtitle).toBeInTheDocument();
+    // Inline style sets ``color: var(--warn)``; jsdom returns the
+    // raw token string. Asserting the style avoids snapshot brittleness.
+    expect(subtitle.getAttribute("style") ?? "").toContain("var(--warn)");
+  });
+});

--- a/frontend/src/__tests__/HighlightActionPopover.test.tsx
+++ b/frontend/src/__tests__/HighlightActionPopover.test.tsx
@@ -5,7 +5,7 @@
  * untested: selection detection, ``data-highlightable`` ancestor
  * walk, ``onSelect`` invocation, and Escape dismissal.
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { HighlightActionPopover } from "../components/HighlightActionPopover";
@@ -62,7 +62,9 @@ describe("HighlightActionPopover", () => {
         />
       </>,
     );
-    dispatchSelectionInside(screen.getByTestId("non-highlightable"));
+    await act(async () => {
+      dispatchSelectionInside(screen.getByTestId("non-highlightable"));
+    });
     // No menu appears.
     await waitFor(() => {
       expect(screen.queryByRole("menu")).toBeNull();
@@ -92,9 +94,13 @@ describe("HighlightActionPopover", () => {
         />
       </>,
     );
-    dispatchSelectionInside(screen.getByTestId("bubble"), "AI inject text");
+    await act(async () => {
+      dispatchSelectionInside(screen.getByTestId("bubble"), "AI inject text");
+    });
     const btn = await screen.findByRole("menuitem", { name: /add to notes/i });
-    fireEvent.click(btn);
+    await act(async () => {
+      fireEvent.click(btn);
+    });
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledTimes(1);
     });
@@ -107,6 +113,89 @@ describe("HighlightActionPopover", () => {
       sourceKind: "ai",
     });
     expect(ctx.text.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT open the menu mid-drag (suppressed until mouseup)", async () => {
+    const onSelect = vi.fn().mockResolvedValue(undefined);
+    const actions: HighlightAction[] = [
+      { id: "pin", label: "Add to notes", onSelect },
+    ];
+    render(
+      <>
+        <div
+          data-testid="bubble"
+          data-highlightable="true"
+          data-message-id="msg_drag"
+          data-message-kind="chat"
+        >
+          some text the user is drag-selecting
+        </div>
+        <HighlightActionPopover
+          sessionId="s"
+          roleId="r"
+          token="t"
+          actions={actions}
+        />
+      </>,
+    );
+    // Simulate the user pressing the mouse button down on the bubble
+    // (start of a drag-select). The popover should NOT open on the
+    // selectionchange events that fire while the mouse is held down —
+    // the menu would otherwise pop up under the cursor and break the
+    // drag a few characters in.
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByTestId("bubble"));
+      dispatchSelectionInside(screen.getByTestId("bubble"), "some text");
+    });
+    // No menu while the mouse is down.
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+    // Release the mouse — popover should now appear at the final
+    // selection rect.
+    await act(async () => {
+      fireEvent.mouseUp(document);
+    });
+    await screen.findByRole("menu");
+  });
+
+  it("does NOT clear the selection on scroll (regression: drag-select dies)", async () => {
+    const actions: HighlightAction[] = [
+      { id: "pin", label: "Pin", onSelect: vi.fn().mockResolvedValue(undefined) },
+    ];
+    render(
+      <>
+        <div
+          data-testid="bubble"
+          data-highlightable="true"
+          data-message-id="m"
+          data-message-kind="chat"
+        >
+          some text
+        </div>
+        <HighlightActionPopover
+          sessionId="s"
+          roleId="r"
+          token="t"
+          actions={actions}
+        />
+      </>,
+    );
+    await act(async () => {
+      dispatchSelectionInside(screen.getByTestId("bubble"), "some text");
+    });
+    await screen.findByRole("menu");
+    // Confirm the selection is intact before the scroll.
+    expect(window.getSelection()?.isCollapsed).toBe(false);
+    // Fire a window-level scroll (e.g. chat container auto-scrolls
+    // because the user dragged near the edge).
+    await act(async () => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    // The popover hides (its rect is now stale) but the selection
+    // MUST stay alive — clearing it would terminate the drag-select
+    // mid-stream, which was the user-reported regression.
+    expect(window.getSelection()?.isCollapsed).toBe(false);
   });
 
   it("hides the menu on Escape", async () => {
@@ -131,9 +220,13 @@ describe("HighlightActionPopover", () => {
         />
       </>,
     );
-    dispatchSelectionInside(screen.getByTestId("bubble"), "some text");
+    await act(async () => {
+      dispatchSelectionInside(screen.getByTestId("bubble"), "some text");
+    });
     await screen.findByRole("menu");
-    fireEvent.keyDown(document, { key: "Escape" });
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
     await waitFor(() => {
       expect(screen.queryByRole("menu")).toBeNull();
     });

--- a/frontend/src/__tests__/highlightActions.test.ts
+++ b/frontend/src/__tests__/highlightActions.test.ts
@@ -12,12 +12,14 @@
  *   - ``onSelect`` is invoked with the full context and surfaces errors
  *     to the caller.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   defaultHighlightActions,
+  NOTEPAD_PIN_EVENT,
   type HighlightAction,
   type HighlightContext,
+  type NotepadPinEventDetail,
 } from "../lib/highlightActions";
 
 describe("highlightActions default registry", () => {
@@ -91,5 +93,102 @@ describe("HighlightAction interface contract", () => {
         token: "t",
       }),
     ).rejects.toThrow("nope");
+  });
+});
+
+describe("pin-to-notepad action — window event dispatch", () => {
+  // Restore fetch after each test so the global stub doesn't leak.
+  let originalFetch: typeof globalThis.fetch | undefined;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+  });
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it("dispatches crittable:notepad-pin on the window after a successful POST", async () => {
+    const action = defaultHighlightActions[0];
+    const seen: NotepadPinEventDetail[] = [];
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<NotepadPinEventDetail>).detail;
+      seen.push(detail);
+    };
+    window.addEventListener(NOTEPAD_PIN_EVENT, handler);
+    try {
+      await action.onSelect({
+        text: "selected snippet",
+        sourceMessageId: "msg_42",
+        sourceKind: "ai",
+        roleId: "r",
+        sessionId: "s",
+        token: "t",
+      });
+    } finally {
+      window.removeEventListener(NOTEPAD_PIN_EVENT, handler);
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual({
+      text: "selected snippet",
+      sourceMessageId: "msg_42",
+    });
+  });
+
+  it("sanitises the dispatched text — markdown markers and HTML are stripped", async () => {
+    // Belt-and-braces: server runs the same sanitiser on the POST
+    // payload, but the editor inserts the dispatched text locally and
+    // pushes it back via ``pushSnapshot``. Without client-side
+    // sanitisation, an unsanitised string round-trips into
+    // ``session.notepad.markdown_snapshot`` and the AAR.
+    const action = defaultHighlightActions[0];
+    const seen: NotepadPinEventDetail[] = [];
+    const handler = (e: Event) => {
+      seen.push((e as CustomEvent<NotepadPinEventDetail>).detail);
+    };
+    window.addEventListener(NOTEPAD_PIN_EVENT, handler);
+    try {
+      await action.onSelect({
+        text: "# heading injected\n[link](http://evil.example) <script>x</script>",
+        sourceMessageId: "msg_xss",
+        sourceKind: "chat",
+        roleId: "r",
+        sessionId: "s",
+        token: "t",
+      });
+    } finally {
+      window.removeEventListener(NOTEPAD_PIN_EVENT, handler);
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0].text).not.toMatch(/^#/);
+    expect(seen[0].text).not.toContain("](http");
+    expect(seen[0].text).not.toContain("<script>");
+    expect(seen[0].text).toContain("heading injected");
+    expect(seen[0].text).toContain("link");
+  });
+
+  it("does NOT dispatch the event if the POST rejects — caller decides toast wording", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "rate limited" }), { status: 429 }),
+    );
+    const action = defaultHighlightActions[0];
+    const handler = vi.fn();
+    window.addEventListener(NOTEPAD_PIN_EVENT, handler);
+    try {
+      await expect(
+        action.onSelect({
+          text: "selected snippet",
+          sourceMessageId: "msg_42",
+          sourceKind: "ai",
+          roleId: "r",
+          sessionId: "s",
+          token: "t",
+        }),
+      ).rejects.toBeDefined();
+    } finally {
+      window.removeEventListener(NOTEPAD_PIN_EVENT, handler);
+    }
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/sanitizePinText.test.ts
+++ b/frontend/src/__tests__/sanitizePinText.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Direct unit tests for ``sanitizePinText``. The
+ * ``highlightActions.test.ts`` integration case covers the typical
+ * case via the action wrapper; these target the regex-set edge
+ * cases that CodeQL's "incomplete multi-character sanitisation"
+ * rule was concerned about.
+ *
+ * Mirror of ``backend/tests/test_notepad.py::
+ * test_sanitize_pin_text_*`` — keep the two suites in sync.
+ */
+import { describe, expect, it } from "vitest";
+
+import { sanitizePinText } from "../lib/notepad";
+
+describe("sanitizePinText", () => {
+  it("strips ``# heading``, ``[link](url)``, ``<script>...</script>`` markers", () => {
+    const raw =
+      "  ## hello [click](https://evil.com) ![img](x.png) <script>alert(1)</script> world ";
+    const out = sanitizePinText(raw);
+    expect(out).not.toContain("evil.com");
+    expect(out.toLowerCase()).not.toContain("<script");
+    expect(out).toContain("alert(1)"); // text kept; tags stripped
+    expect(out.startsWith("#")).toBe(false);
+    expect(out.startsWith(" ")).toBe(false);
+  });
+
+  it("strips nested HTML tags to fixed-point (CodeQL regression)", () => {
+    // A single-pass ``replace(/<[^>]+>/g, "")`` would collapse
+    // ``<scr<script>ipt>`` to ``<script>`` after the first match
+    // and leave it in place. Fixed-point loop must keep stripping
+    // until stable.
+    const raw = "<scr<script>ipt>alert(1)</scr</script>ipt>";
+    const out = sanitizePinText(raw);
+    expect(out.toLowerCase()).not.toContain("<script");
+    expect(out.toLowerCase()).not.toContain("</script");
+    expect(out).toContain("alert(1)");
+  });
+
+  it("strips nested markdown links to fixed-point", () => {
+    const raw = "[![img](x.png)](http://evil.example)";
+    const out = sanitizePinText(raw);
+    expect(out).not.toContain("evil.example");
+    expect(out).not.toContain("](");
+    expect(out).not.toContain("![");
+    expect(out).toContain("img");
+  });
+
+  it("returns empty string when input is only markup", () => {
+    expect(sanitizePinText("<b><i></i></b>")).toBe("");
+    expect(sanitizePinText("```code```")).toBe("");
+    expect(sanitizePinText("[](http://x)")).toBe("");
+  });
+
+  it("preserves plain visible text", () => {
+    expect(sanitizePinText("plain text — no markup")).toBe(
+      "plain text — no markup",
+    );
+  });
+});

--- a/frontend/src/__tests__/sharedNotepadInsert.test.ts
+++ b/frontend/src/__tests__/sharedNotepadInsert.test.ts
@@ -109,4 +109,24 @@ describe("appendPinToEditor", () => {
     appendPinToEditor(editor, "negative-clamp pin", future);
     expect(editor.getText()).toMatch(/T\+00:00 — negative-clamp pin/);
   });
+
+  it("emits one paragraph per non-empty line; continuation lines use ↳ (NOT 4 spaces)", () => {
+    // 4-space indent would round-trip through ``editorToMarkdown`` as a
+    // CommonMark indented code block, which would change AAR rendering.
+    // Per Copilot review on PR #125 — keep the lead-in as ``↳ `` so the
+    // serialised markdown stays as plain paragraphs.
+    const editor = makeEditor("<p>x</p>");
+    const sessionStartedAt = new Date(Date.now() - 60_000).toISOString();
+    appendPinToEditor(
+      editor,
+      "first line\n\nsecond line\n  third line  ",
+      sessionStartedAt,
+    );
+    const text = editor.getText();
+    expect(text).toMatch(/T\+01:00 — first line/);
+    expect(text).toMatch(/↳ second line/);
+    expect(text).toMatch(/↳ third line/);
+    // No 4-space prefix — that would parse as an indented code block.
+    expect(text).not.toMatch(/^ {4}second line/m);
+  });
 });

--- a/frontend/src/__tests__/sharedNotepadInsert.test.ts
+++ b/frontend/src/__tests__/sharedNotepadInsert.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the Timeline-section-end finder + pin-append helpers
+ * in ``SharedNotepad.tsx``. These run against a headless TipTap editor
+ * (no React, no Collaboration plugin) — enough to exercise the doc
+ * walk and the ``insertContentAt`` call path without booting the full
+ * notepad.
+ */
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, expect, it } from "vitest";
+
+import {
+  appendPinToEditor,
+  findPinInsertPos,
+} from "../lib/notepadEditor";
+
+function makeEditor(html: string): Editor {
+  return new Editor({
+    extensions: [StarterKit.configure({ undoRedo: false })],
+    content: html,
+  });
+}
+
+describe("findPinInsertPos", () => {
+  it("returns end-of-doc when there is no Timeline heading", () => {
+    const editor = makeEditor("<p>just a paragraph</p>");
+    expect(findPinInsertPos(editor)).toBe(editor.state.doc.content.size);
+  });
+
+  it("returns the start of the next h2 when Timeline is followed by another section", () => {
+    const editor = makeEditor(
+      "<h2>Timeline</h2><p>existing</p><h2>Action Items</h2><p>todo</p>",
+    );
+    const pos = findPinInsertPos(editor);
+    // Insert position should be the start of the "Action Items" heading,
+    // i.e. strictly less than doc.content.size and strictly greater than
+    // the position of the first paragraph after Timeline.
+    expect(pos).toBeLessThan(editor.state.doc.content.size);
+    expect(pos).toBeGreaterThan(0);
+    // Round-trip: inserting a paragraph there should land BEFORE the
+    // "Action Items" heading.
+    editor.commands.insertContentAt(pos, [
+      { type: "paragraph", content: [{ type: "text", text: "INSERTED" }] },
+    ]);
+    const text = editor.getText();
+    expect(text.indexOf("INSERTED")).toBeLessThan(text.indexOf("Action Items"));
+    expect(text.indexOf("INSERTED")).toBeGreaterThan(text.indexOf("Timeline"));
+  });
+
+  it("returns end-of-doc when Timeline is the last section", () => {
+    const editor = makeEditor(
+      "<h2>Action Items</h2><p>todo</p><h2>Timeline</h2><p>existing</p>",
+    );
+    expect(findPinInsertPos(editor)).toBe(editor.state.doc.content.size);
+  });
+
+  it("matches Timeline case-insensitively (TIMELINE / timeline / Timeline)", () => {
+    const upper = makeEditor("<h2>TIMELINE</h2><p>x</p><h2>Next</h2>");
+    expect(findPinInsertPos(upper)).toBeLessThan(
+      upper.state.doc.content.size,
+    );
+    const lower = makeEditor("<h2>timeline</h2><p>x</p><h2>Next</h2>");
+    expect(findPinInsertPos(lower)).toBeLessThan(
+      lower.state.doc.content.size,
+    );
+  });
+
+  it("ignores h1 / h3 timeline headings — only h2 counts", () => {
+    const h1 = makeEditor("<h1>Timeline</h1><p>x</p><h2>Next</h2>");
+    // h1 doesn't match — falls through to end-of-doc.
+    expect(findPinInsertPos(h1)).toBe(h1.state.doc.content.size);
+    const h3 = makeEditor("<h3>Timeline</h3><p>x</p><h2>Next</h2>");
+    expect(findPinInsertPos(h3)).toBe(h3.state.doc.content.size);
+  });
+});
+
+describe("appendPinToEditor", () => {
+  it("inserts a paragraph with a T+MM:SS prefix at the Timeline-section end", () => {
+    const editor = makeEditor(
+      "<h2>Timeline</h2><p>existing</p><h2>Action Items</h2>",
+    );
+    // Use a fixed sessionStartedAt 90s in the past so the stamp is "T+01:30".
+    const sessionStartedAt = new Date(Date.now() - 90_000).toISOString();
+    appendPinToEditor(editor, "important snippet", sessionStartedAt);
+    const text = editor.getText();
+    expect(text).toMatch(/T\+01:30 — important snippet/);
+    // And the new paragraph lives in the Timeline section, not after
+    // "Action Items".
+    expect(text.indexOf("important snippet")).toBeGreaterThan(
+      text.indexOf("Timeline"),
+    );
+    expect(text.indexOf("important snippet")).toBeLessThan(
+      text.indexOf("Action Items"),
+    );
+  });
+
+  it("appends at end-of-doc when there is no Timeline heading", () => {
+    const editor = makeEditor("<p>scratch note</p>");
+    appendPinToEditor(editor, "PIN", new Date().toISOString());
+    const text = editor.getText();
+    // PIN should live AFTER the existing scratch note.
+    expect(text.indexOf("PIN")).toBeGreaterThan(text.indexOf("scratch note"));
+  });
+
+  it("clamps a future sessionStartedAt so the stamp never goes negative", () => {
+    const editor = makeEditor("<p>x</p>");
+    // Session "starts" 10 minutes in the future — clamp should yield T+00:00.
+    const future = new Date(Date.now() + 10 * 60_000).toISOString();
+    appendPinToEditor(editor, "negative-clamp pin", future);
+    expect(editor.getText()).toMatch(/T\+00:00 — negative-clamp pin/);
+  });
+});

--- a/frontend/src/components/HighlightActionPopover.tsx
+++ b/frontend/src/components/HighlightActionPopover.tsx
@@ -70,10 +70,19 @@ export function HighlightActionPopover({
   const [focusedIdx, setFocusedIdx] = useState<number>(0);
   const dismissRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  // ``true`` while the user has the mouse held down to drag-select.
+  // Suppresses popover OPENING during the drag — the menu would
+  // otherwise pop up under the cursor mid-selection, where the
+  // ``onMouseDown={preventDefault}`` collapses the user's drag and
+  // ends the selection a few characters in. ``mouseup`` clears it
+  // and re-evaluates so the popover lands at the final rect. Tests
+  // dispatch ``selectionchange`` directly without a mousedown, so
+  // they bypass this gate naturally.
+  const draggingRef = useRef(false);
 
   // Selection → popover state.
   useEffect(() => {
-    function onChange(): void {
+    function applySelection(): void {
       // Guard the entire handler — selection state can be invalid
       // (Range with no rect, jsdom Selection-impl emitting stray
       // selectionchange after a test teardown, etc.). Treat any
@@ -121,8 +130,66 @@ export function HighlightActionPopover({
         setState(null);
       }
     }
+    function onChange(): void {
+      if (draggingRef.current) {
+        // Mid-drag: don't open the popover (see draggingRef comment).
+        // Still allow the dismiss path so a collapsed selection clears
+        // a stale menu, but never set a new rect/ctx here.
+        try {
+          const sel = window.getSelection();
+          if (!sel || sel.isCollapsed || sel.toString().trim().length < 2) {
+            setState(null);
+          }
+        } catch {
+          setState(null);
+        }
+        return;
+      }
+      applySelection();
+    }
+    function onMouseDown(e: MouseEvent): void {
+      // Clicks INSIDE the menu shouldn't be counted as a drag-select
+      // start (the menu's ``onMouseDown={preventDefault}`` already
+      // shields its own clicks). Anything else — including a fresh
+      // mousedown on a chat bubble that starts a new drag — flips us
+      // into drag mode until the matching mouseup.
+      if (menuRef.current?.contains(e.target as Node)) return;
+      draggingRef.current = true;
+    }
+    function onMouseUp(): void {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      // After the drag completes, render the popover at the final
+      // selection rect. We DON'T just rely on the next selectionchange
+      // here because Chrome doesn't always fire one if the mouseup
+      // happens inside the same text run as the last selectionchange.
+      applySelection();
+    }
+    function clearDragging(): void {
+      // Defensive reset: if the OS swallows the matching mouseup
+      // (window switch, context menu, drag-out-of-window, tab
+      // background-throttle mid-drag), ``draggingRef`` would otherwise
+      // stay ``true`` and suppress every subsequent popover open.
+      // ``visibilitychange`` and ``blur`` cover the alt-tab path;
+      // ``pointercancel`` covers touch / pen interactions where the
+      // OS reroutes the gesture. Mirror state with the clean-slate.
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+    }
     document.addEventListener("selectionchange", onChange);
-    return () => document.removeEventListener("selectionchange", onChange);
+    document.addEventListener("mousedown", onMouseDown, true);
+    document.addEventListener("mouseup", onMouseUp, true);
+    document.addEventListener("pointercancel", clearDragging, true);
+    document.addEventListener("visibilitychange", clearDragging);
+    window.addEventListener("blur", clearDragging);
+    return () => {
+      document.removeEventListener("selectionchange", onChange);
+      document.removeEventListener("mousedown", onMouseDown, true);
+      document.removeEventListener("mouseup", onMouseUp, true);
+      document.removeEventListener("pointercancel", clearDragging, true);
+      document.removeEventListener("visibilitychange", clearDragging);
+      window.removeEventListener("blur", clearDragging);
+    };
   }, [sessionId, roleId, token]);
 
   // Dismiss on scroll (selection rectangles drift) and on Escape.
@@ -131,8 +198,14 @@ export function HighlightActionPopover({
   useEffect(() => {
     if (!state) return;
     function onScroll(): void {
+      // Hide the popover (its anchor rect is now stale) but DO NOT
+      // call ``removeAllRanges()`` here. A scroll event fires when a
+      // scrollable chat container auto-scrolls during a drag-select,
+      // and clearing the range mid-drag terminates the user's
+      // selection a few characters in — exactly the bug the user
+      // reported. The selection itself stays valid; the next
+      // selectionchange or mouseup will re-anchor the menu.
       setState(null);
-      window.getSelection()?.removeAllRanges();
     }
     function onKey(e: KeyboardEvent): void {
       if (e.key === "Escape") {
@@ -165,13 +238,20 @@ export function HighlightActionPopover({
   // focus is still in the chat selection) — the advertised
   // arrow-key/Enter contract per the ARIA APG menu pattern would
   // be a lie. Per Copilot review on PR #115.
+  //
+  // ``preventScroll: true`` is load-bearing: without it the browser
+  // scrolls the focused button into view, which fires our scroll
+  // handler, which hides the menu. The menu is already inside the
+  // viewport (clamped below) so a scroll-into-view is always a no-op
+  // visually; suppressing it just keeps the open/scroll cycle from
+  // racing.
   useEffect(() => {
     if (!state || !menuRef.current) return;
     const items = menuRef.current.querySelectorAll<HTMLButtonElement>(
       '[role="menuitem"]',
     );
     const target = items[focusedIdx] ?? items[0];
-    target?.focus();
+    target?.focus({ preventScroll: true });
   }, [state, focusedIdx]);
 
   const onClick = useCallback(
@@ -180,7 +260,13 @@ export function HighlightActionPopover({
       setPending(action.id);
       try {
         await action.onSelect(state.ctx);
-        setToast(`${action.label}: pinned to Timeline.`);
+        // The previous wording "pinned to Timeline" surprised users —
+        // the visible side effect of "Add to notes" is text appearing
+        // in the team notepad, not in the right-rail Timeline widget.
+        // Action authors can override per-action via ``successToast``;
+        // the default names the panel that just changed.
+        const success = action.successToast ?? `${action.label} — pinned.`;
+        setToast(success);
         // Clear the selection so the popover hides cleanly.
         window.getSelection()?.removeAllRanges();
         setState(null);

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { MessageView, RoleView } from "../api/client";
+import { CollapsibleRailPanel } from "./brand/CollapsibleRailPanel";
 import { Timeline } from "./Timeline";
 
 interface Props {
@@ -21,12 +22,22 @@ interface Props {
  * Desktop: an always-visible right column. Mobile: collapsed into a
  * ``<details>`` block so the chat stays the primary surface and the user
  * isn't burying scrolling beneath several hundred px of side panels.
+ *
+ * The Timeline is rendered inside a ``CollapsibleRailPanel`` so users
+ * can collapse it to give the notepad more vertical space (sessions
+ * with few or zero pinned beats produce a small Timeline panel that
+ * still ate ~60px of header chrome under the previous layout).
  */
 export function RightSidebar({ messages, roles, notepad }: Props) {
   return (
     <>
       <aside className="hidden flex-col gap-4 lg:flex lg:min-h-0 lg:overflow-y-auto lg:pr-1">
-        <Timeline messages={messages} roles={roles} />
+        <CollapsibleRailPanel
+          title="TIMELINE"
+          persistKey="crittable.rail.timeline.collapsed"
+        >
+          <Timeline messages={messages} roles={roles} />
+        </CollapsibleRailPanel>
         {notepad ?? null}
       </aside>
       <details

--- a/frontend/src/components/SharedNotepad.tsx
+++ b/frontend/src/components/SharedNotepad.tsx
@@ -25,6 +25,10 @@ import * as Y from "yjs";
 import { RailHeader } from "./brand/RailHeader";
 import { StatusChip } from "./brand/StatusChip";
 import {
+  NOTEPAD_PIN_EVENT,
+  type NotepadPinEventDetail,
+} from "../lib/highlightActions";
+import {
   applyTemplate,
   exportMarkdownUrl,
   editorToMarkdown,
@@ -33,6 +37,7 @@ import {
   templateMarkdownToHtml,
 } from "../lib/notepad";
 import type { NotepadTemplate } from "../lib/notepad";
+import { appendPinToEditor, relativeStamp } from "../lib/notepadEditor";
 import type { ServerEvent, WsClient } from "../lib/ws";
 
 interface Props {
@@ -244,13 +249,7 @@ function timestampHotkeyExtension(sessionStartedAt: string): Extension {
     addKeyboardShortcuts() {
       return {
         "Mod-Shift-t": () => {
-          const start = new Date(sessionStartedAt).getTime();
-          const elapsedMs = Date.now() - start;
-          const minutes = Math.max(0, Math.floor(elapsedMs / 60000));
-          const seconds = Math.max(0, Math.floor((elapsedMs % 60000) / 1000));
-          const stamp = `T+${String(minutes).padStart(2, "0")}:${String(
-            seconds,
-          ).padStart(2, "0")} — `;
+          const stamp = `${relativeStamp(sessionStartedAt)} — `;
           // @ts-expect-error: editor is bound by TipTap at runtime
           this.editor?.chain().focus().insertContent(stamp).run();
           return true;
@@ -349,6 +348,50 @@ export function SharedNotepad({
   useEffect(() => {
     if (editor) editor.setEditable(!locked);
   }, [editor, locked]);
+
+  // "Add to notes" pin from the chat-highlight popover. The popover
+  // POSTs the snippet, then dispatches ``crittable:notepad-pin`` on
+  // the window — only the originating tab inserts; Yjs collab fans
+  // the resulting transaction to peers. Per-tab dispatch (rather
+  // than a server-side broadcast) prevents double-insert when one
+  // user has two tabs of the same role open.
+  //
+  // The server idempotently 204s a re-pin of the same
+  // ``source_message_id`` (a panic-clicker double-tapping the same
+  // chat bubble), but the popover still dispatches the event for
+  // every successful request. ``insertedPinIdsRef`` tracks the ids
+  // we've already written so the second click of the same pin
+  // doesn't double the editor entry.
+  const insertedPinIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!editor) return;
+    const insertedIds = insertedPinIdsRef.current;
+    function onPin(e: Event): void {
+      const detail = (e as CustomEvent<NotepadPinEventDetail>).detail;
+      if (!detail || !detail.text) return;
+      if (locked) {
+        console.warn("[notepad] pin received while locked; dropping");
+        return;
+      }
+      if (detail.sourceMessageId) {
+        if (insertedIds.has(detail.sourceMessageId)) {
+          console.debug(
+            "[notepad] pin already inserted for source",
+            detail.sourceMessageId,
+          );
+          return;
+        }
+        insertedIds.add(detail.sourceMessageId);
+      }
+      try {
+        appendPinToEditor(editor!, detail.text, sessionStartedAt);
+      } catch (err) {
+        console.warn("[notepad] pin insertion failed", err);
+      }
+    }
+    window.addEventListener(NOTEPAD_PIN_EVENT, onPin);
+    return () => window.removeEventListener(NOTEPAD_PIN_EVENT, onPin);
+  }, [editor, sessionStartedAt, locked]);
 
   // Track empty-state. We watch ydoc updates rather than editor state
   // so the picker disappears as soon as ANY content arrives — even

--- a/frontend/src/components/SharedNotepad.tsx
+++ b/frontend/src/components/SharedNotepad.tsx
@@ -261,6 +261,13 @@ function timestampHotkeyExtension(sessionStartedAt: string): Extension {
 
 const COACHMARK_KEY = "crittable.notepad.coachmark_seen";
 
+// Bound for the per-instance "already-inserted" pin id ring buffer.
+// Long sessions can produce hundreds of pins; keeping every id in
+// memory forever is a slow leak. 256 is well past any realistic
+// double-click window — by the time we evict the oldest id, the
+// user's panic-click flurry on that message is long over.
+const MAX_INSERTED_PIN_IDS = 256;
+
 export function SharedNotepad({
   sessionId,
   token,
@@ -361,11 +368,15 @@ export function SharedNotepad({
   // chat bubble), but the popover still dispatches the event for
   // every successful request. ``insertedPinIdsRef`` tracks the ids
   // we've already written so the second click of the same pin
-  // doesn't double the editor entry.
-  const insertedPinIdsRef = useRef<Set<string>>(new Set());
+  // doesn't double the editor entry. The id is recorded ONLY after
+  // the insert succeeds — if ``appendPinToEditor`` throws, the user
+  // can retry the same pin (per Copilot review on PR #125). Bounded
+  // to the last ``MAX_INSERTED_PIN_IDS`` ids in FIFO order so a long
+  // session doesn't grow the Set unboundedly.
+  const insertedPinIdsRef = useRef<string[]>([]);
   useEffect(() => {
     if (!editor) return;
-    const insertedIds = insertedPinIdsRef.current;
+    const inserted = insertedPinIdsRef.current;
     function onPin(e: Event): void {
       const detail = (e as CustomEvent<NotepadPinEventDetail>).detail;
       if (!detail || !detail.text) return;
@@ -373,18 +384,24 @@ export function SharedNotepad({
         console.warn("[notepad] pin received while locked; dropping");
         return;
       }
-      if (detail.sourceMessageId) {
-        if (insertedIds.has(detail.sourceMessageId)) {
-          console.debug(
-            "[notepad] pin already inserted for source",
-            detail.sourceMessageId,
-          );
-          return;
-        }
-        insertedIds.add(detail.sourceMessageId);
+      if (
+        detail.sourceMessageId &&
+        inserted.includes(detail.sourceMessageId)
+      ) {
+        console.debug(
+          "[notepad] pin already inserted for source",
+          detail.sourceMessageId,
+        );
+        return;
       }
       try {
         appendPinToEditor(editor!, detail.text, sessionStartedAt);
+        if (detail.sourceMessageId) {
+          inserted.push(detail.sourceMessageId);
+          if (inserted.length > MAX_INSERTED_PIN_IDS) {
+            inserted.splice(0, inserted.length - MAX_INSERTED_PIN_IDS);
+          }
+        }
       } catch (err) {
         console.warn("[notepad] pin insertion failed", err);
       }

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -202,15 +202,19 @@ export function Timeline({ messages, roles: _roles }: Props) {
   void flashing;
 
   return (
-    <section
+    <div
       aria-labelledby="timeline-heading"
-      className="flex min-h-0 flex-col gap-2 rounded-r-3 border border-ink-600 bg-ink-850 p-3 text-sm"
+      className="flex min-h-0 flex-col gap-2 p-3 text-sm"
     >
+      {/* Visually-hidden heading — the parent ``CollapsibleRailPanel``
+          renders the visible "TIMELINE" chrome, but screen readers
+          still benefit from the section being labelled inside the
+          accordion body. */}
       <h3
         id="timeline-heading"
-        className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-ink-300"
+        className="sr-only"
       >
-        TIMELINE · {items.length} {items.length === 1 ? "EVENT" : "EVENTS"}
+        Timeline · {items.length} {items.length === 1 ? "event" : "events"}
       </h3>
       {items.length === 0 ? (
         <p className="mono text-[10px] uppercase tracking-[0.04em] text-ink-400">
@@ -240,6 +244,6 @@ export function Timeline({ messages, roles: _roles }: Props) {
           ))}
         </ol>
       )}
-    </section>
+    </div>
   );
 }

--- a/frontend/src/components/brand/CollapsibleRailPanel.tsx
+++ b/frontend/src/components/brand/CollapsibleRailPanel.tsx
@@ -1,0 +1,108 @@
+import { useState, type ReactNode } from "react";
+
+/**
+ * Right-rail panel wrapper that keeps the brand RailHeader pattern but
+ * adds a collapse/expand affordance. Mounts as a ``section`` with the
+ * standard ink-850 / ink-600 chrome; the body is hidden when collapsed
+ * so the panel takes only its header height (~36px).
+ *
+ * Designed to share the rail with several stacked panels — the user
+ * collapses the ones they aren't using and the next-stacked panel
+ * reclaims the vertical space (right-rail is ``overflow-y-auto`` so a
+ * single expanded notepad can grow as far as the viewport allows).
+ *
+ * The header chevron is the brand mono ``▼`` / ``▶``: small, square,
+ * no animation. ``localStorage`` persistence is opt-in via
+ * ``persistKey`` so a user who collapses the placeholder HUD on Tab A
+ * doesn't have to re-collapse it on Tab B.
+ */
+interface Props {
+  title: string;
+  /** Optional short label rendered after the title (e.g. ``placeholder``). */
+  subtitle?: ReactNode;
+  /** Subtitle tone — ``warn`` is the brand "this is a stub" hue. */
+  subtitleTone?: "default" | "signal" | "warn";
+  /** Initial state on first render. Default: expanded. */
+  defaultCollapsed?: boolean;
+  /** localStorage key to persist collapse state across reloads. */
+  persistKey?: string;
+  children: ReactNode;
+}
+
+export function CollapsibleRailPanel({
+  title,
+  subtitle,
+  subtitleTone,
+  defaultCollapsed = false,
+  persistKey,
+  children,
+}: Props) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (persistKey) {
+      try {
+        const stored = window.localStorage.getItem(persistKey);
+        if (stored === "1") return true;
+        if (stored === "0") return false;
+      } catch {
+        /* localStorage unavailable; fall through to default */
+      }
+    }
+    return defaultCollapsed;
+  });
+
+  const subtitleColor =
+    subtitleTone === "signal"
+      ? "var(--signal)"
+      : subtitleTone === "warn"
+        ? "var(--warn)"
+        : "var(--ink-400)";
+
+  function toggle(): void {
+    const next = !collapsed;
+    setCollapsed(next);
+    if (persistKey) {
+      try {
+        window.localStorage.setItem(persistKey, next ? "1" : "0");
+      } catch {
+        /* localStorage unavailable; transient state */
+      }
+    }
+  }
+
+  return (
+    <section className="flex min-h-0 flex-col rounded-r-3 border border-ink-600 bg-ink-850">
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        onClick={toggle}
+        className="mono flex items-baseline justify-between gap-2 px-4 py-3 text-left hover:bg-ink-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-signal"
+        style={{ borderBottom: collapsed ? "none" : "1px solid var(--ink-600)" }}
+      >
+        <span className="flex items-baseline gap-2">
+          <span
+            aria-hidden="true"
+            className="text-[9px] leading-none text-ink-300"
+          >
+            {collapsed ? "▶" : "▼"}
+          </span>
+          <span
+            className="text-[10px] font-bold uppercase tracking-[0.22em] text-ink-200"
+          >
+            {title}
+          </span>
+        </span>
+        {subtitle ? (
+          <span
+            className="mono text-[10px]"
+            style={{ color: subtitleColor, letterSpacing: "0.04em" }}
+          >
+            {subtitle}
+          </span>
+        ) : null}
+      </button>
+      {collapsed ? null : (
+        <div className="flex min-h-0 flex-col">{children}</div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/brand/HudGauges.tsx
+++ b/frontend/src/components/brand/HudGauges.tsx
@@ -1,16 +1,14 @@
-import { RailHeader } from "./RailHeader";
-
 /**
- * Brand-mock <PressureGauge> + the <RightRail> "HUD" panel that wraps
+ * Brand-mock <PressureGauge> + the right-rail "HUD" panel that wraps
  * three of them. Lifted from /tmp/brand-source/handoff/source/app-screens.jsx
  * lines 37-63 (PressureGauge) and 498-503 (the HUD panel).
  *
  * THESE ARE PLACEHOLDERS — the user explicitly asked to keep them
  * visible but not wire them to live data. The wrapper carries
  * ``data-placeholder="1"`` so any future "wire it up" engineer can
- * grep for it, and the panel's RailHeader subtitle reads PLACEHOLDER
- * (warn-toned) instead of the brand mock's "live" so it's obvious at
- * a glance that the bars aren't real.
+ * grep for it. The panel renders inside a ``CollapsibleRailPanel`` at
+ * the page level, which carries the ``placeholder`` warn-toned chip
+ * in the header so it's obvious at a glance that the bars aren't real.
  */
 
 interface GaugeProps {
@@ -92,31 +90,27 @@ interface PanelProps {
 }
 
 /**
- * The 3-gauge HUD panel — drop-in for the right rail. Static demo
- * values mirror the brand mock (0.62 / 0.34 / 0.18). Wrap in any
- * scroll container; the panel itself is fixed-height.
+ * The 3-gauge HUD panel body — drop-in for the right rail. Static
+ * demo values mirror the brand mock (0.62 / 0.34 / 0.18). The
+ * ``data-placeholder="1"`` attribute is grep-able for any future
+ * "wire it up" engineer. Header chrome lives in the parent
+ * ``CollapsibleRailPanel``; this component renders body only.
  */
 export function HudGauges({ className }: PanelProps) {
   return (
     <div
       className={className}
       data-placeholder="1"
-      style={{ display: "flex", flexDirection: "column" }}
+      style={{
+        padding: 14,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+      }}
     >
-      <RailHeader title="HUD" subtitle="placeholder" subtitleTone="warn" />
-      <div
-        style={{
-          padding: 14,
-          display: "flex",
-          flexDirection: "column",
-          gap: 14,
-          borderBottom: "1px solid var(--ink-600)",
-        }}
-      >
-        <PressureGauge value={0.62} label="MGMT PRESSURE" />
-        <PressureGauge value={0.34} label="CONTAINMENT" />
-        <PressureGauge value={0.18} label="BURN RATE" />
-      </div>
+      <PressureGauge value={0.62} label="MGMT PRESSURE" />
+      <PressureGauge value={0.34} label="CONTAINMENT" />
+      <PressureGauge value={0.18} label="BURN RATE" />
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -243,3 +243,175 @@ html, body {
 ::-webkit-scrollbar-corner {
   background: transparent;
 }
+
+/*
+ * Shared notepad — TipTap/ProseMirror node styling.
+ *
+ * Tailwind preflight resets ``h1..h6 { font-size: inherit; font-weight:
+ * inherit }`` and strips list markers, so a ``# Heading`` typed into the
+ * notepad parses correctly into a heading node but renders identical to
+ * a paragraph. The editor was tagged ``data-notepad-editor`` so we can
+ * scope these rules without leaking into chat bubbles or other prose.
+ *
+ * The ``prose prose-invert`` classes on the editor are aspirational —
+ * @tailwindcss/typography isn't installed, and adding the ~40 KB plugin
+ * just to style a small editor doesn't pay for itself. Hand-roll the
+ * subset we actually use; brand tokens keep colours consistent.
+ */
+[data-notepad-editor] h1 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0.6em 0 0.3em;
+  color: var(--ink-050);
+}
+[data-notepad-editor] h2 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0.6em 0 0.3em;
+  color: var(--ink-050);
+}
+[data-notepad-editor] h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0.5em 0 0.2em;
+  color: var(--ink-100);
+}
+[data-notepad-editor] h4,
+[data-notepad-editor] h5,
+[data-notepad-editor] h6 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0.4em 0 0.2em;
+  color: var(--ink-100);
+}
+[data-notepad-editor] p {
+  margin: 0.3em 0;
+}
+[data-notepad-editor] ul {
+  list-style: disc;
+  padding-left: 1.4em;
+  margin: 0.3em 0;
+}
+[data-notepad-editor] ol {
+  list-style: decimal;
+  padding-left: 1.4em;
+  margin: 0.3em 0;
+}
+[data-notepad-editor] li {
+  margin: 0.1em 0;
+}
+[data-notepad-editor] li > p {
+  margin: 0;
+}
+[data-notepad-editor] ul[data-type="taskList"] {
+  list-style: none;
+  padding-left: 0.2em;
+}
+[data-notepad-editor] ul[data-type="taskList"] li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45em;
+}
+[data-notepad-editor] ul[data-type="taskList"] li > label {
+  margin-top: 0.25em;
+  user-select: none;
+}
+[data-notepad-editor] ul[data-type="taskList"] li > div {
+  flex: 1;
+  min-width: 0;
+}
+[data-notepad-editor] strong {
+  font-weight: 600;
+  color: var(--ink-050);
+}
+[data-notepad-editor] em {
+  font-style: italic;
+}
+[data-notepad-editor] code {
+  font-family: var(--font-mono);
+  background: var(--ink-850);
+  padding: 0.05em 0.3em;
+  border-radius: 2px;
+  font-size: 0.85em;
+  color: var(--signal);
+}
+[data-notepad-editor] pre {
+  font-family: var(--font-mono);
+  background: var(--ink-950);
+  border: 1px solid var(--ink-600);
+  padding: 0.6em 0.75em;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 0.5em 0;
+  font-size: 0.85em;
+}
+[data-notepad-editor] pre code {
+  background: transparent;
+  padding: 0;
+  color: var(--ink-100);
+}
+[data-notepad-editor] blockquote {
+  border-left: 2px solid var(--signal);
+  padding-left: 0.8em;
+  color: var(--ink-300);
+  margin: 0.4em 0;
+  font-style: italic;
+}
+[data-notepad-editor] hr {
+  border: none;
+  border-top: 1px dashed var(--ink-600);
+  margin: 0.8em 0;
+}
+[data-notepad-editor] a {
+  color: var(--signal);
+  text-decoration: underline;
+}
+
+/*
+ * TipTap CollaborationCaret — remote-user cursor + label.
+ *
+ * y-tiptap renders the remote caret as
+ *   <span class="collaboration-carets__caret"><div class="collaboration-carets__label">Name</div></span>
+ * with only ``border-color`` / ``background-color`` set inline. Without
+ * widths/positioning the ``<div>`` (a block element) sat inline and
+ * filled the line height — the user's name showed up as a giant block
+ * obscuring the surrounding text. Style as a thin vertical sliver with
+ * a small floating label above the caret position, matching every other
+ * collaborative editor (Google Docs / Notion / Tiptap demos).
+ */
+[data-notepad-editor] .collaboration-carets__caret {
+  position: relative;
+  margin-left: -1px;
+  margin-right: -1px;
+  border-left: 1px solid;
+  border-right: 1px solid;
+  word-break: normal;
+  pointer-events: none;
+}
+[data-notepad-editor] .collaboration-carets__label {
+  position: absolute;
+  top: -1.5em;
+  left: -1px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--ink-950);
+  padding: 1px 4px;
+  border-radius: 2px 2px 2px 0;
+  white-space: nowrap;
+  user-select: none;
+  pointer-events: none;
+}
+/*
+ * Remote-user selected-text decoration. y-tiptap sets
+ * ``background-color`` inline (semi-transparent user colour); we just
+ * make sure the highlight doesn't bleed past the line by clamping the
+ * decoration to the inline rendering.
+ */
+[data-notepad-editor] .ProseMirror-yjs-selection {
+  border-radius: 1px;
+}

--- a/frontend/src/lib/highlightActions.ts
+++ b/frontend/src/lib/highlightActions.ts
@@ -15,7 +15,20 @@
  */
 import type { ReactNode } from "react";
 
-import { pinToNotepad } from "./notepad";
+import { pinToNotepad, sanitizePinText } from "./notepad";
+
+/**
+ * Dispatched on ``window`` after a successful "Add to notes" POST.
+ * SharedNotepad listens and inserts the snippet locally; Yjs collab
+ * propagates to peers. Per-tab dispatch (rather than a server-side
+ * broadcast) prevents double-insert when one user has two tabs open.
+ */
+export const NOTEPAD_PIN_EVENT = "crittable:notepad-pin";
+
+export interface NotepadPinEventDetail {
+  text: string;
+  sourceMessageId: string | null;
+}
 
 /**
  * Source surfaces the highlight popover may activate over. Keep the
@@ -41,14 +54,33 @@ export interface HighlightAction {
   isAvailable?: (ctx: HighlightContext) => boolean;
   /** Returned promise resolves on success; rejects to surface a toast. */
   onSelect: (ctx: HighlightContext) => Promise<void>;
+  /** Optional override for the success toast. Default: "{label} — pinned." */
+  successToast?: string;
 }
 
 const pinToNotepadAction: HighlightAction = {
   id: "pin-to-notepad",
   label: "Add to notes",
   glyph: "+",
-  onSelect: ({ sessionId, token, text, sourceMessageId }) =>
-    pinToNotepad(sessionId, token, text, sourceMessageId),
+  successToast: "Pinned to notepad.",
+  onSelect: async ({ sessionId, token, text, sourceMessageId }) => {
+    await pinToNotepad(sessionId, token, text, sourceMessageId);
+    // Sanitize before dispatch so the editor receives the same shape
+    // the server stores in ``session.notepad.markdown_snapshot``.
+    // Without this, an unsanitized ``# heading injected`` round-trips
+    // through the next ``pushSnapshot`` and ends up feeding the AAR.
+    // Mirrors ``backend/app/sessions/notepad.py::sanitize_pin_text``.
+    const safe = sanitizePinText(text).slice(0, 280);
+    if (!safe) return;
+    // The Yjs doc is untouched server-side — inserting the snippet is
+    // the originating tab's job. Yjs collab propagates the resulting
+    // transaction to peers via the regular ``notepad_update`` flow.
+    const detail: NotepadPinEventDetail = {
+      text: safe,
+      sourceMessageId,
+    };
+    window.dispatchEvent(new CustomEvent(NOTEPAD_PIN_EVENT, { detail }));
+  },
 };
 
 /**

--- a/frontend/src/lib/notepad.ts
+++ b/frontend/src/lib/notepad.ts
@@ -119,11 +119,17 @@ export async function pinToNotepad(
  * ``session.notepad.markdown_snapshot`` and feeds the AAR.
  *
  * Strips, in order:
- *   1. Fenced code blocks (``\`\`\`...\`\`\``)
- *   2. Markdown links / images, until fixed-point
- *   3. HTML tags
+ *   1. Fenced code blocks (``\`\`\`...\`\`\``) — fixed-point
+ *   2. Markdown links / images — fixed-point
+ *   3. HTML tags — fixed-point
  *   4. Backticks
  *   5. Leading whitespace / blockquote / heading / list markers per line
+ *
+ * Each tag-stripping pass is run until fixed-point: a single-pass
+ * ``replace`` leaves residual markup when an attacker nests tags
+ * (e.g. ``<scr<script>ipt>`` collapses to ``<script>`` after one
+ * pass) — flagged by CodeQL's "incomplete multi-character
+ * sanitisation" rule.
  *
  * Keep in sync with the server regexes — there are tests on each side
  * that exercise the regex set; if you add a marker class to one,
@@ -135,14 +141,25 @@ const PIN_FENCE_RE = /```[^`]*```/gs;
 const PIN_BACKTICK_RE = /`+/g;
 const PIN_LEADING_RE = /^[\s>#\-*+]+/gm;
 
-export function sanitizePinText(raw: string): string {
-  let out = raw.replace(PIN_FENCE_RE, "");
-  for (let i = 0; i < 8; i++) {
-    const next = out.replace(PIN_LINK_RE, "$1");
+function replaceUntilStable(
+  input: string,
+  re: RegExp,
+  replacement: string,
+  limit = 8,
+): string {
+  let out = input;
+  for (let i = 0; i < limit; i++) {
+    const next = out.replace(re, replacement);
     if (next === out) break;
     out = next;
   }
-  out = out.replace(PIN_HTML_RE, "");
+  return out;
+}
+
+export function sanitizePinText(raw: string): string {
+  let out = replaceUntilStable(raw, PIN_FENCE_RE, "");
+  out = replaceUntilStable(out, PIN_LINK_RE, "$1");
+  out = replaceUntilStable(out, PIN_HTML_RE, "");
   out = out.replace(PIN_BACKTICK_RE, "");
   out = out.replace(PIN_LEADING_RE, "");
   return out.trim();

--- a/frontend/src/lib/notepad.ts
+++ b/frontend/src/lib/notepad.ts
@@ -109,6 +109,45 @@ export async function pinToNotepad(
   );
 }
 
+/**
+ * Mirror of ``backend/app/sessions/notepad.py::sanitize_pin_text``. The
+ * server runs this on every ``/notepad/pin`` POST as defence in depth,
+ * but the editor inserts the snippet locally (via the
+ * ``crittable:notepad-pin`` window event) and then pushes its full
+ * markdown snapshot back to the server — so without client-side
+ * sanitisation, an unsanitised string round-trips into
+ * ``session.notepad.markdown_snapshot`` and feeds the AAR.
+ *
+ * Strips, in order:
+ *   1. Fenced code blocks (``\`\`\`...\`\`\``)
+ *   2. Markdown links / images, until fixed-point
+ *   3. HTML tags
+ *   4. Backticks
+ *   5. Leading whitespace / blockquote / heading / list markers per line
+ *
+ * Keep in sync with the server regexes — there are tests on each side
+ * that exercise the regex set; if you add a marker class to one,
+ * update both.
+ */
+const PIN_LINK_RE = /!?\[([^\]]*)\]\(([^)]*)\)/g;
+const PIN_HTML_RE = /<[^>]+>/g;
+const PIN_FENCE_RE = /```[^`]*```/gs;
+const PIN_BACKTICK_RE = /`+/g;
+const PIN_LEADING_RE = /^[\s>#\-*+]+/gm;
+
+export function sanitizePinText(raw: string): string {
+  let out = raw.replace(PIN_FENCE_RE, "");
+  for (let i = 0; i < 8; i++) {
+    const next = out.replace(PIN_LINK_RE, "$1");
+    if (next === out) break;
+    out = next;
+  }
+  out = out.replace(PIN_HTML_RE, "");
+  out = out.replace(PIN_BACKTICK_RE, "");
+  out = out.replace(PIN_LEADING_RE, "");
+  return out.trim();
+}
+
 export function exportMarkdownUrl(sessionId: string, token: string): string {
   return `/api/sessions/${sessionId}/notepad/export.md?token=${encodeURIComponent(token)}`;
 }

--- a/frontend/src/lib/notepadEditor.ts
+++ b/frontend/src/lib/notepadEditor.ts
@@ -1,0 +1,86 @@
+/**
+ * Editor-side helpers for the shared notepad — extracted from
+ * ``SharedNotepad.tsx`` so the component file only exports React
+ * components (eslint-plugin-react-refresh requirement) and the helpers
+ * are unit-testable without mounting the full editor.
+ */
+import type { Editor } from "@tiptap/core";
+
+/**
+ * "T+MM:SS" relative to ``sessionStartedAt``. Used by both the hotkey-
+ * insert path and the highlight-pin path so the two timestamp formats
+ * stay identical.
+ */
+export function relativeStamp(sessionStartedAt: string): string {
+  const start = new Date(sessionStartedAt).getTime();
+  const elapsedMs = Date.now() - start;
+  const minutes = Math.max(0, Math.floor(elapsedMs / 60000));
+  const seconds = Math.max(0, Math.floor((elapsedMs % 60000) / 1000));
+  return `T+${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+/**
+ * If the doc has a top-level ``## Timeline`` heading, return the
+ * position right before the next h2 (the end of the Timeline section)
+ * — or ``doc.content.size`` if Timeline is the last section. If there
+ * is no Timeline heading, also return ``doc.content.size``.
+ *
+ * Walks only top-level children — pinning into a heading nested inside
+ * a list item or blockquote is not a real case for our templates.
+ */
+export function findPinInsertPos(editor: Editor): number {
+  const doc = editor.state.doc;
+  let timelineFound = false;
+  let nextSectionPos: number | null = null;
+  doc.descendants((node, pos, parent) => {
+    if (parent !== doc) return false;
+    if (node.type.name === "heading" && node.attrs?.level === 2) {
+      const text = node.textContent.trim().toLowerCase();
+      if (text === "timeline" && !timelineFound) {
+        timelineFound = true;
+      } else if (timelineFound && nextSectionPos === null) {
+        nextSectionPos = pos;
+        return false;
+      }
+    }
+    return false;
+  });
+  if (!timelineFound) return doc.content.size;
+  return nextSectionPos ?? doc.content.size;
+}
+
+/**
+ * Append a pinned snippet at the Timeline-section boundary. Only the
+ * originating client should call this — Yjs collab propagates to peers
+ * automatically.
+ *
+ * Multi-line snippets emit one paragraph per line: ProseMirror text
+ * nodes silently swallow ``\n`` (rendered as a space), so a chat
+ * selection that spans paragraphs would otherwise become a single
+ * run-on line. The first line carries the ``T+MM:SS — `` stamp;
+ * continuation lines are indented (visually grouped, no second stamp).
+ * Empty lines are dropped.
+ */
+export function appendPinToEditor(
+  editor: Editor,
+  text: string,
+  sessionStartedAt: string,
+): void {
+  const stamp = relativeStamp(sessionStartedAt);
+  const lines = text
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (lines.length === 0) return;
+  const paragraphs = lines.map((line, idx) => ({
+    type: "paragraph",
+    content: [
+      {
+        type: "text",
+        text: idx === 0 ? `${stamp} — ${line}` : `    ${line}`,
+      },
+    ],
+  }));
+  const insertPos = findPinInsertPos(editor);
+  editor.chain().insertContentAt(insertPos, paragraphs).run();
+}

--- a/frontend/src/lib/notepadEditor.ts
+++ b/frontend/src/lib/notepadEditor.ts
@@ -58,8 +58,11 @@ export function findPinInsertPos(editor: Editor): number {
  * nodes silently swallow ``\n`` (rendered as a space), so a chat
  * selection that spans paragraphs would otherwise become a single
  * run-on line. The first line carries the ``T+MM:SS — `` stamp;
- * continuation lines are indented (visually grouped, no second stamp).
- * Empty lines are dropped.
+ * continuation lines get a ``↳ `` lead-in marker. We deliberately
+ * avoid a 4-space indent: when ``editorToMarkdown`` serialises the
+ * snapshot back out, CommonMark-style renderers parse paragraphs that
+ * start with 4+ spaces as indented code blocks, which would change
+ * how pins appear in the AAR pipeline. Per Copilot review on PR #125.
  */
 export function appendPinToEditor(
   editor: Editor,
@@ -77,7 +80,7 @@ export function appendPinToEditor(
     content: [
       {
         type: "text",
-        text: idx === 0 ? `${stamp} — ${line}` : `    ${line}`,
+        text: idx === 0 ? `${stamp} — ${line}` : `↳ ${line}`,
       },
     ],
   }));

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -92,10 +92,10 @@ export type ServerEvent =
   // base64-encoded inside JSON envelopes so they ride the existing
   // /ws/sessions/{id} channel without a separate y-websocket server.
   // Server-side recording policy:
-  //   - notepad_update / notepad_pin_appended / notepad_awareness /
-  //     notepad_lock_pending: record=False — high-volume, not
-  //     idempotent against the 256-event replay buffer; reconnecting
-  //     clients explicitly send notepad_sync_request for current state.
+  //   - notepad_update / notepad_awareness / notepad_lock_pending:
+  //     record=False — high-volume, not idempotent against the 256-
+  //     event replay buffer; reconnecting clients explicitly send
+  //     notepad_sync_request for current state.
   //   - notepad_locked: record=True — terminal state; a late joiner
   //     who reconnects after End must learn the notepad is locked
   //     (otherwise their editor would be writable but every edit
@@ -110,12 +110,6 @@ export type ServerEvent =
       type: "notepad_update";
       update: string;
       origin_role_id: string;
-    }
-  | {
-      type: "notepad_pin_appended";
-      text: string;
-      source_message_id: string | null;
-      by_role_id: string;
     }
   | {
       // Live cursor presence (y-protocols Awareness update). record=False
@@ -306,10 +300,6 @@ export class WsClient {
           case "notepad_update":
             safe.update_chars = parsed.update?.length ?? 0;
             safe.origin_role_id = parsed.origin_role_id;
-            break;
-          case "notepad_pin_appended":
-            safe.text_chars = parsed.text?.length ?? 0;
-            safe.by_role_id = parsed.by_role_id;
             break;
           case "notepad_lock_pending":
             safe.locks_in_seconds = parsed.locks_in_seconds;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -22,6 +22,7 @@ import { SetupChat } from "../components/SetupChat";
 import { Transcript } from "../components/Transcript";
 import { BottomActionBar } from "../components/brand/BottomActionBar";
 import { DieLoader } from "../components/brand/DieLoader";
+import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
 import { TurnStateRail } from "../components/brand/TurnStateRail";
 import { SetupWizard } from "../components/setup/SetupWizard";
@@ -1017,7 +1018,7 @@ export function Facilitator() {
           return Array.from(seen).sort();
         })()}
       />
-      <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-3 p-3 lg:min-h-0 lg:grid-cols-[260px_1fr_280px] lg:overflow-hidden">
+      <div className="grid w-full flex-1 grid-cols-1 gap-3 p-3 lg:min-h-0 lg:grid-cols-[260px_minmax(0,1fr)_320px] lg:overflow-hidden xl:grid-cols-[280px_minmax(0,1fr)_400px] 2xl:grid-cols-[300px_minmax(0,1fr)_minmax(440px,28%)]">
         <aside className="flex flex-col gap-3 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
           <RolesPanel
             sessionId={state.sessionId}
@@ -1318,9 +1319,15 @@ export function Facilitator() {
         </section>
 
         <aside className="flex flex-col gap-3 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
-          <div className="rounded-r-3 border border-ink-600 bg-ink-850">
+          <CollapsibleRailPanel
+            title="HUD"
+            subtitle="placeholder"
+            subtitleTone="warn"
+            persistKey="crittable.rail.hud.collapsed"
+            defaultCollapsed
+          >
             <HudGauges />
-          </div>
+          </CollapsibleRailPanel>
           <RightSidebar
             messages={snapshot.messages}
             roles={snapshot.roles}

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -8,6 +8,7 @@ import { RoleRoster } from "../components/RoleRoster";
 import { SharedNotepad } from "../components/SharedNotepad";
 import { Transcript } from "../components/Transcript";
 import { DieLoader } from "../components/brand/DieLoader";
+import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
 import { confirmLeaveSession } from "../lib/leaveGuard";
 import { isMidSessionJoiner } from "../lib/proxy";
@@ -923,7 +924,7 @@ export function Play({ sessionId, token }: Props) {
           tight, the current beat is finishing up.
         </div>
       ) : null}
-      <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-3 p-3 lg:min-h-0 lg:grid-cols-[220px_1fr_280px] lg:overflow-hidden">
+      <div className="grid w-full flex-1 grid-cols-1 gap-3 p-3 lg:min-h-0 lg:grid-cols-[220px_minmax(0,1fr)_320px] lg:overflow-hidden xl:grid-cols-[240px_minmax(0,1fr)_400px] 2xl:grid-cols-[260px_minmax(0,1fr)_minmax(440px,28%)]">
         <aside className="flex flex-col gap-3 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
           <RoleRoster
             roles={snapshot.roles}
@@ -1068,9 +1069,15 @@ export function Play({ sessionId, token }: Props) {
           </div>
         </section>
         <aside className="flex flex-col gap-3 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
-          <div className="rounded-r-3 border border-ink-600 bg-ink-850">
+          <CollapsibleRailPanel
+            title="HUD"
+            subtitle="placeholder"
+            subtitleTone="warn"
+            persistKey="crittable.rail.hud.collapsed"
+            defaultCollapsed
+          >
             <HudGauges />
-          </div>
+          </CollapsibleRailPanel>
           <RightSidebar
             messages={snapshot.messages}
             roles={snapshot.roles}


### PR DESCRIPTION
## Summary

Four user-facing bugs reported manually after #115 / #117 shipped:

1. **Notepad remote cursor rendered as a giant block** — y-tiptap ships no widths/positioning for `.collaboration-carets__caret` / `__label`, so the inline `<div>` label filled the line. Fixed via scoped CSS in `index.css`: thin vertical caret + a small floated chip 1.5em above.
2. **`# Foo` typed in the notepad didn't render as a heading** — Tailwind preflight zeroes `h1..h6 { font-size: inherit; font-weight: inherit }`, and `@tailwindcss/typography` isn't installed (the `prose` class on the editor was a no-op). Added hand-rolled `[data-notepad-editor] *` rules for h1..h6, lists, code, blockquote, hr, links, task items.
3. **Chat-transcript drag-select stopped after a few characters** — the popover opened mid-drag and the auto-focus + scroll cycle called `removeAllRanges()`, which terminated the user's drag. Two fixes: (a) `mousedown` / `mouseup` gate so the popover never opens mid-drag (mouse-up triggers a final selection re-evaluation; keyboard selection still works), and (b) the scroll handler no longer clears the selection — only hides the now-stale popover. `focus({ preventScroll: true })` defends against future regressions.
4. **"Add to notes" appeared to do nothing** — the server's `notepad_pin_appended` broadcast had no client handler. Replaced with a per-tab `crittable:notepad-pin` window CustomEvent dispatched after a successful POST; SharedNotepad listens and inserts at the end of the `## Timeline` section (fallback: end of doc). Yjs collab fans the resulting transaction to peers — no separate broadcast needed, so the server-side broadcast was deleted (per CLAUDE.md no-back-compat policy). Toast is now `Pinned to notepad.` (configurable per action via `successToast`).

Per-tab dispatch prevents double-insert when one user has two tabs of the same role open. Panic-click de-dup happens in SharedNotepad via `insertedPinIdsRef` keyed on `source_message_id`.

### Defence-in-depth follow-ups from sub-agent review

- **Client-side `sanitizePinText`** in `lib/notepad.ts` mirrors the server regex set so an unsanitised pin can't round-trip through `pushSnapshot` and feed the AAR. (Security M1.)
- **Multi-line pins** emit one paragraph per non-empty line — ProseMirror text nodes silently swallow `\n`. (UI/UX H1.)
- **`draggingRef` reset** on `pointercancel` / `visibilitychange` / `blur` so a swallowed mouseup (alt-tab, context menu, touch reroute) doesn't leave the popover suppressed forever. (UI/UX H3.)

## Test plan

- [x] `cd frontend && npm test -- --run` — 153 passing (+13 new). Covers `findPinInsertPos`, `appendPinToEditor` round-trip, drag-suppression, scroll-no-clear regression, sanitisation, and pin-event dispatch.
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd backend && pytest -q --ignore=tests/live` — 347 passing.
- [ ] **Manual smoke (visual fixes only):** open two tabs, second tab's cursor renders as a thin vertical line + small floated label (no giant block obscuring text).
- [ ] **Manual smoke:** type `# Foo` in the notepad — renders as a heading, distinct from a paragraph.
- [ ] **Manual smoke:** drag-select 200+ chars across multiple chat bubbles — selection stays alive end-to-end; popover appears at release.
- [ ] **Manual smoke:** click "Add to notes" once — text appears in the notepad's Timeline section with `T+MM:SS — ` prefix; toast says "Pinned to notepad."; click three more times rapidly — only one paragraph inserted (idempotency holds).

## Files

| File | Change |
|---|---|
| `backend/app/api/routes.py` | Delete dead `notepad_pin_appended` broadcast (no client subscribers). |
| `frontend/src/index.css` | New `[data-notepad-editor] *` and `.collaboration-carets__*` rules. |
| `frontend/src/components/HighlightActionPopover.tsx` | Drag-suppression, scroll-no-clear, `preventScroll: true`, defensive `draggingRef` reset, configurable success-toast. |
| `frontend/src/components/SharedNotepad.tsx` | `crittable:notepad-pin` listener, `insertedPinIdsRef` panic-click de-dup. |
| `frontend/src/lib/highlightActions.ts` | Action dispatches CustomEvent post-POST; sanitises text; `successToast` field. |
| `frontend/src/lib/notepad.ts` | `sanitizePinText` mirror of server regexes. |
| `frontend/src/lib/notepadEditor.ts` | New: `relativeStamp` / `findPinInsertPos` / `appendPinToEditor` (extracted for unit testability + react-refresh compliance). |
| `frontend/src/lib/ws.ts` | Drop `notepad_pin_appended` from `ServerEvent` union. |
| `frontend/src/__tests__/sharedNotepadInsert.test.ts` | New: 8 tests for the editor helpers. |
| `frontend/src/__tests__/HighlightActionPopover.test.tsx` | + drag-suppression test, + scroll-no-clear regression test, `act()` wrapping. |
| `frontend/src/__tests__/highlightActions.test.ts` | + dispatch-on-success / no-dispatch-on-reject / sanitisation tests. |

https://claude.ai/code/session_01NJXMuX9y8hxuAjzGS5fUZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJXMuX9y8hxuAjzGS5fUZE)_