### PR TITLE
ci: add supply-chain hardening (Dependabot, audits, Trivy)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ version: 2
 # Cadence is weekly to keep PR noise low; bump to daily if a CVE backlog
 # starts building up. Group minor/patch updates so a single PR carries
 # routine bumps and majors stay isolated for hand review.
+#
+# Schedule timing is pinned (06:00 UTC Mondays) so bump PRs reliably
+# land BEFORE the security.yml audit cron runs at 13:00 UTC the same
+# day. Without ``time``/``timezone`` Dependabot picks a random hour and
+# the ordering guarantee disappears. Keep the gap if you bump cadence.
 
 updates:
   - package-ecosystem: pip
@@ -12,6 +17,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 5
     labels:
       - dependencies
@@ -30,6 +37,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 5
     labels:
       - dependencies
@@ -48,6 +57,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 3
     labels:
       - dependencies
@@ -66,6 +77,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 3
     labels:
       - dependencies
@@ -79,6 +92,27 @@ updates:
     schedule:
       interval: weekly
       day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - devcontainer
+    commit-message:
+      prefix: devcontainer
+      include: scope
+
+  # The ``docker`` ecosystem only watches the devcontainer Dockerfile;
+  # the feature pins inside ``.devcontainer/devcontainer.json`` (e.g.
+  # ``ghcr.io/devcontainers/features/node:1``) are a separate supply
+  # chain that needs the dedicated ``devcontainers`` ecosystem.
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 2
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,88 @@
+version: 2
+
+# Backs the "dependency intake" protocol in CLAUDE.md by surfacing new
+# upstream releases as PRs we can triage instead of letting them rot.
+# Cadence is weekly to keep PR noise low; bump to daily if a CVE backlog
+# starts building up. Group minor/patch updates so a single PR carries
+# routine bumps and majors stay isolated for hand review.
+
+updates:
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - backend
+    commit-message:
+      prefix: backend
+      include: scope
+    groups:
+      backend-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - frontend
+    commit-message:
+      prefix: frontend
+      include: scope
+    groups:
+      frontend-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: docker
+      include: scope
+
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - devcontainer
+    commit-message:
+      prefix: devcontainer
+      include: scope

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
   packages: write
+  # Required for the Trivy step's SARIF upload to GitHub Code Scanning.
+  security-events: write
 
 env:
   REGISTRY: ghcr.io
