### PR TITLE
ui(notepad): chevron parity with HUD/TIMELINE; drop hamburger

### DIFF
--- a/frontend/src/components/SharedNotepad.tsx
+++ b/frontend/src/components/SharedNotepad.tsx
@@ -539,7 +539,7 @@ export function SharedNotepad({
               another status chip alongside the SHARED chip. */}
           <a
             href={exportMarkdownUrl(sessionId, token)}
-            target="_blank"
+            download
             rel="noopener noreferrer"
             className="mono whitespace-nowrap rounded-r-1 border border-signal-deep bg-signal-tint px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-signal hover:border-signal hover:bg-signal/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal"
           >

--- a/frontend/src/components/SharedNotepad.tsx
+++ b/frontend/src/components/SharedNotepad.tsx
@@ -22,7 +22,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Awareness, applyAwarenessUpdate, encodeAwarenessUpdate } from "y-protocols/awareness";
 import * as Y from "yjs";
 
-import { RailHeader } from "./brand/RailHeader";
+import { CollapsibleRailPanel } from "./brand/CollapsibleRailPanel";
 import { StatusChip } from "./brand/StatusChip";
 import {
   NOTEPAD_PIN_EVENT,
@@ -53,7 +53,6 @@ interface Props {
    */
   ws: WsClient;
   isCreator: boolean;
-  initiallyExpanded?: boolean;
   /** Session start time (ISO) — used to render T+MM:SS timestamps. */
   sessionStartedAt: string;
   /** Caller's role id — used for ``CollaborationCaret`` user identity. */
@@ -259,8 +258,6 @@ function timestampHotkeyExtension(sessionStartedAt: string): Extension {
   } as unknown as Extension;
 }
 
-const COACHMARK_KEY = "crittable.notepad.coachmark_seen";
-
 // Bound for the per-instance "already-inserted" pin id ring buffer.
 // Long sessions can produce hundreds of pins; keeping every id in
 // memory forever is a slow leak. 256 is well past any realistic
@@ -273,7 +270,6 @@ export function SharedNotepad({
   token,
   ws,
   isCreator,
-  initiallyExpanded,
   sessionStartedAt,
   selfRoleId,
   selfDisplayName,
@@ -283,14 +279,6 @@ export function SharedNotepad({
   const awareness = useMemo(() => new Awareness(ydoc), [ydoc]);
   const myColor = useMemo(() => roleColor(selfRoleId), [selfRoleId]);
 
-  const [expanded, setExpanded] = useState(() => {
-    if (initiallyExpanded !== undefined) return initiallyExpanded;
-    try {
-      return !window.localStorage.getItem(COACHMARK_KEY);
-    } catch {
-      return false;
-    }
-  });
   const [locked, setLocked] = useState(false);
   const [lockPendingSecs, setLockPendingSecs] = useState<number | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -513,51 +501,29 @@ export function SharedNotepad({
     applyTemplate(sessionId, token, t.id).catch((err) =>
       console.warn("[notepad] template POST failed", err),
     );
-    try {
-      window.localStorage.setItem(COACHMARK_KEY, "1");
-    } catch {
-      /* localStorage unavailable; fine */
-    }
   }
 
   function handleStartBlank(): void {
-    try {
-      window.localStorage.setItem(COACHMARK_KEY, "1");
-    } catch {
-      /* fine */
-    }
     editor?.chain().focus().run();
   }
 
-  if (!expanded) {
-    return (
-      <section
-        aria-label="Team notepad (collapsed)"
-        className="rounded-r-3 border border-ink-600 bg-ink-850"
-      >
-        <button
-          type="button"
-          className="flex w-full items-center justify-between px-3 py-2 text-left"
-          onClick={() => setExpanded(true)}
-          title="Shared notes — team timeline, action items, decisions."
-        >
-          <RailHeader title="TEAM NOTEPAD" inline />
-          <span className="mono text-[10px] uppercase tracking-[0.18em] text-ink-400">
-            EXPAND
-          </span>
-        </button>
-      </section>
-    );
-  }
-
   return (
-    <section
-      aria-label="Team notepad"
-      className="flex min-h-0 flex-col gap-2 rounded-r-3 border border-ink-600 bg-ink-850 p-3 text-sm"
+    <CollapsibleRailPanel
+      title="TEAM NOTEPAD"
+      persistKey="crittable.rail.notepad.collapsed"
     >
-      <header className="flex flex-wrap items-center justify-between gap-2">
-        <RailHeader title="TEAM NOTEPAD" inline />
-        <div className="flex items-center gap-2">
+      <div
+        aria-labelledby="notepad-heading"
+        className="flex min-h-0 flex-col gap-2 p-3 text-sm"
+      >
+        {/* Visually-hidden heading — the parent ``CollapsibleRailPanel``
+            renders the visible "TEAM NOTEPAD" chrome, but screen readers
+            still benefit from the section being labelled inside the
+            accordion body (matches Timeline's pattern). */}
+        <h3 id="notepad-heading" className="sr-only">
+          Team notepad
+        </h3>
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <StatusChip
             tone="warn"
             label="SHARED"
@@ -568,121 +534,104 @@ export function SharedNotepad({
                 : "Hidden from the AI during play; the AI reads it only at the end of the session, when generating the final report. Plan and debrief freely."
             }
           />
-          {/* Right-rail is 280px; the bare EXPORT + COLLAPSE labels
-              clipped off the edge alongside the chip. Collapsed into
-              a small ⋯ menu so the header always fits the rail. */}
-          <details className="relative">
-            <summary
-              aria-label="Notepad actions"
-              className="mono cursor-pointer list-none rounded-r-1 border border-ink-600 bg-ink-850 px-2 py-0.5 text-[12px] leading-none text-ink-200 hover:border-signal-deep marker:hidden [&::-webkit-details-marker]:hidden"
-            >
-              ⋯
-            </summary>
-            <div className="absolute right-0 z-10 mt-1 flex flex-col gap-0 rounded-r-1 border border-ink-500 bg-ink-900 p-1 shadow-md">
-              <a
-                href={exportMarkdownUrl(sessionId, token)}
-                target="_blank"
-                rel="noreferrer"
-                className="mono whitespace-nowrap rounded-r-1 px-2 py-1 text-[10px] uppercase tracking-[0.18em] text-ink-200 hover:bg-ink-800 hover:text-ink-100"
-              >
-                Export .md
-              </a>
-              <button
-                type="button"
-                onClick={() => setExpanded(false)}
-                className="mono whitespace-nowrap rounded-r-1 px-2 py-1 text-left text-[10px] uppercase tracking-[0.18em] text-ink-200 hover:bg-ink-800 hover:text-ink-100"
-              >
-                Collapse
-              </button>
-            </div>
-          </details>
-        </div>
-      </header>
-
-      {lockPendingSecs !== null && !locked ? (
-        <div
-          role="status"
-          aria-live="polite"
-          className="rounded-r-1 border border-warn bg-warn-bg px-2 py-1 text-[12px] text-warn"
-        >
-          Session ending — notepad locks in {lockPendingSecs}s. Notes will
-          export regardless.
-        </div>
-      ) : null}
-
-      {locked ? (
-        <div className="rounded-r-1 border border-ink-500 bg-ink-900 px-2 py-1 text-[12px] text-ink-200">
-          NOTEPAD LOCKED — session ended. Export still available via the
-          link above.
-        </div>
-      ) : null}
-
-      {errorMsg ? (
-        <div
-          className="rounded-r-1 border border-warn bg-warn-bg px-2 py-1 text-[12px] text-warn"
-          role="alert"
-        >
-          {errorMsg.toLowerCase().includes("too large")
-            ? "That edit was too large to sync — break it into smaller paste chunks."
-            : errorMsg}
-        </div>
-      ) : null}
-
-      {/* Coachmark: visible to ALL roles, even non-creators. Empty
-          notepad on first visit needs the highlight-to-pin tip; non-
-          creators don't get the picker, but they do get this hint. */}
-      {isEmpty ? (
-        <div className="text-[11px] text-ink-400">
-          Tip: highlight any chat message to pin it here.
-          <span className="mono ml-2 text-ink-500">
-            (Ctrl/⌘+Shift+T inserts a T+MM:SS timestamp.)
-          </span>
-        </div>
-      ) : null}
-
-      {isEmpty && isCreator ? (
-        <div className="space-y-2 rounded-r-1 border border-ink-600 bg-ink-900 p-2">
-          <div className="mono text-[10px] uppercase tracking-[0.18em] text-ink-300">
-            START WITH A TEMPLATE
-          </div>
-          {templates?.length ? (
-            <div className="grid gap-2">
-              {templates.map((t) => (
-                <button
-                  key={t.id}
-                  type="button"
-                  onClick={() => handleApplyTemplate(t)}
-                  className="rounded-r-1 border border-ink-600 bg-ink-850 p-2 text-left hover:border-signal-deep"
-                >
-                  <div className="mono text-[11px] font-bold uppercase tracking-[0.12em] text-ink-100">
-                    {t.label}
-                  </div>
-                  <div className="mt-1 text-[12px] text-ink-300">
-                    {t.description}
-                  </div>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="text-[11px] text-ink-400">Loading templates…</div>
-          )}
-          <button
-            type="button"
-            onClick={handleStartBlank}
-            className="mono w-full text-left text-[10px] uppercase tracking-[0.18em] text-ink-400 hover:text-ink-200"
+          {/* Signal-tinted button styling (same pattern as AAR's MARKDOWN /
+              JSON exports) so the affordance reads as "click me", not as
+              another status chip alongside the SHARED chip. */}
+          <a
+            href={exportMarkdownUrl(sessionId, token)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mono whitespace-nowrap rounded-r-1 border border-signal-deep bg-signal-tint px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-signal hover:border-signal hover:bg-signal/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal"
           >
-            OR START TYPING
-          </button>
+            Export .md
+          </a>
         </div>
-      ) : null}
 
-      <div
-        className="min-h-[12rem] max-h-[60vh] overflow-y-auto rounded-r-1 border border-ink-600 bg-ink-900 p-2"
-        onClick={() => editor?.chain().focus().run()}
-      >
-        <EditorContent editor={editor} />
+        {lockPendingSecs !== null && !locked ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="rounded-r-1 border border-warn bg-warn-bg px-2 py-1 text-[12px] text-warn"
+          >
+            Session ending — notepad locks in {lockPendingSecs}s. Notes will
+            export regardless.
+          </div>
+        ) : null}
+
+        {locked ? (
+          <div className="rounded-r-1 border border-ink-500 bg-ink-900 px-2 py-1 text-[12px] text-ink-200">
+            NOTEPAD LOCKED — session ended. Export still available via the
+            link above.
+          </div>
+        ) : null}
+
+        {errorMsg ? (
+          <div
+            className="rounded-r-1 border border-warn bg-warn-bg px-2 py-1 text-[12px] text-warn"
+            role="alert"
+          >
+            {errorMsg.toLowerCase().includes("too large")
+              ? "That edit was too large to sync — break it into smaller paste chunks."
+              : errorMsg}
+          </div>
+        ) : null}
+
+        {/* Coachmark: visible to ALL roles, even non-creators. Empty
+            notepad on first visit needs the highlight-to-pin tip; non-
+            creators don't get the picker, but they do get this hint. */}
+        {isEmpty ? (
+          <div className="text-[11px] text-ink-400">
+            Tip: highlight any chat message to pin it here.
+            <span className="mono ml-2 text-ink-500">
+              (Ctrl/⌘+Shift+T inserts a T+MM:SS timestamp.)
+            </span>
+          </div>
+        ) : null}
+
+        {isEmpty && isCreator ? (
+          <div className="space-y-2 rounded-r-1 border border-ink-600 bg-ink-900 p-2">
+            <div className="mono text-[10px] uppercase tracking-[0.18em] text-ink-300">
+              START WITH A TEMPLATE
+            </div>
+            {templates?.length ? (
+              <div className="grid gap-2">
+                {templates.map((t) => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => handleApplyTemplate(t)}
+                    className="rounded-r-1 border border-ink-600 bg-ink-850 p-2 text-left hover:border-signal-deep"
+                  >
+                    <div className="mono text-[11px] font-bold uppercase tracking-[0.12em] text-ink-100">
+                      {t.label}
+                    </div>
+                    <div className="mt-1 text-[12px] text-ink-300">
+                      {t.description}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="text-[11px] text-ink-400">Loading templates…</div>
+            )}
+            <button
+              type="button"
+              onClick={handleStartBlank}
+              className="mono w-full text-left text-[10px] uppercase tracking-[0.18em] text-ink-400 hover:text-ink-200"
+            >
+              OR START TYPING
+            </button>
+          </div>
+        ) : null}
+
+        <div
+          className="min-h-[12rem] max-h-[60vh] overflow-y-auto rounded-r-1 border border-ink-600 bg-ink-900 p-2"
+          onClick={() => editor?.chain().focus().run()}
+        >
+          <EditorContent editor={editor} />
+        </div>
       </div>
-    </section>
+    </CollapsibleRailPanel>
   );
 }
 


### PR DESCRIPTION
## Summary

User screenshot showed inconsistent collapsible UI on the right rail: HUD and TIMELINE used the brand `▼`/`▶` chevron via `CollapsibleRailPanel`, but TEAM NOTEPAD had its own bespoke expand/collapse with an EXPAND text button when collapsed and a `⋯` hamburger containing Export .md + Collapse.

This wraps `SharedNotepad` in the same `CollapsibleRailPanel` everyone else uses. With "Collapse" removed from the hamburger, only "Export .md" remained — a single-item dropdown is a UX anti-pattern, so it's inlined as a direct anchor next to the SHARED chip and the `<details>` is gone entirely.

- Removed legacy `expanded` / `setExpanded` state, `initiallyExpanded` prop, and the `coachmark_seen` localStorage flag (per CLAUDE.md no-back-compat).
- Persistence key follows the existing namespace: `crittable.rail.notepad.collapsed`.
- Export .md anchor styled with the brand's signal-tinted export pattern (same as `AarReport.tsx`'s MARKDOWN / JSON anchors) so it reads as a button, not a chip.
- Added `aria-labelledby` + sr-only `<h3>` to match Timeline's body labelling.
- Standardised the `rel` attribute to `noopener noreferrer` for explicitness on a token-bearing URL.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (eslint --max-warnings 0)
- [x] `npm test -- --run` — 184 passing (no new tests; the wrapper's contract is already covered by `CollapsibleRailPanel.test.tsx`)
- [ ] Manual smoke at 1440w / 1024w / 360w: chevron toggles, persists across reload, mobile `<details>` still works
- [ ] Manual smoke: Export .md anchor reads as a clickable button, downloads .md file
- [ ] Screen reader: TEAM NOTEPAD section announces correctly

## Sub-agent review (per `CLAUDE.md`)

All six reviewers ran in parallel. Triage:

| Agent | Verdict | Notable findings |
|---|---|---|
| QA | Ship | All MEDIUM/LOW deferrable; no test coverage lost |
| Security | Ship | Pre-existing `rel` inconsistency; tightened to `noopener noreferrer` here |
| UI/UX | 1 HIGH (fixed) | Export .md looked like a chip → switched to signal-tinted button styling |
| Product | Ship | Single-file scope, no drift |
| User Agent | 1 HIGH (deferred) | "Collapsed panels are a black box — no change indicator" — equally applies to Timeline; proper fix is a feature on `CollapsibleRailPanel` itself |
| Prompt Expert | N/A | No prompts/tools touched |

### Deferred follow-ups (filed here so they don't get lost)

- "Content changed since last expand" indicator on `CollapsibleRailPanel` (badge / dot). Affects notepad and timeline.
- Notepad now defaults to expanded every session vs old "collapse on later visits"; product to confirm intent.
- Export .md visible from minute 0 — could gate on `!isEmpty`.

https://claude.ai/code/session_011dhvwMjnNniXdvASMmaJro

---
_Generated by [Claude Code](https://claude.ai/code/session_011dhvwMjnNniXdvASMmaJro)_