### PR TITLE
backend: fail fast on missing ANTHROPIC_API_KEY at app construction

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,10 +42,6 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     configure_logging(settings)
     logger = get_logger("startup")
 
-    if not settings.test_mode:
-        # Validates ``ANTHROPIC_API_KEY`` is present in production-ish runs.
-        settings.require_anthropic_key()
-
     secret = settings.resolve_session_secret()
     authn = HMACAuthenticator(secret)
     audit = AuditLog(ring_size=settings.audit_ring_size)
@@ -167,6 +163,28 @@ def create_app(
 
         _cfg.get_settings.cache_clear()
 
+    cfg = settings or get_settings()
+
+    # Validate critical runtime config eagerly — at import time, before any
+    # FastAPI machinery is constructed. Doing this in the lifespan instead
+    # leaves uvicorn printing "Started server process", then swallowing the
+    # lifespan traceback and exiting with code 0; under
+    # ``docker compose restart: unless-stopped`` that produces a silent
+    # restart loop (issue #118). Failing in ``create_app`` propagates as an
+    # import-time exception so uvicorn never binds the port and exits
+    # non-zero with a clear, single-line error.
+    #
+    # Configure logging here too so the gate emits a structured success line
+    # (and any failure traceback is captured by structlog, not by stderr).
+    # ``configure_logging`` is idempotent; the lifespan re-runs it harmlessly.
+    configure_logging(cfg)
+    _bootstrap_log = get_logger("startup")
+    if not cfg.test_mode:
+        cfg.require_anthropic_key()
+        _bootstrap_log.info("anthropic_api_key_present", test_mode=False)
+    else:
+        _bootstrap_log.info("anthropic_api_key_check_skipped", test_mode=True)
+
     app = FastAPI(
         title="Crittable",
         version="0.0.2",
@@ -177,7 +195,6 @@ def create_app(
     # ``request_id`` shows up in CORS-preflight log lines too.
     app.add_middleware(RequestContextMiddleware)
 
-    cfg = settings or get_settings()
     cors = cfg.cors_origin_list()
     app.add_middleware(
         CORSMiddleware,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -418,26 +418,56 @@ def test_empty_env_vars_fall_back_to_defaults(
     assert resolved.endswith("backend/scenarios")
 
 
-def test_create_app_refuses_without_anthropic_api_key(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Issue #118: ``create_app()`` must raise at import / construction time
-    when ``ANTHROPIC_API_KEY`` is unset and ``TEST_MODE`` is off. Pre-fix the
-    check lived in the lifespan, so uvicorn printed ``Started server
-    process``, swallowed the lifespan traceback, then exited with code 0 —
-    silently restart-looping under ``docker compose restart: unless-stopped``.
-    Failing eagerly in ``create_app`` propagates as an import-time exception
-    and uvicorn exits non-zero."""
+def test_create_app_refuses_without_anthropic_api_key() -> None:
+    """Issue #118: importing ``app.main`` (which evaluates
+    ``app = create_app()`` at module level) must fail at the process
+    boundary when ``ANTHROPIC_API_KEY`` is unset and ``TEST_MODE`` is
+    off.
 
-    from app.config import reset_settings_cache
-    from app.main import create_app
+    Pre-fix the check lived in the lifespan, so uvicorn printed
+    ``Started server process``, swallowed the lifespan traceback, then
+    exited with code 0 — silently restart-looping under
+    ``docker compose restart: unless-stopped``. Post-fix the import
+    itself raises so uvicorn never binds the port and exits non-zero.
 
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.setenv("TEST_MODE", "false")
-    reset_settings_cache()
+    Runs in a subprocess for two reasons:
 
-    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
-        create_app()
+    * The pytest process imports ``app.main`` once at startup with
+      ``TEST_MODE=true`` (set in ``conftest.py``). Re-asserting against
+      that already-imported module would skip the actual import-time
+      gate. A subprocess gives us a fresh, never-imported module space.
+    * ``create_app`` calls ``configure_logging(cfg)`` which, when
+      ``test_mode=False``, reconfigures structlog into production mode
+      (logger caching + ``sys.stdout`` pin). Running that in-process
+      would break subsequent ``capsys``-based tests (see
+      ``test_logging_setup_test_mode.py`` for the failure mode).
+    """
+
+    import os
+    import subprocess
+    import sys
+
+    env = os.environ.copy()
+    env.pop("ANTHROPIC_API_KEY", None)
+    env["TEST_MODE"] = "false"
+    env.setdefault("SESSION_SECRET", "x" * 32)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import app.main"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, (
+        "Expected import of ``app.main`` to fail with a non-zero exit, "
+        f"got {result.returncode}.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "ANTHROPIC_API_KEY" in result.stderr, (
+        "Error message must name the missing variable so the operator "
+        f"knows what to fix. stderr:\n{result.stderr}"
+    )
 
 
 def test_app_boots_with_empty_env_vars(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -418,6 +418,28 @@ def test_empty_env_vars_fall_back_to_defaults(
     assert resolved.endswith("backend/scenarios")
 
 
+def test_create_app_refuses_without_anthropic_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #118: ``create_app()`` must raise at import / construction time
+    when ``ANTHROPIC_API_KEY`` is unset and ``TEST_MODE`` is off. Pre-fix the
+    check lived in the lifespan, so uvicorn printed ``Started server
+    process``, swallowed the lifespan traceback, then exited with code 0 —
+    silently restart-looping under ``docker compose restart: unless-stopped``.
+    Failing eagerly in ``create_app`` propagates as an import-time exception
+    and uvicorn exits non-zero."""
+
+    from app.config import reset_settings_cache
+    from app.main import create_app
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("TEST_MODE", "false")
+    reset_settings_cache()
+
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+        create_app()
+
+
 def test_app_boots_with_empty_env_vars(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Moves the `ANTHROPIC_API_KEY` runtime check from the FastAPI lifespan into `create_app()` itself, so it fires at module import time before uvicorn binds the port.
- Adds a structured `anthropic_api_key_present` log line on the success path so operators can confirm from the boot log that the gate ran.
- Adds a regression test asserting `create_app()` raises when the key is unset and `TEST_MODE` is off.

Closes #118.

### Why

Pre-fix, when `ANTHROPIC_API_KEY` was unset, uvicorn printed `Started server process`, then ran the lifespan, raised `RuntimeError`, printed the traceback through starlette internals, and exited with code 0. Under `docker compose restart: unless-stopped` that produced a silent restart loop with no clear surfaced error — the app appeared to "start" while never actually serving requests.

Post-fix, `app = create_app()` at module level raises immediately on import, uvicorn never binds the port, and the process exits **non-zero** with a clear single-line error pointing the operator at the missing variable.

### Sub-agent reviews

Per CLAUDE.md, six reviews ran in parallel:

| Agent | Result |
|---|---|
| QA | 1 MEDIUM (already handled by autouse `_reset_settings_singleton` in conftest), 2 LOW |
| Security | 1 HIGH (debuggability — missing success-path log line) — **fixed** |
| Product | clean |
| UI/UX | out of scope (no UI changes) |
| User persona | 1 HIGH about `restart: unless-stopped` still tight-looping on fatal config errors |
| Prompt expert | out of scope (no prompt changes) |

**Deferred:** the user-persona HIGH is an orchestration-layer concern — the app-level fix is strictly better than the silent exit-0 it replaced, and changing the compose restart policy has its own tradeoffs for production transient failures. Tracked separately.

## Test plan

- [x] `pytest -q` passes (491 passed, 40 skipped)
- [x] `ruff check .` clean
- [x] `mypy app` clean
- [x] Manual: `env -u ANTHROPIC_API_KEY uvicorn app.main:app` exits non-zero with `RuntimeError: ANTHROPIC_API_KEY is required.` and **does not** print `Started server process`
- [x] Manual: `ANTHROPIC_API_KEY=fake uvicorn app.main:app` still starts normally
- [x] Manual: `TEST_MODE=true uvicorn app.main:app` still starts normally (key check skipped)
- [x] New test `test_create_app_refuses_without_anthropic_api_key` asserts the eager-raise behavior

https://claude.ai/code/session_013a66iak2Do8b86xgMHDKB4

---
_Generated by [Claude Code](https://claude.ai/code/session_013a66iak2Do8b86xgMHDKB4)_