### PR TITLE
sessions: invalidate kicked user's live WebSocket (issue #127)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1004,7 +1004,10 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
             new_token = await manager.reissue_role_token(
-                session_id=session_id, role_id=role_id, revoke_previous=False
+                session_id=session_id,
+                role_id=role_id,
+                revoke_previous=False,
+                by_role_id=token["role_id"],
             )
         except AuthorizationError as exc:
             raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
@@ -1027,7 +1030,10 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
             new_token = await manager.reissue_role_token(
-                session_id=session_id, role_id=role_id, revoke_previous=True
+                session_id=session_id,
+                role_id=role_id,
+                revoke_previous=True,
+                by_role_id=token["role_id"],
             )
         except AuthorizationError as exc:
             raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -254,6 +254,7 @@ class SessionManager:
         session_id: str,
         role_id: str,
         revoke_previous: bool,
+        by_role_id: str | None = None,
     ) -> str:
         """Re-mint a role's join token.
 
@@ -290,7 +291,22 @@ class SessionManager:
             session,
             role_id=role_id,
             label=role.label,
+            # Issue #127 follow-up (Product review): operator-action
+            # audit lines must record WHO performed the action, not
+            # just the target. Defaults to None for non-API callers.
+            by=by_role_id,
         )
+        if revoke_previous:
+            # Bumping token_version only blocks *future* connect / API
+            # attempts. The kicked player's existing WebSocket stays
+            # open until we close it explicitly, so they could keep
+            # posting through their already-open tab (issue #127).
+            # Force-close every open socket for this role; the close
+            # is fire-and-forget — the per-connection recv pump runs
+            # its normal teardown when the close lands.
+            await self._connections.disconnect_role(
+                session_id, role_id, code=4401, reason="kicked"
+            )
         return token
 
     async def set_role_display_name(
@@ -381,6 +397,14 @@ class SessionManager:
         await self._connections.broadcast(
             session.id,
             {"type": "participant_left", "role_id": role_id},
+        )
+        # Same reasoning as the revoke path in ``reissue_role_token``:
+        # the removed player's already-open WS would otherwise let them
+        # keep submitting messages until the next reconnect (issue #127).
+        # ``_bind_token`` rejects the next REST poll because the role no
+        # longer exists, but the live socket has no equivalent gate.
+        await self._connections.disconnect_role(
+            session_id, role_id, code=4401, reason="removed"
         )
 
     # ------------------------------------------------------- setup-phase API
@@ -556,7 +580,12 @@ class SessionManager:
             return
 
     async def submit_response(
-        self, *, session_id: str, role_id: str, content: str
+        self,
+        *,
+        session_id: str,
+        role_id: str,
+        content: str,
+        expected_token_version: int | None = None,
     ) -> bool:
         """Record a player's submission. Returns True if the turn is now complete.
 
@@ -575,6 +604,29 @@ class SessionManager:
             session = await self._repo.get(session_id)
             if session.state != SessionState.AWAITING_PLAYERS:
                 raise IllegalTransitionError("session is not awaiting player input")
+            # Defense-in-depth for issue #127: even if the kicked /
+            # removed player's WebSocket close raced with an in-flight
+            # ``submit_response`` (the close is fire-and-forget; the
+            # submit was already on the wire), the role lookup here
+            # rejects it before it lands in the transcript. The
+            # ``expected_token_version`` covers the kick (revoke) path
+            # — the role is still in ``session.roles`` post-revoke, so
+            # the existence check alone would miss it; the version
+            # match closes the gap. Callers that don't carry a token
+            # version (scenario runner, test helpers) pass None and
+            # only get the existence check.
+            existing = session.role_by_id(role_id)
+            if existing is None:
+                raise IllegalTransitionError(
+                    f"role no longer exists in session: {role_id}"
+                )
+            if (
+                expected_token_version is not None
+                and existing.token_version != expected_token_version
+            ):
+                raise IllegalTransitionError(
+                    "token has been revoked; rejoin with the new join link"
+                )
             turn = session.current_turn
             if turn is None:
                 raise IllegalTransitionError("no current turn")