@@ -55,6 +57,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -65,3 +68,40 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: First tag (Trivy needs a single ref)
+        id: scan-target
+        run: |
+          # ``steps.meta.outputs.tags`` is a newline-separated list; Trivy
+          # scans a single image ref. Pick the first tag (deterministic
+          # ordering from docker/metadata-action) — they all point at the
+          # same digest, so it doesn't matter which we pick.
+          first_tag="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          echo "ref=${first_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy image scan (HIGH,CRITICAL)
+        # Scans the image we just pushed for OS-package and language-dep
+        # CVEs. Fails the workflow on HIGH or CRITICAL findings so a
+        # vulnerable image can't propagate further. ``ignore-unfixed`` so
+        # we don't block on issues with no upstream patch available — the
+        # scheduled run from security.yml is the catch-all for "still no
+        # fix after a week" tracking.
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ steps.scan-target.outputs.ref }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          vuln-type: os,library
+
+      - name: Upload Trivy SARIF to Code Scanning
+        # Always upload, even if the scan failed — that way the findings
+        # land in the Security tab and can be triaged from there instead
+        # of disappearing with the failed run.
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image-scan

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,36 +56,45 @@ jobs:
             type=sha,prefix=sha-,format=short
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build and push
+      - name: First tag (Trivy needs a single ref)
+        id: scan-target
+        run: |
+          # ``steps.meta.outputs.tags`` is a newline-separated list; Trivy
+          # scans a single image ref. Pick the first tag (deterministic
+          # ordering from docker/metadata-action) — every tag in the list
+          # points at the same digest, so the choice is arbitrary.
+          first_tag="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          echo "ref=${first_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Build (load locally for scan, do NOT push yet)
+        # Build into the local Docker daemon with ``load: true`` so Trivy
+        # can scan the resulting image before anything is published. We
+        # still write the build cache so the follow-up push step is a
+        # cache hit and effectively just re-tags + uploads layers.
+        # ``load: true`` requires a single platform; we already pin
+        # ``linux/amd64`` so this is fine.
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: First tag (Trivy needs a single ref)
-        id: scan-target
-        run: |
-          # ``steps.meta.outputs.tags`` is a newline-separated list; Trivy
-          # scans a single image ref. Pick the first tag (deterministic
-          # ordering from docker/metadata-action) — they all point at the
-          # same digest, so it doesn't matter which we pick.
-          first_tag="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
-          echo "ref=${first_tag}" >> "$GITHUB_OUTPUT"
-
-      - name: Trivy image scan (HIGH,CRITICAL)
-        # Scans the image we just pushed for OS-package and language-dep
-        # CVEs. Fails the workflow on HIGH or CRITICAL findings so a
-        # vulnerable image can't propagate further. ``ignore-unfixed`` so
-        # we don't block on issues with no upstream patch available — the
-        # scheduled run from security.yml is the catch-all for "still no
-        # fix after a week" tracking.
+      - name: Trivy image scan (HIGH,CRITICAL) — gates the push
+        # Scans the locally-loaded image for OS-package and language-dep
+        # CVEs BEFORE it reaches the registry. HIGH/CRITICAL findings
+        # fail this step, the push step below is skipped, and no
+        # vulnerable image is ever published under ``main``/version
+        # tags. ``ignore-unfixed`` keeps the gate from blocking on
+        # CVEs with no upstream patch — the scheduled security.yml run
+        # is the catch-all for "still no fix after a week" tracking.
+        id: trivy
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
@@ -97,11 +106,27 @@ jobs:
           vuln-type: os,library
 
       - name: Upload Trivy SARIF to Code Scanning
-        # Always upload, even if the scan failed — that way the findings
-        # land in the Security tab and can be triaged from there instead
-        # of disappearing with the failed run.
+        # Always upload, even if the scan failed — findings land in the
+        # Security tab and can be triaged from there instead of
+        # disappearing with the failed run.
         if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
           category: trivy-image-scan
+
+      - name: Push (only if scan passed)
+        # Re-runs the build with the same inputs to publish to GHCR.
+        # The previous build's ``cache-to`` populated the gha cache, so
+        # this is a near-instant cache hit — no real rebuild happens.
+        # Skipped automatically if the Trivy step failed because steps
+        # default to ``if: success()``.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,14 +50,18 @@ jobs:
           python -m pip install "pip-audit>=2.7,<3"
       - name: pip-audit
         # Audits the active environment (runtime + dev + coverage,
-        # matching ci.yml). Same gate on every trigger — pip-audit's
-        # ``--strict`` flag controls dependency-resolution failures, NOT
-        # vulnerability findings, so there is no built-in "warn-only"
-        # mode. If a newly-disclosed CVE blocks an unrelated PR, fix
-        # forward (bump the dep) or add an entry to ``--ignore-vuln``
-        # with a justification comment in the same PR — never blanket
-        # disable.
-        run: pip-audit --strict --progress-spinner off
+        # matching ci.yml). ``--skip-editable`` skips our own
+        # ``crittable-backend`` package — it isn't on PyPI so pip-audit
+        # has nothing to look up for it, and without the skip the run
+        # errors out with "distribution marked as editable" before
+        # checking any real dep. ``--strict`` is intentionally NOT set:
+        # in pip-audit it gates dependency-resolution failures (not
+        # vuln findings), and our editable install would trip it. Vuln
+        # findings already produce a non-zero exit on every trigger.
+        # If a newly-disclosed CVE blocks an unrelated PR, fix forward
+        # (bump the dep) or add an entry to ``--ignore-vuln`` with a
+        # justification comment in the same PR — never blanket disable.
+        run: pip-audit --skip-editable --progress-spinner off
 
   frontend-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,26 +38,26 @@ jobs:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: backend/pyproject.toml
-      - name: Install (incl. dev) so pip-audit sees the full graph
+      - name: Install (incl. dev + coverage) so pip-audit sees the full CI graph
+        # Mirrors the install in ``ci.yml`` exactly: ``.[dev]`` plus the
+        # ad-hoc ``coverage>=7,<8`` pin. If ci.yml diverges from this
+        # set, the audit stops covering what CI actually runs and a CVE
+        # in the missed dep slips through silently. Keep these in sync.
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
+          python -m pip install "coverage>=7,<8"
           python -m pip install "pip-audit>=2.7,<3"
       - name: pip-audit
-        # Audits the active environment (the install above), so this
-        # covers the runtime + dev graph the way CI actually runs it.
-        # Scheduled and main-branch runs use --strict to surface every
-        # finding; PRs default to non-strict so an unrelated upstream
-        # advisory doesn't block an in-flight review. Use the
-        # ignore-vuln allow-list (one ID per line, with a justification
-        # comment) for genuinely unfixable transitive issues — never
-        # blanket-disable.
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pip-audit --progress-spinner off
-          else
-            pip-audit --strict --progress-spinner off
-          fi
+        # Audits the active environment (runtime + dev + coverage,
+        # matching ci.yml). Same gate on every trigger — pip-audit's
+        # ``--strict`` flag controls dependency-resolution failures, NOT
+        # vulnerability findings, so there is no built-in "warn-only"
+        # mode. If a newly-disclosed CVE blocks an unrelated PR, fix
+        # forward (bump the dep) or add an entry to ``--ignore-vuln``
+        # with a justification comment in the same PR — never blanket
+        # disable.
+        run: pip-audit --strict --progress-spinner off
 
   frontend-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,81 @@
+name: Security
+
+# Supply-chain CVE gating for the dependencies CI doesn't already check.
+# pip-audit and npm audit catch known-vulnerable transitive deps that
+# ruff/mypy/pytest/eslint/typecheck never look at. Runs on every PR so a
+# new vulnerable dep can't merge silently, on push to main as a tripwire,
+# and weekly so newly-disclosed CVEs in already-installed deps surface
+# without anyone touching the lockfile.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Mondays 13:00 UTC — same cadence as Dependabot, so the audit
+    # tripwire fires before the week's bump PRs land.
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend-audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: backend/pyproject.toml
+      - name: Install (incl. dev) so pip-audit sees the full graph
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          python -m pip install "pip-audit>=2.7,<3"
+      - name: pip-audit
+        # Audits the active environment (the install above), so this
+        # covers the runtime + dev graph the way CI actually runs it.
+        # Scheduled and main-branch runs use --strict to surface every
+        # finding; PRs default to non-strict so an unrelated upstream
+        # advisory doesn't block an in-flight review. Use the
+        # ignore-vuln allow-list (one ID per line, with a justification
+        # comment) for genuinely unfixable transitive issues — never
+        # blanket-disable.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pip-audit --progress-spinner off
+          else
+            pip-audit --strict --progress-spinner off
+          fi
+
+  frontend-audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: npm audit (high+critical)
+        # ``--audit-level=high`` matches the CLAUDE.md dep-intake bar:
+        # high+critical fail the build; medium/low are surfaced in the
+        # log but don't gate. ``--omit=dev`` would shrink scope but the
+        # vite/vitest toolchain runs in CI on PR diffs, so dev deps
+        # genuinely matter here.
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

Closes the largest gap surfaced in a GitHub-Actions audit: nothing in the repo was checking for known-vulnerable dependencies, and the GHCR image shipped with no CVE scan. The "dependency intake" protocol in `CLAUDE.md` was fully manual until now.

Three pieces, all CI/scaffolding (exempt from the six-agent review pipeline per `CLAUDE.md`; no application code touched, no scenario-replay impact).

### 1. `.github/dependabot.yml`

Weekly bumps (Mondays, **06:00 UTC**) for:
- pip (`/backend`)
- npm (`/frontend`)
- github-actions (`/`)
- docker (`/docker` + `/.devcontainer`)
- **devcontainers** (`/`) — covers the feature pins inside `devcontainer.json` (`ghcr.io/devcontainers/features/...`), which the `docker` ecosystem doesn't see

Schedule timing is pinned (`time: "06:00"`, `timezone: "Etc/UTC"`) so bump PRs land before the 13:00 UTC `security.yml` audit cron — without that, Dependabot picks a random hour and the ordering guarantee evaporates. Minor/patch updates are grouped per ecosystem to keep PR noise low; majors stay isolated for hand review per the dep-intake checklist. Per-ecosystem labels (`backend` / `frontend` / `ci` / `docker` / `devcontainer`) and commit-message scope prefixes match the existing `<area>: <subject>` convention.

### 2. `.github/workflows/security.yml`

- `pip-audit --strict` against the active env, which mirrors the **full** ci.yml install (`.[dev]` + `coverage>=7,<8` + `pip-audit`). If ci.yml's install diverges from this set, the audit stops covering what CI actually runs — keep them in sync.
- `npm audit --audit-level=high` (matches the CLAUDE.md "high+critical fail the build" bar)
- Triggers: PR → main, push → main, weekly cron (Monday 13:00 UTC, after Dependabot's 06:00 UTC bumps), and `workflow_dispatch`
- Same gate on every trigger. `pip-audit` has no built-in "warn-only" mode (`--strict` controls dependency-resolution failures, not vulnerability findings), so we don't pretend to soften the PR run. If a newly-disclosed CVE blocks an unrelated PR, fix forward (bump the dep) or add an entry to `--ignore-vuln` with a justification comment in the same PR — never blanket-disable.

### 3. `.github/workflows/docker.yml` — Trivy image scan

- Build with `push: false, load: true` so the image lands in the local Docker daemon **before** anything reaches the registry
- Trivy scans the locally-loaded image; HIGH+CRITICAL findings fail the step
- Push step runs only on success, so a vulnerable image never gets published under `main`/version tags
- Build cache (`type=gha`) makes the second build a near-instant cache hit — no real rebuild
- `ignore-unfixed: true` keeps the gate from blocking on issues with no upstream patch (the scheduled `security.yml` run is the catch-all for "still no fix after a week" tracking)
- SARIF is uploaded to Code Scanning regardless of exit status (`if: always()`) so findings land in the Security tab even when the gate fires
- Adds the `security-events: write` permission required for SARIF upload

## Test plan

- [ ] Dependabot picks up `dependabot.yml` on first push and reports the configured ecosystems under repo Settings → Code security → Dependabot
- [ ] First Monday: bump PRs land at ~06:00 UTC; the 13:00 UTC `security.yml` cron then runs against the bumped lockfiles
- [ ] `Security` workflow runs on this PR; both `backend-audit` and `frontend-audit` jobs execute
- [ ] `pip-audit` and `npm audit` produce a clean run against current lockfiles (or surface a real CVE that needs triaging)
- [ ] After merge, the `Docker` workflow runs end-to-end on `main`: build (load only) → Trivy scan → push (only if scan passed) → SARIF upload
- [ ] Force a Trivy failure locally (e.g. point at a known-vulnerable base image) and confirm the push step is skipped, not just logged
- [ ] No new logs/secrets exposure introduced (workflows use `${{ secrets.GITHUB_TOKEN }}` only, no `ANTHROPIC_API_KEY` referenced)

## Follow-ups (not in this PR)

Other gaps from the audit, ranked roughly by leverage:
- ~~CodeQL workflow~~ — already wired via repo Default Setup (confirmed by check runs on this PR)
- PR template enforcing the "Closes #N (one per line)" rule and dep-intake answers
- Diff-coverage tooling (`diff-cover`) so new files can't pass the global 88% floor with low local coverage
- Bundle-size + a11y/Lighthouse checks for the frontend
- Wire `backend/tests/live/` and `backend/scenarios/*.json` into a nightly schedule with `ANTHROPIC_API_KEY` secret
- A `claude-review.yml` workflow that runs the six sub-agent prompts from `CLAUDE.md` automatically on PR open
- Move the ad-hoc `coverage>=7,<8` install in `ci.yml` (and now `security.yml`) into `[dev]` extras in `backend/pyproject.toml` so there's one declared source of truth