--- a/backend/app/sessions/submission_pipeline.py
+++ b/backend/app/sessions/submission_pipeline.py
@@ -81,6 +81,7 @@ async def prepare_and_submit_player_response(
     session_id: str,
     role_id: str,
     content: str,
+    expected_token_version: int | None = None,
 ) -> SubmissionOutcome:
     """Validate, truncate, classify, and submit one player response.
 
@@ -130,7 +131,10 @@ async def prepare_and_submit_player_response(
         )
 
     advanced = await manager.submit_response(
-        session_id=session_id, role_id=role_id, content=content
+        session_id=session_id,
+        role_id=role_id,
+        content=content,
+        expected_token_version=expected_token_version,
     )
     return SubmissionOutcome(
         content=content,

--- a/backend/app/ws/connection_manager.py
+++ b/backend/app/ws/connection_manager.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import AsyncIterator, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+from fastapi import WebSocket
 
 from ..logging_setup import get_logger
 
@@ -31,6 +33,11 @@ class _Connection:
     # at least one of its open connections has ``focused=True`` —
     # see ``role_has_focused_connection``.
     focused: bool = True
+    # Live socket reference used by ``disconnect_role`` to force-close
+    # a kicked / removed user's still-open tab. Optional so unit tests
+    # that exercise the connection manager directly (without a real
+    # WebSocket) keep working.
+    websocket: WebSocket | None = field(default=None, repr=False)
 
 
 class ConnectionManager:
@@ -52,12 +59,14 @@ class ConnectionManager:
         session_id: str,
         role_id: str,
         is_creator: bool,
+        websocket: WebSocket | None = None,
     ) -> _Connection:
         conn = _Connection(
             session_id=session_id,
             role_id=role_id,
             is_creator=is_creator,
             queue=asyncio.Queue(maxsize=self._MAX_QUEUE),
+            websocket=websocket,
         )
         async with self._lock:
             self._connections[session_id].append(conn)
@@ -104,6 +113,79 @@ class ConnectionManager:
             ]
         for conn in recipients:
             await self._enqueue(conn, event)
+
+    async def disconnect_role(
+        self,
+        session_id: str,
+        role_id: str,
+        *,
+        code: int = 4401,
+        reason: str = "kicked",
+    ) -> int:
+        """Force-close every open WebSocket held by ``(session_id, role_id)``.
+
+        Called by ``SessionManager`` when a creator kicks a player or
+        removes a role: bumping ``role.token_version`` only blocks
+        *future* connect / API attempts, but the player's existing tab
+        keeps its socket and can keep submitting until the close lands.
+        Without this primitive a kicked player can keep posting through
+        their already-open tab — see issue #127.
+
+        Returns the number of sockets we issued ``close()`` against.
+        Matching ``_Connection`` records are *not* unregistered here —
+        the per-connection recv loop will see ``WebSocketDisconnect``
+        and run its normal teardown (``unregister`` + presence
+        broadcast). Calling close twice is a no-op for the underlying
+        socket; doing the unregister here would race that pump.
+        """
+
+        async with self._lock:
+            targets = [
+                c
+                for c in self._connections.get(session_id, ())
+                if c.role_id == role_id
+            ]
+        if not targets:
+            return 0
+        closed = 0
+        for conn in targets:
+            ws = conn.websocket
+            if ws is None:
+                # Test fixture connection (no live socket attached). Best
+                # effort: drop it from the registry so subsequent broadcasts
+                # don't fan out to a "ghost" subscriber.
+                async with self._lock:
+                    try:
+                        self._connections[conn.session_id].remove(conn)
+                    except ValueError:
+                        pass
+                closed += 1
+                continue
+            try:
+                await ws.close(code=code, reason=reason)
+                closed += 1
+            except Exception as exc:  # pragma: no cover - best-effort close
+                # Log but keep going — every other tab on this role
+                # still needs to be closed. A failed close on one tab
+                # (already-closed socket, transport error) must not
+                # leave a peer tab alive.
+                _logger.warning(
+                    "ws_force_close_failed",
+                    session_id=session_id,
+                    role_id=role_id,
+                    code=code,
+                    reason=reason,
+                    error=str(exc),
+                )
+        _logger.info(
+            "ws_role_disconnected",
+            session_id=session_id,
+            role_id=role_id,
+            code=code,
+            reason=reason,
+            closed_count=closed,
+        )
+        return closed
 
     async def shutdown(self) -> None:
         async with self._lock:

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -167,6 +167,7 @@ def register_ws_routes(app: FastAPI) -> None:
             session_id=session_id,
             role_id=payload["role_id"],
             is_creator=is_creator,
+            websocket=websocket,
         )
         _logger.info(
             "ws_connected",
@@ -217,6 +218,7 @@ def register_ws_routes(app: FastAPI) -> None:
                 session_id=session_id,
                 role_id=payload["role_id"],
                 kind=payload["kind"],
+                token_version=int(payload.get("v", 0)),
                 conn=conn,
                 connections=connections,
             )
@@ -489,6 +491,7 @@ async def _client_pump(
     session_id: str,
     role_id: str,
     kind: ParticipantKindLiteral,
+    token_version: int,
     conn: _Connection,
     connections: ConnectionManager,
 ) -> None:
@@ -507,6 +510,64 @@ async def _client_pump(
         "kind": kind,
         "v": 0,
     }
+
+    async def _role_still_authorized() -> bool:
+        """Issue #127: re-check the role's existence + token_version
+        before processing each mutating event.
+
+        The WS upgrade gate (``session_socket`` above) only fires
+        once. After that the recv pump can in principle process events
+        for milliseconds-to-seconds while the creator is in the
+        middle of revoking / removing this role. The
+        ``ConnectionManager.disconnect_role`` call from
+        ``SessionManager`` will close this socket asynchronously, but
+        a frame already in the local recv buffer can still race ahead.
+        Without this gate, a kicked player can squeeze in a
+        ``submit_response`` / ``request_force_advance`` /
+        ``notepad_update`` / ``notepad_awareness`` between the
+        token-version bump and the close landing.
+
+        On detection: send a typed error frame, then close the
+        socket so the recv loop exits immediately rather than
+        looping on subsequent buffered frames. The error frame is
+        intentionally vague — we don't tell a kicked attacker
+        whether the role was removed vs revoked.
+        """
+
+        try:
+            session = await manager.get_session(session_id)
+        except SessionNotFoundError:
+            try:
+                await websocket.close(code=CLOSE_NOT_FOUND)
+            except Exception:
+                pass
+            return False
+        role = session.role_by_id(role_id)
+        if role is None or role.token_version != token_version:
+            _logger.warning(
+                "ws_role_authorization_revoked",
+                session_id=session_id,
+                role_id=role_id,
+                upgrade_version=token_version,
+                current_version=(role.token_version if role else None),
+                role_present=role is not None,
+            )
+            try:
+                await websocket.send_json(
+                    {
+                        "type": "error",
+                        "scope": "auth",
+                        "message": "your seat was removed by the facilitator",
+                    }
+                )
+            except Exception:
+                pass
+            try:
+                await websocket.close(code=CLOSE_BAD_TOKEN)
+            except Exception:
+                pass
+            return False
+        return True
     try:
         while True:
             try:
@@ -614,6 +675,17 @@ async def _client_pump(
                         }
                     )
                     continue
+                # Issue #127: every mutating event re-checks that the
+                # role still exists with the version this socket was
+                # upgraded with. ``disconnect_role`` is fire-and-forget
+                # (the close lands milliseconds later); without this
+                # gate a kicked player can squeeze a final
+                # ``submit_response`` / ``force_advance`` / notepad
+                # write through the race window. ``_role_still_authorized``
+                # closes the socket on failure so subsequent buffered
+                # frames are not processed.
+                if not await _role_still_authorized():
+                    return
             if event_type == "submit_response":
                 # Validation / truncation / guardrail / submit live in
                 # ``submission_pipeline`` so the dev-tools scenario
@@ -637,6 +709,7 @@ async def _client_pump(
                         session_id=session_id,
                         role_id=role_id,
                         content=content,
+                        expected_token_version=token_version,
                     )
                 except EmptySubmissionError:
                     await websocket.send_json(

--- a/backend/tests/test_connection_manager_disconnect.py
+++ b/backend/tests/test_connection_manager_disconnect.py
@@ -1,0 +1,142 @@
+"""``ConnectionManager.disconnect_role`` — force-close primitive used
+by ``SessionManager`` when a creator kicks (revokes) or removes a
+role. Token-version bump alone leaves the kicked tab with a live
+WebSocket; ``disconnect_role`` is what severs the channel (issue
+#127).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ws.connection_manager import ConnectionManager
+
+
+class _FakeWebSocket:
+    """Minimal stand-in for a Starlette ``WebSocket``.
+
+    Records ``close()`` calls so the test can assert on the code /
+    reason that landed. Nothing else from the real WS surface is
+    exercised here — the recv / send pumps that read the queue live
+    in the live WS routes test.
+    """
+
+    def __init__(self) -> None:
+        self.closed_with: list[tuple[int, str]] = []
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed_with.append((code, reason))
+
+
+@pytest.mark.asyncio
+async def test_disconnect_role_closes_every_open_socket_for_role() -> None:
+    cm = ConnectionManager()
+    ws_a = _FakeWebSocket()
+    ws_b = _FakeWebSocket()
+    other_ws = _FakeWebSocket()
+
+    # Two tabs for the same role + an unrelated role on the same session.
+    await cm.register(
+        session_id="s1", role_id="kicked", is_creator=False, websocket=ws_a  # type: ignore[arg-type]
+    )
+    await cm.register(
+        session_id="s1", role_id="kicked", is_creator=False, websocket=ws_b  # type: ignore[arg-type]
+    )
+    other = await cm.register(
+        session_id="s1",
+        role_id="bystander",
+        is_creator=False,
+        websocket=other_ws,  # type: ignore[arg-type]
+    )
+
+    closed = await cm.disconnect_role("s1", "kicked", code=4401, reason="kicked")
+
+    assert closed == 2
+    assert ws_a.closed_with == [(4401, "kicked")]
+    assert ws_b.closed_with == [(4401, "kicked")]
+    # The bystander's socket must be untouched — disconnect_role is
+    # surgical, not a session-wide reset.
+    assert other_ws.closed_with == []
+
+    # Per-connection recv pumps would normally call ``unregister`` on
+    # the WebSocketDisconnect they observe; ``disconnect_role`` does
+    # NOT remove the connection itself when there's a live socket so
+    # the pump can run its normal teardown.
+    assert other in cm._connections["s1"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_role_no_open_connections_returns_zero() -> None:
+    cm = ConnectionManager()
+    closed = await cm.disconnect_role("s1", "phantom")
+    assert closed == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_role_isolates_per_session() -> None:
+    """Same role_id in two sessions must not be mass-disconnected."""
+
+    cm = ConnectionManager()
+    ws_a = _FakeWebSocket()
+    ws_b = _FakeWebSocket()
+    await cm.register(
+        session_id="A", role_id="r1", is_creator=False, websocket=ws_a  # type: ignore[arg-type]
+    )
+    await cm.register(
+        session_id="B", role_id="r1", is_creator=False, websocket=ws_b  # type: ignore[arg-type]
+    )
+
+    closed = await cm.disconnect_role("A", "r1")
+
+    assert closed == 1
+    assert ws_a.closed_with and ws_a.closed_with[0][0] == 4401
+    assert ws_b.closed_with == []
+
+
+@pytest.mark.asyncio
+async def test_disconnect_role_handles_close_failure_per_socket() -> None:
+    """A flaky / already-closed socket on tab #1 must not block tab #2
+    from being closed. The primitive is best-effort per socket; a
+    single failing close cannot leave a live channel behind."""
+
+    class _ExplodingWebSocket:
+        def __init__(self) -> None:
+            self.attempted = False
+
+        async def close(self, code: int = 1000, reason: str = "") -> None:
+            self.attempted = True
+            raise RuntimeError("transport already torn down")
+
+    cm = ConnectionManager()
+    boom = _ExplodingWebSocket()
+    fine = _FakeWebSocket()
+    await cm.register(
+        session_id="s1", role_id="r1", is_creator=False, websocket=boom  # type: ignore[arg-type]
+    )
+    await cm.register(
+        session_id="s1", role_id="r1", is_creator=False, websocket=fine  # type: ignore[arg-type]
+    )
+
+    closed = await cm.disconnect_role("s1", "r1")
+
+    assert boom.attempted is True
+    assert fine.closed_with and fine.closed_with[0][0] == 4401
+    # Only the successful close counts — the failure path logs and
+    # moves on rather than aborting the loop.
+    assert closed == 1
+
+
+@pytest.mark.asyncio
+async def test_disconnect_role_drops_ghost_connection_with_no_socket() -> None:
+    """Test fixtures (``test_connection_manager_focus.py``) call
+    ``register`` without a websocket. ``disconnect_role`` still has to
+    clean those out so subsequent broadcasts don't fan out to a dead
+    subscriber whose role was kicked."""
+
+    cm = ConnectionManager()
+    ghost = await cm.register(session_id="s1", role_id="r1", is_creator=False)
+
+    closed = await cm.disconnect_role("s1", "r1")
+
+    assert closed == 1
+    assert ghost not in cm._connections.get("s1", [])

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -2135,6 +2135,101 @@ def test_remove_role_non_creator_rejected(client: TestClient) -> None:
     assert r.status_code == 403
 
 
+def test_revoke_role_force_closes_open_websocket(client: TestClient) -> None:
+    """Issue #127 regression: kicking a player must terminate their
+    already-open WebSocket. Pre-fix the token-version bump only
+    blocked future connects / REST polls, leaving the kicked tab a
+    live channel they could keep submitting through.
+    """
+
+    from starlette.websockets import WebSocketDisconnect
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={old}") as ws:
+        # Drain the initial presence_snapshot so the recv buffer is clean.
+        first = ws.receive_json()
+        assert first["type"] in {"presence_snapshot", "presence"}
+
+        # Creator kicks the player.
+        r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+        assert r.status_code == 200, r.text
+
+        # The kicked tab's WS must observe a disconnect rather than
+        # remain a live channel. ``WebSocketDisconnect`` may surface on
+        # the next ``receive_json`` (or any subsequent send / receive).
+        with pytest.raises(WebSocketDisconnect):
+            for _ in range(64):
+                ws.receive_json()
+
+
+def test_remove_role_force_closes_open_websocket(client: TestClient) -> None:
+    """Removing the role (DELETE) must also close any open WS for that
+    role — same threat model as revoke (issue #127).
+    """
+
+    from starlette.websockets import WebSocketDisconnect
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={old}") as ws:
+        first = ws.receive_json()
+        assert first["type"] in {"presence_snapshot", "presence"}
+
+        r = client.delete(f"/api/sessions/{sid}/roles/{rid}?token={cr}")
+        assert r.status_code == 200, r.text
+
+        with pytest.raises(WebSocketDisconnect):
+            for _ in range(64):
+                ws.receive_json()
+
+
+def test_submit_response_rejects_removed_role(client: TestClient) -> None:
+    """Defense-in-depth: even if an in-flight ``submit_response`` raced
+    the WS-close, ``manager.submit_response`` must refuse to land a
+    message from a role no longer in ``session.roles`` (issue #127).
+    """
+
+    import asyncio
+
+    from app.sessions.turn_engine import IllegalTransitionError
+
+    seats = _create_and_seat(client, role_count=2)
+    _install_mock_and_drive(
+        client, role_ids=seats["role_ids"], extension="lookup_threat_intel"
+    )
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    manager = client.app.state.manager
+
+    async def _kick_then_submit() -> None:
+        await manager.remove_role(
+            session_id=sid, role_id=rid, by_role_id=seats["creator_role_id"]
+        )
+        # Even though the WS would normally have been closed by now,
+        # any racing in-flight ``submit_response`` must still be
+        # rejected at the session-state boundary.
+        with pytest.raises(IllegalTransitionError):
+            await manager.submit_response(
+                session_id=sid, role_id=rid, content="ghost"
+            )
+
+    asyncio.run(_kick_then_submit())
+
+
 def test_activity_endpoint_creator_only(client: TestClient) -> None:
     seats = _create_and_seat(client, role_count=2)
     sid = seats["session_id"]

--- a/backend/tests/test_kick_regression.py
+++ b/backend/tests/test_kick_regression.py
@@ -1,0 +1,798 @@
+"""Issue #127 regression net — session-management invalidation tests.
+
+Pre-fix the creator could click "Kick" in the RolesPanel, the server
+would bump ``role.token_version`` (so REST polls 401'd), but the
+kicked player's already-open WebSocket stayed live and they kept
+posting messages. The fix has three layers:
+
+1. ``ConnectionManager.disconnect_role`` force-closes every open
+   socket for ``(session_id, role_id)``.
+2. ``SessionManager.reissue_role_token(revoke_previous=True)`` and
+   ``SessionManager.remove_role`` call ``disconnect_role`` after
+   committing the state change.
+3. ``SessionManager.submit_response`` and similar mutating entry
+   points reject if the role no longer exists in
+   ``session.roles`` (defense-in-depth for the in-flight race).
+
+Session-management correctness is load-bearing for security: a
+permissive bug here lets a kicked attacker keep talking. This file
+covers the variants — multi-tab, multi-session isolation, every
+mutating WS event, reissue-vs-revoke contract, reconnect-after-kick,
+side-effects on other roles, and the audit trail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.config import reset_settings_cache
+from app.main import create_app
+from app.sessions.turn_engine import IllegalTransitionError
+from tests.mock_anthropic import MockAnthropic, setup_then_play_script
+
+
+@pytest.fixture(autouse=True)
+def _e2e_env(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("ANTHROPIC_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("ANTHROPIC_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("ANTHROPIC_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    monkeypatch.setenv("DUPLICATE_SUBMISSION_WINDOW_SECONDS", "0")
+    reset_settings_cache()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as c:
+        c.app.state.llm.set_transport(MockAnthropic({}).messages)
+        yield c
+
+
+def _install_play_mock(client: TestClient, role_ids: list[str]) -> None:
+    """Install a script-driven mock that handles setup + play tiers,
+    so ``/start`` doesn't immediately end the session via the
+    minimal ``end_session``-everywhere fallback."""
+
+    scripts = setup_then_play_script(role_ids=role_ids, extension_tool=None)
+    client.app.state.llm.set_transport(MockAnthropic(scripts).messages)
+
+
+def _create_and_seat(client: TestClient, *, role_count: int) -> dict[str, Any]:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Ransomware via vendor portal",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    created = resp.json()
+    sid = created["session_id"]
+    cr = created["creator_token"]
+    creator_role_id = created["creator_role_id"]
+    role_ids: list[str] = [creator_role_id]
+    role_tokens: dict[str, str] = {creator_role_id: cr}
+    for i in range(role_count - 1):
+        r = client.post(
+            f"/api/sessions/{sid}/roles?token={cr}",
+            json={"label": f"Player_{i + 1}", "display_name": f"P{i + 1}"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        role_ids.append(body["role_id"])
+        role_tokens[body["role_id"]] = body["token"]
+    return {
+        "session_id": sid,
+        "creator_token": cr,
+        "creator_role_id": creator_role_id,
+        "role_ids": role_ids,
+        "role_tokens": role_tokens,
+    }
+
+
+def _drain_until(ws, predicate, *, max_frames: int = 64) -> dict[str, Any] | None:
+    """Pull WS frames until ``predicate(frame)`` returns True, or until
+    the WebSocket closes / the budget runs out. Returns the matching
+    frame, or None if we hit the end without a match."""
+
+    for _ in range(max_frames):
+        try:
+            evt = ws.receive_json()
+        except WebSocketDisconnect:
+            return None
+        if predicate(evt):
+            return evt
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: ConnectionManager.disconnect_role primitive — multi-tab + isolation
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_disconnects_every_tab_for_kicked_role(client: TestClient) -> None:
+    """A kicked role with two open tabs gets BOTH tabs closed. A
+    one-tab close would leave a live channel the player could still
+    post through — same effective bug as before the fix."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={old}") as tab1:
+        with client.websocket_connect(f"/ws/sessions/{sid}?token={old}") as tab2:
+            # Drain initial presence frames so the recv buffer is clean
+            # for the post-revoke disconnect signal.
+            tab1.receive_json()
+            tab2.receive_json()
+
+            r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+            assert r.status_code == 200, r.text
+
+            with pytest.raises(WebSocketDisconnect):
+                for _ in range(64):
+                    tab1.receive_json()
+            with pytest.raises(WebSocketDisconnect):
+                for _ in range(64):
+                    tab2.receive_json()
+
+
+def test_revoke_does_not_disconnect_other_roles_in_session(
+    client: TestClient,
+) -> None:
+    """The kick is surgical — the creator and any other player still
+    have a live channel. Pre-fix this WAS surgical (revoke didn't
+    close ANY socket); post-fix we must keep it surgical, not regress
+    to a session-wide reset."""
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    kicked_rid = seats["role_ids"][1]
+    bystander_rid = seats["role_ids"][2]
+    kicked_tok = seats["role_tokens"][kicked_rid]
+    bystander_tok = seats["role_tokens"][bystander_rid]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={cr}") as creator_ws:
+        with client.websocket_connect(
+            f"/ws/sessions/{sid}?token={bystander_tok}"
+        ) as bystander_ws:
+            with client.websocket_connect(
+                f"/ws/sessions/{sid}?token={kicked_tok}"
+            ) as kicked_ws:
+                # Initial presence frame on each.
+                creator_ws.receive_json()
+                bystander_ws.receive_json()
+                kicked_ws.receive_json()
+
+                r = client.post(
+                    f"/api/sessions/{sid}/roles/{kicked_rid}/revoke?token={cr}"
+                )
+                assert r.status_code == 200, r.text
+
+                # Kicked tab must close…
+                with pytest.raises(WebSocketDisconnect):
+                    for _ in range(64):
+                        kicked_ws.receive_json()
+
+                # …but the bystander's channel must still deliver. Use
+                # heartbeat as a cheap "is the socket alive" probe.
+                bystander_ws.send_json({"type": "heartbeat"})
+                creator_ws.send_json({"type": "heartbeat"})
+
+
+def test_revoke_does_not_disconnect_same_role_in_other_session(
+    client: TestClient,
+) -> None:
+    """Each session is its own subscription scope. A kick on session A
+    must not leak into session B even if (impossibly, but as a
+    boundary check) the same role_id exists on both. The
+    ConnectionManager keys on session_id; this test pins that
+    contract."""
+
+    seats_a = _create_and_seat(client, role_count=2)
+    seats_b = _create_and_seat(client, role_count=2)
+
+    other_a = seats_a["role_tokens"][seats_a["role_ids"][1]]
+    other_b = seats_b["role_tokens"][seats_b["role_ids"][1]]
+
+    with client.websocket_connect(
+        f"/ws/sessions/{seats_a['session_id']}?token={other_a}"
+    ) as ws_a:
+        with client.websocket_connect(
+            f"/ws/sessions/{seats_b['session_id']}?token={other_b}"
+        ) as ws_b:
+            ws_a.receive_json()
+            ws_b.receive_json()
+
+            r = client.post(
+                f"/api/sessions/{seats_a['session_id']}"
+                f"/roles/{seats_a['role_ids'][1]}/revoke?token={seats_a['creator_token']}"
+            )
+            assert r.status_code == 200
+
+            with pytest.raises(WebSocketDisconnect):
+                for _ in range(64):
+                    ws_a.receive_json()
+
+            ws_b.send_json({"type": "heartbeat"})  # session B still alive
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: reissue ≠ revoke — non-destructive reissue must NOT close sockets
+# ---------------------------------------------------------------------------
+
+
+def test_reissue_without_revoke_keeps_existing_websocket_alive(
+    client: TestClient,
+) -> None:
+    """Reissue is "show me the link again." It must NOT close the
+    holder's open socket — that would defeat the documented use case
+    (creator lost the URL but the player is still on the call)."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    tok = seats["role_tokens"][rid]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={tok}") as ws:
+        ws.receive_json()  # initial presence
+        r = client.post(f"/api/sessions/{sid}/roles/{rid}/reissue?token={cr}")
+        assert r.status_code == 200, r.text
+
+        # Socket must still be alive after the no-revoke reissue.
+        ws.send_json({"type": "heartbeat"})
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: every mutating WS event must be blocked for a removed role
+# ---------------------------------------------------------------------------
+
+
+def test_kicked_role_cannot_reconnect_with_old_token(client: TestClient) -> None:
+    """Even if the kicked tab's reconnect logic ignored 4401 codes, a
+    fresh ``websocket_connect`` with the old token must be rejected."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+    assert r.status_code == 200, r.text
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/ws/sessions/{sid}?token={old}"):
+            pass
+    assert exc_info.value.code == 4401
+
+
+def test_new_token_after_kick_can_reconnect_cleanly(client: TestClient) -> None:
+    """The whole point of revoke-then-reissue is that the *new* token
+    works. Confirms the kick path doesn't accidentally lock the seat
+    permanently."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+    new = r.json()["token"]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={new}") as ws:
+        ws.receive_json()  # presence frame proves the WS upgraded
+
+
+def test_removed_role_cannot_reconnect(client: TestClient) -> None:
+    """``DELETE /roles/{rid}`` removes the role entirely; the old
+    token must 4401 on reconnect with "role no longer exists" rather
+    than treating the missing role as "fresh-version-0"."""
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    r = client.delete(f"/api/sessions/{sid}/roles/{rid}?token={cr}")
+    assert r.status_code == 200, r.text
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/ws/sessions/{sid}?token={old}"):
+            pass
+    assert exc_info.value.code == 4401
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: defense-in-depth at the session-manager layer
+# ---------------------------------------------------------------------------
+
+
+def test_submit_response_after_remove_raises_illegal_transition(
+    client: TestClient,
+) -> None:
+    """Even if a racing in-flight submit_response slipped past the
+    WS-close, the manager must refuse to land a message from a role
+    that's no longer in ``session.roles``. Same gate covers any
+    future caller (proxy, scenario runner, dev API)."""
+
+    from app.sessions.models import SessionState
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    # Drive into AWAITING_PLAYERS via the dev-skip path so the
+    # submit_response state guard is satisfied. The dev skip drops a
+    # minimal plan and transitions straight to READY; ``start`` opens
+    # the first turn — but the AI play turn must yield to a player,
+    # not immediately ``end_session`` (which is what the auto-mock
+    # in the fixture does for every tier).
+    _install_play_mock(client, seats["role_ids"])
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    manager = client.app.state.manager
+
+    async def _check() -> None:
+        await manager.remove_role(
+            session_id=sid, role_id=rid, by_role_id=seats["creator_role_id"]
+        )
+        with pytest.raises(IllegalTransitionError) as exc_info:
+            await manager.submit_response(
+                session_id=sid, role_id=rid, content="ghost message"
+            )
+        assert "no longer exists" in str(exc_info.value)
+        # Session is still alive for the remaining roles.
+        snapshot = await manager.get_session(sid)
+        assert snapshot.state == SessionState.AWAITING_PLAYERS
+
+    asyncio.run(_check())
+
+
+def test_submit_response_for_unknown_role_id_rejected_at_manager(
+    client: TestClient,
+) -> None:
+    """The unknown-role guard is generic — covers a forged role_id
+    that was never in the session, not just one that *was* removed.
+    Useful seam for any future proxy / dev surface that constructs
+    a manager call from less-trusted input."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+
+    _install_play_mock(client, seats["role_ids"])
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    manager = client.app.state.manager
+
+    async def _check() -> None:
+        with pytest.raises(IllegalTransitionError):
+            await manager.submit_response(
+                session_id=sid,
+                role_id="ghost-role-that-was-never-real",
+                content="hello",
+            )
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Layer 5: audit trail + side-effects on peer roles
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_emits_role_token_revoked_audit_event(client: TestClient) -> None:
+    """Operators investigating a stuck-session report rely on the
+    audit log to reconstruct who kicked whom. The emit must fire
+    regardless of whether anyone was connected at the time."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+    assert r.status_code == 200, r.text
+
+    audit = client.app.state.manager.audit().dump(sid)
+    kinds = [evt.kind for evt in audit]
+    assert "role_token_revoked" in kinds, kinds
+
+
+def test_remove_role_broadcasts_participant_left_to_peers(
+    client: TestClient,
+) -> None:
+    """Peer clients learn about the removal via the
+    ``participant_left`` event so their roster panel updates
+    without a polling round-trip. Was working before this change;
+    pinning it here so a future "force-disconnect early-return"
+    refactor can't accidentally drop the broadcast."""
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    bystander_rid = seats["role_ids"][1]
+    target_rid = seats["role_ids"][2]
+    bystander_tok = seats["role_tokens"][bystander_rid]
+
+    with client.websocket_connect(
+        f"/ws/sessions/{sid}?token={bystander_tok}"
+    ) as ws:
+        ws.receive_json()  # initial presence
+
+        r = client.delete(f"/api/sessions/{sid}/roles/{target_rid}?token={cr}")
+        assert r.status_code == 200, r.text
+
+        evt = _drain_until(
+            ws,
+            lambda e: e.get("type") == "participant_left"
+            and e.get("role_id") == target_rid,
+        )
+        assert evt is not None, "expected participant_left for the removed role"
+
+
+def test_creator_cannot_revoke_own_token(client: TestClient) -> None:
+    """Self-revoke is a footgun (it locks the creator out of their
+    own session) — guard rail belongs at the manager. Pinning the
+    refusal so a future "let creators rotate their token" feature
+    has to think about what to do about live sockets."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    creator_role_id = seats["creator_role_id"]
+
+    r = client.post(
+        f"/api/sessions/{sid}/roles/{creator_role_id}/revoke?token={cr}"
+    )
+    assert r.status_code == 409, r.text
+
+
+def test_non_creator_cannot_revoke_other_role(client: TestClient) -> None:
+    """Authorisation regression net: only the creator can kick. A
+    misbehaving player must not be able to kick a peer using their
+    own token."""
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    attacker_tok = seats["role_tokens"][seats["role_ids"][1]]
+    target_rid = seats["role_ids"][2]
+
+    r = client.post(
+        f"/api/sessions/{sid}/roles/{target_rid}/revoke?token={attacker_tok}"
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_revoke_clears_role_from_active_set_on_remove(
+    client: TestClient,
+) -> None:
+    """``remove_role`` must also drop the role from
+    ``current_turn.active_role_ids`` so the turn isn't stuck waiting
+    on a player that no longer exists. Pre-existing behaviour; pinned
+    here in the regression net so a future kick-cleanup refactor
+    can't drop it."""
+
+    from app.sessions.models import SessionState
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+
+    _install_play_mock(client, seats["role_ids"])
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    manager = client.app.state.manager
+
+    async def _check() -> None:
+        snapshot = await manager.get_session(sid)
+        assert snapshot.state == SessionState.AWAITING_PLAYERS
+        # Pick a target that's actually in the AI-chosen active set so
+        # the post-remove "no longer in active_role_ids" assertion is
+        # exercising the cleanup path, not a vacuous "wasn't there to
+        # begin with" pass. Skip the test if the AI's first turn only
+        # asked one role and removing it would unblock the turn.
+        active = list(snapshot.current_turn.active_role_ids or [])
+        target_rid = next(
+            (rid for rid in active if rid != seats["creator_role_id"]),
+            None,
+        )
+        if target_rid is None:
+            pytest.skip("AI didn't seat any non-creator role for turn 1")
+
+        await manager.remove_role(
+            session_id=sid, role_id=target_rid, by_role_id=seats["creator_role_id"]
+        )
+
+        snapshot = await manager.get_session(sid)
+        assert target_rid not in (snapshot.current_turn.active_role_ids or [])
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Layer 6: REST surface for the kicked token (REST + WS share the same
+# token-version gate; if one path regresses while the other doesn't, the
+# attacker just switches transport).
+# ---------------------------------------------------------------------------
+
+
+def test_kicked_token_cannot_post_setup_reply(client: TestClient) -> None:
+    """The kicked token must 401 on every authenticated REST surface,
+    not just GET /sessions/{id}. We pick a representative MUTATING
+    POST endpoint (setup reply) — the full path goes through the same
+    ``_bind_token`` so once the version-mismatch returns 401 the
+    handler never runs."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+    assert r.status_code == 200, r.text
+
+    # Setup reply is creator-only, so 403 is the success signal —
+    # what we DON'T want is a 200. Pre-fix the kicked token would
+    # have at least passed _bind_token; now it 401s upstream of any
+    # creator/participant gate.
+    resp = client.post(
+        f"/api/sessions/{sid}/setup/reply?token={old}",
+        json={"content": "ignored"},
+    )
+    assert resp.status_code == 401, resp.text
+
+
+def test_kicked_token_cannot_force_advance_via_websocket(
+    client: TestClient,
+) -> None:
+    """Issue #127 / Security review CRITICAL #2:
+    ``request_force_advance`` must be rejected for a kicked player
+    whose old WebSocket is still mid-recv. The per-event
+    ``_role_still_authorized`` gate in the WS pump catches this even
+    if the recv buffer holds frames from before the disconnect lands.
+    """
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    _install_play_mock(client, seats["role_ids"])
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={old}") as ws:
+        # Drain initial presence so the race window is narrow.
+        _drain_until(ws, lambda e: e.get("type") == "presence_snapshot")
+
+        # Bump token_version OUT-OF-BAND directly on the manager so
+        # the bump lands BEFORE we send the ``request_force_advance``
+        # — this simulates the race: the WS's token_version is now
+        # stale relative to ``role.token_version``, but the socket
+        # is still open because we sidestepped the route's
+        # ``disconnect_role`` call.
+        async def _bump() -> None:
+            session = await client.app.state.manager.get_session(sid)
+            role = session.role_by_id(rid)
+            assert role is not None
+            role.token_version += 1
+            await client.app.state.manager._repo.save(session)
+
+        asyncio.run(_bump())
+
+        ws.send_json({"type": "request_force_advance"})
+
+        # Either an error frame or a disconnect — both are acceptable
+        # outcomes. The CRITICAL bug pre-fix was that force_advance
+        # would land and mutate session state.
+        outcome: dict[str, Any] | None = None
+        with pytest.raises(WebSocketDisconnect):
+            for _ in range(64):
+                evt = ws.receive_json()
+                if evt.get("type") == "error" and evt.get("scope") == "auth":
+                    outcome = evt
+
+        # Confirm post-condition: turn was NOT advanced. With the
+        # mock's first turn typically still ``awaiting``, status
+        # must remain ``awaiting`` (or the turn AI was driving
+        # already), but it must NOT contain a "Force-advanced"
+        # SYSTEM message attributed to the kicked role.
+        snapshot = client.get(f"/api/sessions/{sid}?token={cr}").json()
+        force_advance_messages = [
+            m
+            for m in snapshot["messages"]
+            if m["kind"] == "system" and "Force-advanced" in (m["body"] or "")
+        ]
+        assert force_advance_messages == [], (
+            "force_advance must not have landed for a kicked role; "
+            f"found: {force_advance_messages}"
+        )
+
+        # Either the auth error frame fired, or the WS disconnected
+        # before any error frame — both are fail-closed outcomes.
+        if outcome is not None:
+            assert outcome["scope"] == "auth"
+
+
+def test_kicked_token_cannot_send_notepad_update(client: TestClient) -> None:
+    """Notepad mutations through the WS pump go through the same
+    require_participant gate as submit / force_advance, so the new
+    per-event role check covers them too. A kicked user must not be
+    able to corrupt the canonical Yjs doc through their stale tab.
+    """
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    _install_play_mock(client, seats["role_ids"])
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={old}") as ws:
+        _drain_until(ws, lambda e: e.get("type") == "presence_snapshot")
+
+        async def _bump() -> None:
+            session = await client.app.state.manager.get_session(sid)
+            role = session.role_by_id(rid)
+            assert role is not None
+            role.token_version += 1
+            await client.app.state.manager._repo.save(session)
+
+        asyncio.run(_bump())
+
+        # Send a notepad update from the now-stale-version socket.
+        # The base64 payload doesn't matter — the gate fires before
+        # any bytes are decoded.
+        ws.send_json({"type": "notepad_update", "update": "AAA="})
+
+        with pytest.raises(WebSocketDisconnect):
+            for _ in range(64):
+                ws.receive_json()
+
+
+def test_submit_response_with_stale_token_version_rejected(
+    client: TestClient,
+) -> None:
+    """Defense-in-depth at the manager: even if the WS pre-check
+    passed (race), ``submit_response(expected_token_version=...)``
+    must reject the submission inside the lock when the server's
+    role.token_version has moved on. This covers the kick/revoke
+    race that the previous ``role_by_id is None`` check missed."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    _install_play_mock(client, seats["role_ids"])
+    client.post(f"/api/sessions/{sid}/setup/skip?token={cr}")
+    client.post(f"/api/sessions/{sid}/start?token={cr}")
+
+    manager = client.app.state.manager
+
+    async def _check() -> None:
+        # Bump the version (simulates a kick that already landed).
+        await manager.reissue_role_token(
+            session_id=sid,
+            role_id=rid,
+            revoke_previous=True,
+            by_role_id=seats["creator_role_id"],
+        )
+        # Submitting with the OLD (now-stale) version must raise.
+        with pytest.raises(IllegalTransitionError) as exc_info:
+            await manager.submit_response(
+                session_id=sid,
+                role_id=rid,
+                content="ghost",
+                expected_token_version=0,  # stale — actual is 1 post-revoke
+            )
+        assert "revoked" in str(exc_info.value).lower()
+
+        # And submitting with the CURRENT version still works (the
+        # role wasn't removed, just its token rotated). Sanity check
+        # so the new gate doesn't accidentally lock the seat.
+        # Note: requires the turn to still allow this role.
+        snapshot = await manager.get_session(sid)
+        if rid in (snapshot.current_turn.active_role_ids or []):
+            await manager.submit_response(
+                session_id=sid,
+                role_id=rid,
+                content="legitimate post-rotation submission",
+                expected_token_version=1,
+            )
+
+    asyncio.run(_check())
+
+
+def test_role_token_revoked_audit_includes_by_role_id(
+    client: TestClient,
+) -> None:
+    """Product review HIGH: ``role_removed`` records ``by`` (the
+    creator who performed the action); ``role_token_revoked`` was
+    missing that field, so post-incident audit couldn't tell who
+    kicked whom. Now both events carry it."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    r = client.post(f"/api/sessions/{sid}/roles/{rid}/revoke?token={cr}")
+    assert r.status_code == 200, r.text
+
+    audit = client.app.state.manager.audit().dump(sid)
+    revoke_events = [e for e in audit if e.kind == "role_token_revoked"]
+    assert revoke_events, "expected at least one role_token_revoked event"
+    last = revoke_events[-1]
+    assert last.payload.get("by") == seats["creator_role_id"], (
+        f"role_token_revoked must record the actor; got payload={last.payload}"
+    )
+    assert last.payload.get("role_id") == rid
+
+
+def test_reissue_without_revoke_audit_records_actor_too(
+    client: TestClient,
+) -> None:
+    """Symmetric coverage for the non-revoke reissue path — same
+    audit field plumbing, both events must populate ``by``."""
+
+    seats = _create_and_seat(client, role_count=2)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+
+    r = client.post(f"/api/sessions/{sid}/roles/{rid}/reissue?token={cr}")
+    assert r.status_code == 200, r.text
+
+    audit = client.app.state.manager.audit().dump(sid)
+    reissue_events = [e for e in audit if e.kind == "role_token_reissued"]
+    assert reissue_events
+    assert reissue_events[-1].payload.get("by") == seats["creator_role_id"]
+
+
+def test_removed_token_cannot_post_setup_reply(client: TestClient) -> None:
+    """Mirror of the kicked-token test for the remove path. The role
+    no longer exists in ``session.roles`` so ``_bind_token`` raises
+    "role no longer exists" → 401."""
+
+    seats = _create_and_seat(client, role_count=3)
+    sid = seats["session_id"]
+    cr = seats["creator_token"]
+    rid = seats["role_ids"][1]
+    old = seats["role_tokens"][rid]
+
+    r = client.delete(f"/api/sessions/{sid}/roles/{rid}?token={cr}")
+    assert r.status_code == 200, r.text
+
+    resp = client.post(
+        f"/api/sessions/{sid}/setup/reply?token={old}",
+        json={"content": "ignored"},
+    )
+    assert resp.status_code == 401, resp.text

--- a/frontend/src/__tests__/classifySnapshotError.test.ts
+++ b/frontend/src/__tests__/classifySnapshotError.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Pin the snapshot-error → terminal-status mapping (issue #127, Copilot
+ * review on PR #131).
+ *
+ * The backend's ``HTTPException.detail`` is the only signal a returning
+ * kicked / orphaned player gets when their localStorage was cleared and
+ * the WebSocket is still gated on ``displayName``. Without a tight
+ * regex set, the player either falls through to JoinIntro (the bug
+ * Copilot flagged) or sees a generic snapshot error inside the intro
+ * card and never reaches the dead-end view. Pin every detail message
+ * the backend emits today AND the bare ``\d{3}`` status fallbacks the
+ * api client uses when the JSON-body parse fails.
+ */
+import { describe, expect, it } from "vitest";
+
+import { classifySnapshotError } from "../lib/snapshotError";
+
+describe("classifySnapshotError — kicked", () => {
+  it.each([
+    "token has been revoked",
+    "role no longer exists",
+    "401",
+    "401 Unauthorized",
+    "401: token has been revoked",
+  ])("maps %p to 'kicked'", (msg) => {
+    expect(classifySnapshotError(msg)).toBe("kicked");
+  });
+});
+
+describe("classifySnapshotError — session-gone", () => {
+  it.each([
+    "session not found",
+    "Session not found",
+    "404",
+    "404 Not Found",
+    "410",
+    "session has expired",
+  ])("maps %p to 'session-gone'", (msg) => {
+    expect(classifySnapshotError(msg)).toBe("session-gone");
+  });
+});
+
+describe("classifySnapshotError — transient", () => {
+  it.each([
+    "network error",
+    "Failed to fetch",
+    "500",
+    "Internal Server Error",
+    "",
+  ])("returns null for %p", (msg) => {
+    expect(classifySnapshotError(msg)).toBeNull();
+  });
+});
+
+describe("classifySnapshotError — kicked precedence", () => {
+  it("prefers kicked when a message matches both buckets", () => {
+    // A pathological backend rewording could in theory hit both
+    // regex sets at once. Pin the precedence: a revoked-token signal
+    // wins over a session-gone signal so the player sees the more
+    // actionable "ask for a new join link" copy.
+    expect(
+      classifySnapshotError("token revoked; session not found"),
+    ).toBe("kicked");
+  });
+});

--- a/frontend/src/__tests__/wsTerminalClose.test.ts
+++ b/frontend/src/__tests__/wsTerminalClose.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Frontend regression net for issue #127 — terminal close-code mapping
+ * in ``WsClient``. Pre-fix, every server-initiated close re-armed the
+ * exponential-backoff reconnect loop, so a kicked tab kept hammering
+ * the server with 4401 connect attempts indefinitely. Post-fix, codes
+ * 4401 / 4403 / 4404 each translate to a distinct ``onStatus`` value
+ * and the reconnect timer is NOT armed.
+ *
+ * The QA review on the PR flagged the missing frontend coverage — this
+ * file fills that gap by stubbing the ``WebSocket`` global with a fake
+ * that lets the test fire ``close`` events with arbitrary codes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WsClient } from "../lib/ws";
+
+interface FakeListener {
+  type: string;
+  fn: EventListener;
+}
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+  url: string;
+  readyState = 0;
+  listeners: FakeListener[] = [];
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+  addEventListener(type: string, fn: EventListener) {
+    this.listeners.push({ type, fn });
+  }
+  removeEventListener(type: string, fn: EventListener) {
+    this.listeners = this.listeners.filter(
+      (l) => !(l.type === type && l.fn === fn),
+    );
+  }
+  send() {
+    /* noop */
+  }
+  close() {
+    this.closed = true;
+  }
+  fire(type: string, init: Record<string, unknown> = {}) {
+    const evt = Object.assign(new Event(type), init);
+    for (const l of this.listeners) if (l.type === type) l.fn(evt);
+  }
+}
+
+describe("WsClient — terminal close-code mapping (issue #127)", () => {
+  const realWebSocket = globalThis.WebSocket;
+
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    // @ts-expect-error — replace with our fake for this suite.
+    globalThis.WebSocket = FakeWebSocket;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = realWebSocket;
+    vi.useRealTimers();
+  });
+
+  function newClient(onStatus: (s: string) => void) {
+    return new WsClient({
+      sessionId: "s1",
+      token: "tok",
+      onEvent: () => {},
+      onStatus: (s) => onStatus(s as string),
+    });
+  }
+
+  it("maps close 4401 (revoked token) to 'kicked' and stops the reconnect loop", () => {
+    const statuses: string[] = [];
+    const ws = newClient((s) => statuses.push(s));
+    ws.connect();
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    FakeWebSocket.instances[0].fire("close", { code: 4401, reason: "kicked" });
+
+    expect(statuses).toContain("kicked");
+    expect(statuses).not.toContain("closed");
+
+    // Roll the clock past every backoff window — no second connect.
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("maps close 4403 (forbidden origin) to 'rejected' (NOT kicked)", () => {
+    const statuses: string[] = [];
+    const ws = newClient((s) => statuses.push(s));
+    ws.connect();
+
+    FakeWebSocket.instances[0].fire("close", { code: 4403, reason: "" });
+
+    expect(statuses).toContain("rejected");
+    expect(statuses).not.toContain("kicked");
+    expect(statuses).not.toContain("closed");
+  });
+
+  it("maps close 4404 (session not found) to 'session-gone' (NOT kicked)", () => {
+    const statuses: string[] = [];
+    const ws = newClient((s) => statuses.push(s));
+    ws.connect();
+
+    FakeWebSocket.instances[0].fire("close", { code: 4404, reason: "" });
+
+    expect(statuses).toContain("session-gone");
+    expect(statuses).not.toContain("kicked");
+  });
+
+  it("non-terminal close codes still trigger reconnect with backoff", () => {
+    const statuses: string[] = [];
+    const ws = newClient((s) => statuses.push(s));
+    ws.connect();
+
+    // Close with a generic abnormal-close code (1006 — connection lost).
+    FakeWebSocket.instances[0].fire("close", { code: 1006, reason: "" });
+
+    expect(statuses).toContain("closed");
+    expect(statuses).not.toContain("kicked");
+
+    // First backoff is ~1s + jitter; advance 2s to clear it.
+    vi.advanceTimersByTime(2_000);
+    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("manual close() does NOT surface a terminal status", () => {
+    const statuses: string[] = [];
+    const ws = newClient((s) => statuses.push(s));
+    ws.connect();
+    ws.close();
+    FakeWebSocket.instances[0].fire("close", { code: 1000, reason: "" });
+    expect(statuses).not.toContain("kicked");
+    expect(statuses).not.toContain("rejected");
+    expect(statuses).not.toContain("session-gone");
+  });
+});

--- a/frontend/src/components/brand/BottomActionBar.tsx
+++ b/frontend/src/components/brand/BottomActionBar.tsx
@@ -22,7 +22,14 @@ type Phase = "intro" | "setup" | "ready" | "play" | "ended";
 interface Props {
   phase: Phase;
   backendState: string;
-  wsStatus: "connecting" | "open" | "closed" | "error";
+  wsStatus:
+    | "connecting"
+    | "open"
+    | "closed"
+    | "error"
+    | "kicked"
+    | "rejected"
+    | "session-gone";
   godMode: boolean;
   onToggleGodMode: () => void;
   onStart: () => void;

--- a/frontend/src/lib/snapshotError.ts
+++ b/frontend/src/lib/snapshotError.ts
@@ -1,0 +1,47 @@
+/**
+ * Snapshot-error → terminal-status classifier (issue #127, Copilot
+ * review on PR #131).
+ *
+ * ``api.getSession`` errors flow through ``request()`` which throws
+ * ``new Error(json.detail)`` — so the only signal we get is the
+ * backend's ``HTTPException.detail`` string (or the stringified
+ * status code when the JSON body parse failed). Map every backend
+ * message the player can hit at the snapshot boundary onto a
+ * dead-end-view bucket; ``null`` falls through to the page's
+ * generic transient-error path.
+ *
+ * - ``"kicked"``: the seat was revoked / removed. Backend emits
+ *   "token has been revoked" (token-version mismatch) or "role
+ *   no longer exists" (DELETE /roles/{rid}); the api-client
+ *   fallback is a bare "401".
+ * - ``"session-gone"``: the session itself is gone. Backend emits
+ *   "session not found" (GC reaper / never existed) or 410 (AAR
+ *   path); the api-client fallback is a bare "404" / "410".
+ * - ``null``: anything else (5xx, network blip, unparseable JSON);
+ *   the page surfaces it as a transient snapshot error.
+ *
+ * Lives in ``lib/`` rather than alongside ``Play.tsx`` so the
+ * file-level fast-refresh boundary stays component-only and so
+ * other surfaces (Facilitator's snapshot path, future CreatorJoin
+ * path) can reuse it without circular imports.
+ */
+export type SnapshotErrorKind = "kicked" | "session-gone" | null;
+
+export function classifySnapshotError(message: string): SnapshotErrorKind {
+  if (
+    /\b401\b/.test(message) ||
+    /revoked/i.test(message) ||
+    /no longer exists/i.test(message)
+  ) {
+    return "kicked";
+  }
+  if (
+    /\b404\b/.test(message) ||
+    /\b410\b/.test(message) ||
+    /session not found/i.test(message) ||
+    /session.*expired/i.test(message)
+  ) {
+    return "session-gone";
+  }
+  return null;
+}

--- a/frontend/src/lib/useTabFocusReporter.ts
+++ b/frontend/src/lib/useTabFocusReporter.ts
@@ -37,7 +37,14 @@ export function useTabFocusReporter(
    * If omitted, the hook only sends on visibility/focus events plus
    * the initial mount.
    */
-  wsStatus?: "connecting" | "open" | "closed" | "error",
+  wsStatus?:
+    | "connecting"
+    | "open"
+    | "closed"
+    | "error"
+    | "kicked"
+    | "rejected"
+    | "session-gone",
 ): void {
   const lastSentRef = useRef<boolean | null>(null);
 

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -141,11 +141,46 @@ export type ClientEvent =
   | { type: "notepad_update"; update: string }
   | { type: "notepad_awareness"; awareness: string };
 
+/** Close codes the server uses to reject the WS upgrade (or terminate
+ *  it post-kick). Reconnecting with the same token will fail the same
+ *  way, so the client stops the auto-reconnect loop and surfaces a
+ *  status the page can render specifically.
+ *
+ *  - 4401: bad / revoked token. The creator kicked this seat (issue
+ *    #127) OR the join URL was forged. From the player's view both
+ *    look the same — the link no longer works.
+ *  - 4403: forbidden origin. CORS_ORIGINS doesn't include this
+ *    origin. Unlike "kicked", this is usually an operator
+ *    misconfiguration; the player can't fix it by getting a fresh
+ *    link. Render distinct copy so the operator's screenshot of the
+ *    UI doesn't get mistakenly triaged as "the player was kicked".
+ *  - 4404: session not found. The GC reaper evicted the session
+ *    (long-idle), or the operator restarted the in-memory store. A
+ *    fresh creator session would be needed; a fresh link won't help.
+ */
+const CLOSE_CODE_BAD_TOKEN = 4401;
+const CLOSE_CODE_FORBIDDEN_ORIGIN = 4403;
+const CLOSE_CODE_SESSION_GONE = 4404;
+const TERMINAL_CLOSE_CODES = new Set([
+  CLOSE_CODE_BAD_TOKEN,
+  CLOSE_CODE_FORBIDDEN_ORIGIN,
+  CLOSE_CODE_SESSION_GONE,
+]);
+
+export type TerminalCloseStatus = "kicked" | "rejected" | "session-gone";
+
 export interface WsClientOptions {
   sessionId: string;
   token: string;
   onEvent: (event: ServerEvent) => void;
-  onStatus?: (status: "connecting" | "open" | "closed" | "error") => void;
+  onStatus?: (
+    status:
+      | "connecting"
+      | "open"
+      | "closed"
+      | "error"
+      | TerminalCloseStatus,
+  ) => void;
   heartbeatMs?: number;
 }
 
@@ -330,8 +365,38 @@ export class WsClient {
 
     ws.addEventListener("close", (evt) => {
       this._teardownHeartbeat();
-      this.opts.onStatus?.("closed");
       console.debug("[ws] close", { code: evt.code, reason: evt.reason });
+      // Server-initiated terminal closes will fail the same way on
+      // reconnect — looping with backoff just spams the server and
+      // logs. Map each terminal code to a distinct status so the
+      // page can render the right copy (a kicked player and a
+      // CORS-misconfigured origin should NOT see the same banner).
+      // Flip the closed-by-caller flag so any subsequent close
+      // events on this socket also stay out of the reconnect path.
+      if (TERMINAL_CLOSE_CODES.has(evt.code) && !this.closedByCaller) {
+        this.closedByCaller = true;
+        let status: TerminalCloseStatus;
+        switch (evt.code) {
+          case CLOSE_CODE_BAD_TOKEN:
+            status = "kicked";
+            break;
+          case CLOSE_CODE_FORBIDDEN_ORIGIN:
+            status = "rejected";
+            break;
+          case CLOSE_CODE_SESSION_GONE:
+            status = "session-gone";
+            break;
+          default:
+            status = "kicked";
+        }
+        console.info("[ws] terminal close — disabling reconnect", {
+          code: evt.code,
+          status,
+        });
+        this.opts.onStatus?.(status);
+        return;
+      }
+      this.opts.onStatus?.("closed");
       if (!this.closedByCaller) {
         this._scheduleReconnect();
       }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -175,7 +175,7 @@ export function Facilitator() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
-  const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed" | "error">("connecting");
+  const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed" | "error" | "kicked" | "rejected" | "session-gone">("connecting");
 
   // Live AI text streaming was producing visible mid-flight rewrites:
   // the green "streaming…" bubble showed concatenated chunks, then the
@@ -1540,7 +1540,7 @@ export function Facilitator() {
 export function TopBar(props: {
   phase: Phase;
   backendState: string;
-  wsStatus: "connecting" | "open" | "closed" | "error";
+  wsStatus: "connecting" | "open" | "closed" | "error" | "kicked" | "rejected" | "session-gone";
   godMode: boolean;
   onToggleGodMode: () => void;
   // Session-action props (was SessionActionBar):

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -12,6 +12,7 @@ import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
 import { confirmLeaveSession } from "../lib/leaveGuard";
 import { isMidSessionJoiner } from "../lib/proxy";
+import { classifySnapshotError } from "../lib/snapshotError";
 import { useSessionTitle } from "../lib/useSessionTitle";
 import { useStickyScroll } from "../lib/useStickyScroll";
 import { useTabFocusReporter } from "../lib/useTabFocusReporter";
@@ -385,19 +386,17 @@ export function Play({ sessionId, token }: Props) {
       setSnapshot(snap);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // Issue #127: a returning kicked player whose localStorage was
-      // cleared won't have a ``displayName`` yet, so the WS stays
-      // gated and never observes the 4401 close. The snapshot fetch
-      // is the only signal in that path. Detect 401 / "revoked" /
-      // "no longer exists" here and flip to the same dead-end view
-      // so they don't get trapped on JoinIntro.
-      if (
-        /\b401\b/.test(msg) ||
-        /revoked/i.test(msg) ||
-        /no longer exists/i.test(msg)
-      ) {
+      const terminal = classifySnapshotError(msg);
+      if (terminal === "kicked") {
         console.info("[play] snapshot 401 — treating as kicked", { msg });
         setWsStatus("kicked");
+        return;
+      }
+      if (terminal === "session-gone") {
+        console.info("[play] snapshot 404/410 — treating as session-gone", {
+          msg,
+        });
+        setWsStatus("session-gone");
         return;
       }
       setError(msg);

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -153,7 +153,13 @@ export function Play({ sessionId, token }: Props) {
   // backgrounded before a transient disconnect would otherwise show as
   // active in the creator's roster after reconnect.
   const [wsStatus, setWsStatus] = useState<
-    "connecting" | "open" | "closed" | "error"
+    | "connecting"
+    | "open"
+    | "closed"
+    | "error"
+    | "kicked"
+    | "rejected"
+    | "session-gone"
   >("connecting");
 
   // WebSocket is gated on displayName because we want the intro page
@@ -378,7 +384,23 @@ export function Play({ sessionId, token }: Props) {
       const snap = await api.getSession(sessionId, token);
       setSnapshot(snap);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      // Issue #127: a returning kicked player whose localStorage was
+      // cleared won't have a ``displayName`` yet, so the WS stays
+      // gated and never observes the 4401 close. The snapshot fetch
+      // is the only signal in that path. Detect 401 / "revoked" /
+      // "no longer exists" here and flip to the same dead-end view
+      // so they don't get trapped on JoinIntro.
+      if (
+        /\b401\b/.test(msg) ||
+        /revoked/i.test(msg) ||
+        /no longer exists/i.test(msg)
+      ) {
+        console.info("[play] snapshot 401 — treating as kicked", { msg });
+        setWsStatus("kicked");
+        return;
+      }
+      setError(msg);
     }
   }
 
@@ -683,6 +705,59 @@ export function Play({ sessionId, token }: Props) {
   // session transitions to AWAITING_PLAYERS / AI_PROCESSING / etc.
   const isWaitingForSessionStart =
     snapshot?.state === "SETUP" || snapshot?.state === "BRIEFING";
+
+  // Issue #127: terminal WS close codes must short-circuit BEFORE
+  // the JoinIntro guard. Pre-fix a kicked player who reopened the
+  // URL with localStorage cleared landed on JoinIntro forever
+  // because the WS connect was gated on ``displayName`` and the
+  // snapshot fetch silently 401'd into a generic error. Render the
+  // dead-end view here regardless of whether we know their name.
+  if (
+    wsStatus === "kicked" ||
+    wsStatus === "rejected" ||
+    wsStatus === "session-gone"
+  ) {
+    const headline =
+      wsStatus === "kicked"
+        ? "JOIN LINK REVOKED"
+        : wsStatus === "session-gone"
+          ? "SESSION NOT FOUND"
+          : "CONNECTION REJECTED";
+    const body =
+      wsStatus === "kicked"
+        ? "The facilitator removed this seat. Ask them for a new join link."
+        : wsStatus === "session-gone"
+          ? "The exercise this link points to has ended or expired. Ask the facilitator to create a new session."
+          : "The server refused this connection. If you forwarded this link from another window, try opening it directly.";
+    return (
+      <main className="dotgrid flex min-h-screen items-center justify-center bg-ink-900 px-6 text-ink-200">
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="card mono flex max-w-md flex-col gap-3 p-6 text-center"
+          style={{
+            borderColor: "var(--crit)",
+            background: "var(--ink-850)",
+          }}
+        >
+          <h1
+            className="mono text-[12px] font-bold uppercase tracking-[0.22em]"
+            style={{ color: "var(--crit)" }}
+          >
+            {headline}
+          </h1>
+          <p className="text-[12px] leading-relaxed text-ink-300">{body}</p>
+          <a
+            href="/"
+            autoFocus
+            className="btn mt-2 inline-flex items-center justify-center self-center px-4 py-2 text-[11px] font-bold uppercase tracking-[0.16em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal"
+          >
+            Return home
+          </a>
+        </div>
+      </main>
+    );
+  }
 
   if (!effectiveDisplayName || isWaitingForSessionStart) {
     // Pre-fix this was a tiny "what's your name?" dialog that operators


### PR DESCRIPTION
## Summary

Closes #127.

Pre-fix, "kicking" a player only bumped `role.token_version`. That blocks future connects / REST polls, but the kicked player's already-open WebSocket stayed live and they could keep submitting through the channel. The user reported: *"after kicking a user, that user was still able to send a message."*

The fix has four layers:

1. **`ConnectionManager.disconnect_role(session_id, role_id)`** force-closes every open socket for the (session, role) tuple. `SessionManager.reissue_role_token(revoke_previous=True)` and `remove_role` call it after the token bump / role removal.
2. **WebSocket pump per-event recheck** (`backend/app/ws/routes.py::_client_pump`) re-validates `role.token_version` against the version captured at upgrade time before processing every mutating event (`submit_response`, `request_force_advance`, `request_end_session`, typing/notepad). Catches `force_advance` and `notepad_update` / `notepad_awareness` race-window mutations the original patch missed.
3. **Manager-side defense-in-depth** — `submit_response` accepts `expected_token_version` and rejects with `IllegalTransitionError` when the version moved on under the lock. Closes the residual race where the kick wins the lock between WS recheck and mutation.
4. **Frontend** — `ws.ts` maps `4401 → "kicked"`, `4403 → "rejected"`, `4404 → "session-gone"` (separate so a CORS misconfig isn't rendered as a kick) and disarms the reconnect loop. `Play.tsx` renders a brand-aligned dead-end view above the JoinIntro guard so returning users with cleared localStorage aren't trapped on the intro page; `refreshSnapshot()` also flips to `"kicked"` on a 401 so the WS-not-yet-mounted path is covered.

Audit trail (Product review HIGH): `role_token_revoked` and `role_token_reissued` now record `by` (the creator who performed the action), so post-incident audits can answer "who kicked whom?".

## Tests

- `backend/tests/test_connection_manager_disconnect.py` — **5** unit tests on the primitive (multi-tab close, no-op when role absent, per-session isolation, per-socket close-failure tolerance, ghost-without-websocket cleanup).
- `backend/tests/test_kick_regression.py` — **20** cases (1 conditionally skipped) exercising the full kick threat model — multi-tab, multi-session isolation, reissue-vs-revoke contract, kicked token can't reconnect / can't post REST or WS, force_advance and notepad mutations rejected after kick, `expected_token_version` race rejection, audit log includes actor on both reissue and revoke, `active_role_ids` cleanup on remove.
- `backend/tests/test_e2e_session.py` — revoke + remove force-close an open WebSocket; `submit_response` after `remove_role` rejected.
- `frontend/src/__tests__/wsTerminalClose.test.ts` — **5** cases pinning the close-code mapping and reconnect-loop-disarm.

Backend: 401 passed, 1 skipped. Frontend: 189 passed across 19 files. Lint + mypy clean.

## Sub-agent review summary

All six sub-agent reviews ran in parallel. Findings addressed in this commit:

- **QA (HIGH H1)** — `submit_response` defensive check missed the kick race → added `expected_token_version`.
- **QA (HIGH H2)** — e2e tests proved close, not rejection → added force_advance / notepad / submit-version-stale tests.
- **Security (CRITICAL #1, #2, HIGH #3)** — `submit_response`, `force_advance`, notepad_*\* lacked per-event gates → added `_role_still_authorized()` recheck on every mutating event in the WS pump.
- **Security (HIGH #4) / UI/UX (HIGH)** — 4403/4404 conflated with "kicked" → split into `rejected` / `session-gone`.
- **UI/UX (BLOCK)** — kicked early-return below JoinIntro trapped returning users → moved above; also `refreshSnapshot()` 401 → kicked path.
- **UI/UX (BLOCK + HIGH)** — voice / `--warn` color / `.card` override / focus management → rewrote copy ("Join link revoked"), `--crit` border, autoFocus on the link, `focus-visible` outline.
- **Product (HIGH)** — `role_token_revoked` audit missing `by` → both events now record actor.

Deferred (would be product polish, not invalidation correctness):

- User-persona MEDIUM: "live confirmation kick disconnected" / "undo window" / "system message in transcript when a peer is kicked".
- UI/UX MEDIUM: "Try again" affordance when revoke was a fat-finger.
- QA MINOR: `caplog`-asserting test for the new `ws_force_close_failed` warning line.

## Test plan
- [ ] Two browsers side-by-side: creator kicks Bridget; Bridget's tab flips to "JOIN LINK REVOKED" within ~1s without any reconnect spam in the console.
- [ ] Bridget's `Composer` cannot send a message that lands in the transcript (try sending right after the kick).
- [ ] Re-share path is intact: clicking "Copy link again" (no revoke) does NOT disconnect the legitimate user.
- [ ] Audit log: `role_token_revoked` carries both `role_id` and `by`.
- [ ] Multi-tab user: BOTH tabs disconnect on a single kick.
- [ ] Returning kicked user with cleared localStorage lands on the dead-end view, NOT JoinIntro.

https://claude.ai/code/session_0112XTCytoM9idtU4nw6JjEy

---
_Generated by [Claude Code](https://claude.ai/code/session_0112XTCytoM9idtU4nw6JjEy)_