### PR TITLE
chat-declutter: Phase B filter chrome (visible transcript filters)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -322,6 +322,17 @@ def register_api_routes(app: FastAPI) -> None:
                     # Issue #78: True for out-of-turn interjections so
                     # the transcript UI can render a "sidebar" badge.
                     "is_interjection": m.is_interjection,
+                    # Phase B chat-declutter (docs/plans/chat-decluttering.md
+                    # §4.7): the frontend's TranscriptFilters and the
+                    # colored track-bar stripe both read ``workstream_id``
+                    # off this snapshot field. ``None`` = synthetic
+                    # ``#main`` bucket (slate gray stripe). The
+                    # @-highlight + ``(@you)`` badge similarly reads
+                    # ``mentions`` here so a reconnecting tab can recolor
+                    # bubbles from the snapshot alone (no replay buffer
+                    # round-trip required).
+                    "workstream_id": m.workstream_id,
+                    "mentions": list(m.mentions),
                 }
                 for m in session.visible_messages(token["role_id"])
             ],
@@ -348,6 +359,21 @@ def register_api_routes(app: FastAPI) -> None:
             # sidebar Download-AAR button without hitting /export.md early
             # and seeing a 425.
             "aar_status": session.aar_status,
+            # Phase B chat-declutter (docs/plans/chat-decluttering.md §4.1):
+            # the declared-workstreams registry is visible to every
+            # participant (not just the creator) because the
+            # TranscriptFilters pills + colored stripe palette assignment
+            # read off this list — a player needs the same registry the
+            # creator does to filter their own view. ``plan`` itself stays
+            # creator-only (it leaks objectives + injects); we surface
+            # only the workstream rows here, which were always intended to
+            # be a player-visible UI affordance per plan §6.1. Empty list
+            # when no workstreams declared (or feature flag off).
+            "workstreams": (
+                [ws.model_dump(mode="json") for ws in session.plan.workstreams]
+                if session.plan is not None
+                else []
+            ),
             # Per-role follow-up todo list maintained by the AI. Creator-
             # only because seeing other roles' open asks could spoil the
             # narrative. Each item: {id, role_id, prompt, status,

--- a/backend/app/llm/dispatch.py
+++ b/backend/app/llm/dispatch.py
@@ -521,6 +521,17 @@ class ToolDispatcher:
                     "pose_choice requires 2–5 options; "
                     f"got {len(options)}."
                 )
+            # Phase B chat-declutter (plan §3.1): same shape as
+            # ``address_role.workstream_id`` — invalid value triggers
+            # ``is_error=True`` so the strict-retry loop can recover.
+            workstream_id = _validate_workstream_id(
+                session=session,
+                value=args.get("workstream_id"),
+                workstreams_enabled=self._workstreams_enabled,
+                tool_name="pose_choice",
+                session_id=session.id,
+            )
+            args["workstream_id"] = workstream_id
             letters = ["A", "B", "C", "D", "E"]
             option_lines = "\n".join(
                 f"**{letters[i]}.** {opt}" for i, opt in enumerate(options)
@@ -533,6 +544,14 @@ class ToolDispatcher:
                     turn_id=turn_id,
                     tool_name=name,
                     tool_args=args,
+                    workstream_id=workstream_id,
+                    # Phase B chat-declutter (plan §5.1): pose_choice
+                    # is single-addressee like ``address_role`` — stamp
+                    # the target as a structural mention so the
+                    # @-highlight and "(@you)" badge fire even though
+                    # the body's first token is the role label rather
+                    # than ``@<label>``.
+                    mentions=[target_id],
                 )
             )
             outcome.had_player_facing_message = True
@@ -547,6 +566,19 @@ class ToolDispatcher:
             # affordances and so the timeline can show "data shared".
             label = str(args.get("label", "")).strip()
             data = str(args.get("data", ""))
+            # Phase B chat-declutter (plan §3.1): data shares are
+            # often genuinely cross-cutting (an IOC dump can be
+            # relevant to two workstreams) — the field is optional and
+            # the model is expected to omit it for cross-cutting
+            # dumps. Same validation seam as the other three.
+            workstream_id = _validate_workstream_id(
+                session=session,
+                value=args.get("workstream_id"),
+                workstreams_enabled=self._workstreams_enabled,
+                tool_name="share_data",
+                session_id=session.id,
+            )
+            args["workstream_id"] = workstream_id
             if label:
                 body = f"**{label}**\n\n{data}"
             else:
@@ -558,6 +590,7 @@ class ToolDispatcher:
                     turn_id=turn_id,
                     tool_name=name,
                     tool_args=args,
+                    workstream_id=workstream_id,
                 )
             )
             outcome.had_player_facing_message = True
@@ -650,6 +683,21 @@ class ToolDispatcher:
             allowed = await _maybe_call(critical_inject_allowed_cb)
             if not allowed:
                 raise _DispatchError("critical-event rate limit hit")
+            # Phase B chat-declutter (plan §3.1): most injects target
+            # one workstream (press inject → Comms; new IOC →
+            # Containment), so the field is meaningful here. Validation
+            # runs BEFORE the WS broadcast so a bad value still raises
+            # as a strict-retryable tool error rather than fanning out
+            # a half-formed critical_event the frontend would have to
+            # retract.
+            workstream_id = _validate_workstream_id(
+                session=session,
+                value=args.get("workstream_id"),
+                workstreams_enabled=self._workstreams_enabled,
+                tool_name="inject_critical_event",
+                session_id=session.id,
+            )
+            args["workstream_id"] = workstream_id
             body_text = (
                 f"[{args.get('severity','HIGH')}] {args.get('headline','')} — "
                 f"{args.get('body','')}"
@@ -661,6 +709,7 @@ class ToolDispatcher:
                     turn_id=turn_id,
                     tool_name=name,
                     tool_args=args,
+                    workstream_id=workstream_id,
                 )
             )
             outcome.critical_inject_fired = True
@@ -919,14 +968,23 @@ def _validate_workstream_id(
         # what ``/setup/reply`` surfaces back to the creator); the
         # structured code rides alongside as ``reason_code`` so neither
         # consumer is starved.
+        #
+        # Security review LOW: clip the unknown value before echoing
+        # it back to the model and the audit log. The strict-retry
+        # loop replays the prose to the model on its next call, so an
+        # adversarial / hallucinated multi-KB ``workstream_id`` would
+        # otherwise fan out across the audit ring AND inflate the
+        # next prompt. 120 chars is a generous upper bound for a
+        # legit slug-shaped id; longer values are bugs anyway.
+        clipped = value if len(value) <= 120 else f"{value[:120]}…"
         raise _DispatchError(
-            f"unknown workstream_id {value!r} on {tool_name}. Known: "
+            f"unknown workstream_id {clipped!r} on {tool_name}. Known: "
             f"{', '.join(known)}. Pass an id from your earlier "
             "declare_workstreams call, or omit the field for a "
             "cross-cutting beat.",
             audit_extras={
                 "reason_code": "unknown_workstream_id",
-                "attempted": value,
+                "attempted": clipped,
                 "known": known,
             },
         )

--- a/backend/app/llm/prompts.py
+++ b/backend/app/llm/prompts.py
@@ -446,7 +446,8 @@ _GUARDRAIL_CLASSIFIER = (
 
 
 _WORKSTREAMS_PLAY_NOTE = (
-    "\n\n**Workstream metadata.** `address_role` accepts an optional "
+    "\n\n**Workstream metadata.** `address_role`, `pose_choice`, "
+    "`share_data`, and `inject_critical_event` each accept an optional "
     "`workstream_id` from the set declared in setup. Use it when the "
     "beat clearly belongs to one workstream; omit for cross-cutting "
     "beats. UI-filter affordance, not a play-correctness requirement."

--- a/backend/app/llm/tools.py
+++ b/backend/app/llm/tools.py
@@ -57,6 +57,35 @@ _SCENARIO_INJECT_SCHEMA: dict[str, Any] = {
     "required": ["trigger", "type", "summary"],
 }
 
+
+# Phase B chat-declutter (docs/plans/chat-decluttering.md §3.1):
+# shared optional ``workstream_id`` field used by every routing tool
+# that can reasonably belong to one of the session's declared
+# workstreams (``address_role`` / ``pose_choice`` / ``share_data`` /
+# ``inject_critical_event``). Centralised so future schema tweaks
+# (rewordings, additional constraints) only happen in one place — the
+# Prompt Expert review specifically asked we don't let the four
+# descriptions drift across tools.
+#
+# Strict enum on the *value* is intentionally NOT in the JSON schema:
+# the dispatch-time validator (``_validate_workstream_id``) returns a
+# structured ``tool_result is_error=True`` instead so the strict-retry
+# loop can recover (per plan §4.5), rather than the schema-validation
+# layer rejecting before the model gets a chance to self-correct.
+_WORKSTREAM_ID_FIELD: dict[str, Any] = {
+    "type": "string",
+    "description": (
+        "Optional. Workstream this beat belongs to. Must match an id "
+        "from the session's declared workstreams (declared during "
+        "setup). Omit (or pass empty string) for cross-cutting / "
+        "general beats; the message renders under the default "
+        "unscoped bucket. **If no workstreams were declared for this "
+        "session, OMIT this field on every call — do not invent "
+        "values.** UI-filter affordance only; not load-bearing for "
+        "play correctness."
+    ),
+}
+
 PLAY_TOOLS: list[dict[str, Any]] = [
     {
         "name": "address_role",
@@ -79,20 +108,7 @@ PLAY_TOOLS: list[dict[str, Any]] = [
             "properties": {
                 "role_id": {"type": "string"},
                 "message": {"type": "string"},
-                "workstream_id": {
-                    "type": "string",
-                    "description": (
-                        "Optional. Workstream this beat belongs to. Must "
-                        "match an id from the session's declared workstreams "
-                        "(declared during setup). Omit (or pass empty string) "
-                        "for cross-cutting / general beats; the message "
-                        "renders under the default unscoped bucket. **If no "
-                        "workstreams were declared for this session, OMIT "
-                        "this field on every call — do not invent values.** "
-                        "UI-filter affordance only; not load-bearing for "
-                        "play correctness."
-                    ),
-                },
+                "workstream_id": _WORKSTREAM_ID_FIELD,
             },
             "required": ["role_id", "message"],
         },
@@ -180,6 +196,7 @@ PLAY_TOOLS: list[dict[str, Any]] = [
                     "minItems": 2,
                     "maxItems": 5,
                 },
+                "workstream_id": _WORKSTREAM_ID_FIELD,
             },
             "required": ["role_id", "question", "options"],
         },
@@ -219,6 +236,7 @@ PLAY_TOOLS: list[dict[str, Any]] = [
             "properties": {
                 "label": {"type": "string"},
                 "data": {"type": "string"},
+                "workstream_id": _WORKSTREAM_ID_FIELD,
             },
             "required": ["label", "data"],
         },
@@ -248,6 +266,7 @@ PLAY_TOOLS: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                 },
+                "workstream_id": _WORKSTREAM_ID_FIELD,
             },
             "required": ["severity", "headline", "body"],
         },

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -63,6 +63,43 @@ def _is_oversized(value: Any) -> bool:
     return False
 
 
+def _inherit_workstream_id(session: Session, *, role_id: str) -> str | None:
+    """Phase B chat-declutter (docs/plans/chat-decluttering.md §4.4):
+    resolve the workstream_id a player's reply should inherit.
+
+    Two of the four documented rules are implemented in Phase B —
+    the explicit-tag rule (#1) requires the composer ``#tag``
+    autocomplete (Phase C), and the lead_role_id fallback (#3)
+    requires lead-role lookup against open workstreams. The most
+    impactful rule for the visible filter chrome is #2 ("most recent
+    AI message addressing this player"), which is what this helper
+    implements; #4 ("otherwise None") falls out as the default
+    return.
+
+    The walk is bounded by the session's existing message log size
+    (already memory-resident) and short-circuits on the first match,
+    so it's O(N) worst-case per submission with N capped at the
+    session's history. We deliberately don't memoize: the cost is
+    negligible against the sub-millisecond budget for ``submit_response``,
+    and a stale memo would silently corrupt inheritance after a turn
+    flips.
+
+    The dispatch layer guarantees that AI messages produced by
+    ``address_role`` and ``pose_choice`` carry exactly one role_id in
+    their ``mentions`` list (the addressee), so a reverse-walk
+    matching ``role_id in msg.mentions`` is the correct addressing
+    predicate. Pre-Phase-A messages have empty ``mentions`` lists and
+    fail the predicate, so they're safely ignored.
+    """
+
+    for msg in reversed(session.messages):
+        if msg.kind != MessageKind.AI_TEXT:
+            continue
+        if role_id in msg.mentions:
+            return msg.workstream_id
+    return None
+
+
 class SessionManager:
     def __init__(
         self,
@@ -733,6 +770,15 @@ class SessionManager:
                     turn_index=turn.index,
                 )
             self._enforce_dedupe_window(session, role_id=role_id, content=content)
+            # Phase B chat-declutter (docs/plans/chat-decluttering.md
+            # §4.4): inherit the most recent AI-addressed-to-me
+            # workstream so a player's reply lands under the same
+            # track filter as the prompt that drove it. ``None`` if
+            # no such message exists (or the addressing AI message
+            # was cross-cutting).
+            inherited_workstream_id = _inherit_workstream_id(
+                session, role_id=role_id
+            )
             session.messages.append(
                 Message(
                     kind=MessageKind.PLAYER,
@@ -749,6 +795,7 @@ class SessionManager:
                     # Wave 2: cleaned by the submission pipeline; the
                     # raw wire payload never reaches this layer.
                     mentions=list(mentions) if mentions else [],
+                    workstream_id=inherited_workstream_id,
                 )
             )
             walked_back = False
@@ -825,11 +872,12 @@ class SessionManager:
                 # ready_role_ids. ``None`` for interjections (intent
                 # doesn't apply to out-of-turn posts).
                 "intent": intent if is_turn_submission else None,
-                # Phase A chat-declutter (plan §4.8). Player-side
-                # workstream-id inheritance (§4.4) lands in a later
-                # phase; for Phase A every player message reports
-                # ``None`` (the synthetic ``#main`` bucket).
-                "workstream_id": None,
+                # Phase B chat-declutter (plan §4.4 / §4.8): the
+                # message we just appended carries the inherited
+                # workstream — surface it on the broadcast so the
+                # frontend's TranscriptFilters track pills and the
+                # 3 px stripe stay consistent with the snapshot.
+                "workstream_id": inherited_workstream_id,
                 # Wave 2: cleaned by the submission pipeline; clients
                 # render the @-highlight from this list rather than
                 # regex-scanning the body.
@@ -1001,6 +1049,14 @@ class SessionManager:
             self._enforce_dedupe_window(
                 session, role_id=as_role_id, content=content
             )
+            # Phase B chat-declutter (plan §4.4): proxy path inherits
+            # the workstream the same way the regular submit path does
+            # — symmetry matters because creators using proxy_respond
+            # for solo-test runs would otherwise see their proxy
+            # messages permanently in #main.
+            inherited_workstream_id = _inherit_workstream_id(
+                session, role_id=as_role_id
+            )
             session.messages.append(
                 Message(
                     kind=MessageKind.PLAYER,
@@ -1012,6 +1068,7 @@ class SessionManager:
                     # Wave 2: mirror ``submit_response``. The REST
                     # proxy endpoint validates before this layer.
                     mentions=list(mentions) if mentions else [],
+                    workstream_id=inherited_workstream_id,
                 )
             )
             if is_turn_submission:
@@ -1050,9 +1107,8 @@ class SessionManager:
                 "body": content,
                 "is_interjection": not is_turn_submission,
                 "intent": intent if is_turn_submission else None,
-                # Phase A chat-declutter (plan §4.8). Same shape as
-                # ``submit_response`` above.
-                "workstream_id": None,
+                # Phase B chat-declutter (plan §4.4): inherited above.
+                "workstream_id": inherited_workstream_id,
                 # Wave 2: same source as ``submit_response``. The
                 # REST proxy validates the wire payload first.
                 "mentions": list(mentions) if mentions else [],
@@ -1128,6 +1184,13 @@ class SessionManager:
                 # only would block forever.
                 if rid not in turn.ready_role_ids:
                     turn.ready_role_ids.append(rid)
+                # Phase B chat-declutter (plan §4.4): each filled
+                # seat inherits the workstream of the most recent AI
+                # message addressing that role. The fill is N
+                # independent inheritances, not N copies of the same
+                # value — different roles may have been addressed by
+                # different workstream-tagged AI messages.
+                inherited = _inherit_workstream_id(session, role_id=rid)
                 session.messages.append(
                     Message(
                         kind=MessageKind.PLAYER,
@@ -1135,6 +1198,7 @@ class SessionManager:
                         body=content,
                         turn_id=turn.id,
                         intent="ready",
+                        workstream_id=inherited,
                     )
                 )
                 filled.append(rid)
@@ -1144,6 +1208,22 @@ class SessionManager:
                 session.state = SessionState.AI_PROCESSING
             await self._repo.save(session)
         for rid in filled:
+            # Re-resolve the inheritance against the persisted state
+            # so the broadcast carries the same value the persisted
+            # message did (no race between append and broadcast).
+            broadcast_msg = next(
+                (
+                    m
+                    for m in reversed(session.messages)
+                    if m.kind == MessageKind.PLAYER
+                    and m.role_id == rid
+                    and m.body == content
+                ),
+                None,
+            )
+            inherited_for_rid = (
+                broadcast_msg.workstream_id if broadcast_msg else None
+            )
             await self.connections().broadcast(
                 session_id,
                 {
@@ -1156,8 +1236,9 @@ class SessionManager:
                     # the whole point of the helper — auto-advance the
                     # turn).
                     "intent": "ready",
-                    # Phase A chat-declutter (plan §4.8).
-                    "workstream_id": None,
+                    # Phase B chat-declutter (plan §4.4): inherited
+                    # from the persisted message above.
+                    "workstream_id": inherited_for_rid,
                     "mentions": [],
                 },
             )

--- a/backend/tests/test_chat_declutter_phase_b.py
+++ b/backend/tests/test_chat_declutter_phase_b.py
@@ -14,7 +14,7 @@ in ``test_chat_declutter_phase_a.py``; this file is dispatch-side only.
 
 The frontend filter logic + UI components are tested in the frontend
 suite under ``frontend/src/__tests__/transcriptFilters.test.ts`` and
-``transcriptFiltersUI.test.tsx``.
+``TranscriptFilters.test.tsx``.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_chat_declutter_phase_b.py
+++ b/backend/tests/test_chat_declutter_phase_b.py
@@ -1,0 +1,450 @@
+"""Phase B chat-declutter regression tests.
+
+Phase B (docs/plans/chat-decluttering.md §3.1, §4.7) extends the
+``workstream_id`` validation from Phase A's ``address_role`` to three
+more routing tools — ``pose_choice``, ``share_data``, and
+``inject_critical_event``. The dispatch path is shared
+(``_validate_workstream_id``) so the four branches collapse onto the
+same set of tests; what's new in this file is wiring each tool through
+that path and asserting the message stamp + ``tool_args``
+canonicalization.
+
+The schema-shape tests live alongside the existing Phase A schema tests
+in ``test_chat_declutter_phase_a.py``; this file is dispatch-side only.
+
+The frontend filter logic + UI components are tested in the frontend
+suite under ``frontend/src/__tests__/transcriptFilters.test.ts`` and
+``transcriptFiltersUI.test.tsx``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.auth.audit import AuditLog
+from app.extensions.dispatch import ExtensionDispatcher
+from app.extensions.models import ExtensionBundle
+from app.extensions.registry import freeze_bundle
+from app.llm.dispatch import ToolDispatcher
+from app.llm.tools import PLAY_TOOLS
+from app.sessions.models import (
+    Message,
+    MessageKind,
+    Role,
+    ScenarioBeat,
+    ScenarioInject,
+    ScenarioPlan,
+    Session,
+    SessionState,
+    Workstream,
+)
+from app.ws.connection_manager import ConnectionManager
+
+# ----------------------------------------------------------------------
+# Helpers
+
+
+def _build_play_session() -> Session:
+    ciso = Role(id="role-ciso", label="CISO", is_creator=True)
+    ir_lead = Role(id="role-ir", label="IR Lead")
+    plan = ScenarioPlan(
+        title="Ransomware",
+        key_objectives=["Contain"],
+        narrative_arc=[
+            ScenarioBeat(beat=1, label="Detection", expected_actors=["SOC"])
+        ],
+        injects=[
+            ScenarioInject(trigger="after beat 1", type="event", summary="x")
+        ],
+        workstreams=[
+            Workstream(id="containment", label="Containment"),
+            Workstream(id="comms", label="Comms"),
+        ],
+    )
+    return Session(
+        scenario_prompt="r",
+        state=SessionState.AI_PROCESSING,
+        roles=[ciso, ir_lead],
+        creator_role_id=ciso.id,
+        plan=plan,
+    )
+
+
+def _make_dispatcher(*, workstreams_enabled: bool = True) -> ToolDispatcher:
+    bundle = ExtensionBundle()
+    registry = freeze_bundle(bundle)
+    audit = AuditLog()
+    ext_dispatcher = ExtensionDispatcher(registry=registry, audit=audit)
+    return ToolDispatcher(
+        connections=ConnectionManager(),
+        audit=audit,
+        extension_dispatcher=ext_dispatcher,
+        registry=registry,
+        workstreams_enabled=workstreams_enabled,
+    )
+
+
+async def _dispatch(
+    dispatcher: ToolDispatcher,
+    session: Session,
+    *tool_uses: dict[str, Any],
+    critical_allowed: bool = True,
+) -> Any:
+    return await dispatcher.dispatch(
+        session=session,
+        tool_uses=list(tool_uses),
+        turn_id="t1",
+        critical_inject_allowed_cb=lambda: critical_allowed,
+    )
+
+
+def _tu(name: str, args: dict[str, Any], tool_id: str = "tu1") -> dict[str, Any]:
+    return {"name": name, "input": args, "id": tool_id}
+
+
+# ----------------------------------------------------------------------
+# Schema shape — Phase B tools must each gain the optional field
+
+
+class TestPhaseBToolSchemas:
+    """All three new tools accept ``workstream_id`` and keep their
+    pre-existing required lists intact."""
+
+    @pytest.mark.parametrize(
+        "tool_name,required",
+        [
+            ("pose_choice", {"role_id", "question", "options"}),
+            ("share_data", {"label", "data"}),
+            ("inject_critical_event", {"severity", "headline", "body"}),
+        ],
+    )
+    def test_workstream_id_field_added(
+        self, tool_name: str, required: set[str]
+    ) -> None:
+        tool = next(t for t in PLAY_TOOLS if t["name"] == tool_name)
+        props = tool["input_schema"]["properties"]
+        assert "workstream_id" in props, (
+            f"{tool_name} missing the optional workstream_id field"
+        )
+        assert set(tool["input_schema"]["required"]) == required, (
+            f"{tool_name}.required was widened — workstream_id must "
+            "stay optional per plan §3.1"
+        )
+
+    def test_descriptions_did_not_grow_prose(self) -> None:
+        """Plan §3.1 guardrail: only the input_schema grows. The
+        per-tool descriptions stay shape-equivalent to pre-Phase-B —
+        no new directives, examples, or directives that could
+        conflict across tools (Prompt Expert review specifically
+        flagged this as the failure mode for "four near-identical
+        schema diffs at once")."""
+
+        for name in ("pose_choice", "share_data", "inject_critical_event"):
+            tool = next(t for t in PLAY_TOOLS if t["name"] == name)
+            desc = tool["description"]
+            # The description must NOT mention the field name — that
+            # would be a redundant restatement of the input_schema's
+            # description and is the exact kind of prompt-tax the
+            # Prompt Expert review guards against.
+            assert "workstream_id" not in desc, (
+                f"{name} description leaked workstream_id; per plan "
+                "§3.1 only the input_schema grows"
+            )
+
+
+# ----------------------------------------------------------------------
+# Dispatch — pose_choice
+
+
+class TestPoseChoiceWorkstreamDispatch:
+    @pytest.mark.asyncio
+    async def test_valid_workstream_id_is_recorded(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "pose_choice",
+                {
+                    "role_id": "role-ir",
+                    "question": "Isolate now?",
+                    "options": ["Isolate", "Monitor"],
+                    "workstream_id": "containment",
+                },
+            ),
+        )
+        msg = outcome.appended_messages[0]
+        assert msg.kind == MessageKind.AI_TEXT
+        assert msg.workstream_id == "containment"
+        # Phase B parity with address_role: pose_choice is
+        # single-addressee so the target role gets stamped as a
+        # structural mention (drives the @-highlight + (@you) badge).
+        assert msg.mentions == ["role-ir"]
+        assert msg.tool_args is not None
+        assert msg.tool_args["workstream_id"] == "containment"
+        assert outcome.tool_results[0]["is_error"] is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_workstream_id_is_tool_error(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "pose_choice",
+                {
+                    "role_id": "role-ir",
+                    "question": "Q?",
+                    "options": ["A", "B"],
+                    "workstream_id": "vendor_management",
+                },
+            ),
+        )
+        assert outcome.tool_results[0]["is_error"] is True
+        content = outcome.tool_results[0]["content"]
+        assert "vendor_management" in content
+        assert "containment" in content
+        # Strict-retry semantics: rejected calls do NOT append a
+        # message; the model self-corrects on the next turn.
+        assert outcome.appended_messages == []
+
+    @pytest.mark.asyncio
+    async def test_missing_field_is_none(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "pose_choice",
+                {
+                    "role_id": "role-ir",
+                    "question": "Q?",
+                    "options": ["A", "B"],
+                },
+            ),
+        )
+        msg = outcome.appended_messages[0]
+        assert msg.workstream_id is None
+        assert msg.tool_args is not None
+        assert msg.tool_args["workstream_id"] is None
+
+
+# ----------------------------------------------------------------------
+# Dispatch — share_data
+
+
+class TestShareDataWorkstreamDispatch:
+    @pytest.mark.asyncio
+    async def test_valid_workstream_id_is_recorded(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "share_data",
+                {
+                    "label": "Defender telemetry",
+                    "data": "FIN-04 isolated",
+                    "workstream_id": "containment",
+                },
+            ),
+        )
+        msg = outcome.appended_messages[0]
+        assert msg.workstream_id == "containment"
+        # share_data is non-addressed by design (cross-cutting data
+        # dump) — no structural mentions even when scoped.
+        assert msg.mentions == []
+        assert msg.tool_args is not None
+        assert msg.tool_args["workstream_id"] == "containment"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_falls_back_to_none(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "share_data",
+                {"label": "X", "data": "Y", "workstream_id": ""},
+            ),
+        )
+        msg = outcome.appended_messages[0]
+        assert msg.workstream_id is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_workstream_id_is_tool_error(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "share_data",
+                {
+                    "label": "X",
+                    "data": "Y",
+                    "workstream_id": "ghost_track",
+                },
+            ),
+        )
+        assert outcome.tool_results[0]["is_error"] is True
+        assert outcome.appended_messages == []
+
+
+# ----------------------------------------------------------------------
+# Dispatch — inject_critical_event
+
+
+class TestInjectCriticalEventWorkstreamDispatch:
+    @pytest.mark.asyncio
+    async def test_valid_workstream_id_is_recorded(self) -> None:
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "inject_critical_event",
+                {
+                    "severity": "HIGH",
+                    "headline": "Reporter call",
+                    "body": "tabloid leak",
+                    "workstream_id": "comms",
+                },
+            ),
+        )
+        msg = outcome.appended_messages[0]
+        assert msg.kind == MessageKind.CRITICAL_INJECT
+        assert msg.workstream_id == "comms"
+        assert outcome.critical_inject_fired
+
+    @pytest.mark.asyncio
+    async def test_invalid_workstream_id_is_tool_error_no_inject(self) -> None:
+        # Plan §4.5: validation runs BEFORE the WS broadcast so a bad
+        # value short-circuits without fanning out a critical_event
+        # the frontend would have to retract.
+        dispatcher = _make_dispatcher()
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "inject_critical_event",
+                {
+                    "severity": "HIGH",
+                    "headline": "x",
+                    "body": "y",
+                    "workstream_id": "made_up",
+                },
+            ),
+        )
+        assert outcome.tool_results[0]["is_error"] is True
+        assert outcome.critical_inject_fired is False
+        assert outcome.appended_messages == []
+
+    @pytest.mark.asyncio
+    async def test_flag_off_silently_drops_workstream_id(self) -> None:
+        # Defence in depth — an upgraded model emitting the field
+        # against a flag-off backend MUST NOT error the inject.
+        dispatcher = _make_dispatcher(workstreams_enabled=False)
+        session = _build_play_session()
+        outcome = await _dispatch(
+            dispatcher,
+            session,
+            _tu(
+                "inject_critical_event",
+                {
+                    "severity": "HIGH",
+                    "headline": "ok",
+                    "body": "y",
+                    "workstream_id": "containment",
+                },
+            ),
+        )
+        msg = outcome.appended_messages[0]
+        assert msg.workstream_id is None
+        assert outcome.critical_inject_fired
+
+
+# ----------------------------------------------------------------------
+# §4.4 — player-reply workstream inheritance
+
+
+class TestPlayerReplyInheritance:
+    """Plan §4.4 rule (2): the most recent AI message that addressed
+    this player carries a ``workstream_id``; the player's reply
+    inherits it. Validated through the helper directly so the test
+    pins the contract without standing up a full SessionManager."""
+
+    def _addressing_msg(
+        self,
+        *,
+        role_id: str,
+        workstream_id: str | None,
+    ) -> Message:
+        return Message(
+            kind=MessageKind.AI_TEXT,
+            body=f"@{role_id}: do the thing",
+            mentions=[role_id],
+            workstream_id=workstream_id,
+        )
+
+    def test_inherits_from_most_recent_addressing_ai_message(self) -> None:
+        from app.sessions.manager import _inherit_workstream_id
+
+        session = _build_play_session()
+        session.messages.append(
+            self._addressing_msg(role_id="role-ir", workstream_id="comms")
+        )
+        session.messages.append(
+            self._addressing_msg(role_id="role-ir", workstream_id="containment")
+        )
+        # Most recent wins.
+        assert _inherit_workstream_id(session, role_id="role-ir") == "containment"
+
+    def test_returns_none_when_no_addressing_message(self) -> None:
+        from app.sessions.manager import _inherit_workstream_id
+
+        session = _build_play_session()
+        # AI message addresses someone else — ir's reply has nothing
+        # to inherit.
+        session.messages.append(
+            self._addressing_msg(role_id="role-ciso", workstream_id="comms")
+        )
+        assert _inherit_workstream_id(session, role_id="role-ir") is None
+
+    def test_returns_none_when_addressing_message_was_unscoped(self) -> None:
+        from app.sessions.manager import _inherit_workstream_id
+
+        session = _build_play_session()
+        session.messages.append(
+            self._addressing_msg(role_id="role-ir", workstream_id=None)
+        )
+        assert _inherit_workstream_id(session, role_id="role-ir") is None
+
+    def test_skips_player_messages_when_walking_back(self) -> None:
+        # An intervening player post must NOT short-circuit the walk
+        # — only AI messages count as "addressing" events per §4.4.
+        from app.sessions.manager import _inherit_workstream_id
+
+        session = _build_play_session()
+        session.messages.append(
+            self._addressing_msg(role_id="role-ir", workstream_id="containment")
+        )
+        session.messages.append(
+            Message(
+                kind=MessageKind.PLAYER,
+                role_id="role-ir",
+                body="acknowledged",
+            )
+        )
+        # Even though a player message intervenes, the AI message's
+        # workstream is still the most recent ADDRESSING event.
+        assert _inherit_workstream_id(session, role_id="role-ir") == "containment"

--- a/frontend/src/__tests__/Play.e2e.test.tsx
+++ b/frontend/src/__tests__/Play.e2e.test.tsx
@@ -106,6 +106,7 @@ function _baseSnapshot(): SessionSnapshot {
     setup_notes: null,
     cost: null,
     aar_status: null,
+    workstreams: [],
   };
 }
 
@@ -128,6 +129,8 @@ function _playSnapshot(): SessionSnapshot {
       body: "**SOC** — what does the alert queue actually show?",
       tool_name: "broadcast",
       tool_args: null,
+      workstream_id: null,
+      mentions: [],
     },
   ];
   return s;

--- a/frontend/src/__tests__/Timeline.test.tsx
+++ b/frontend/src/__tests__/Timeline.test.tsx
@@ -17,6 +17,8 @@ function msg(over: Partial<MessageView>): MessageView {
     body: "",
     tool_name: null,
     tool_args: null,
+    workstream_id: null,
+    mentions: [],
     ...over,
   };
 }

--- a/frontend/src/__tests__/Transcript.test.tsx
+++ b/frontend/src/__tests__/Transcript.test.tsx
@@ -93,6 +93,8 @@ describe("Transcript", () => {
         body: "Old AI bubble — no ring on this one.",
         tool_name: "broadcast",
         tool_args: null,
+        workstream_id: null,
+        mentions: [],
       },
       {
         id: "m2",
@@ -102,6 +104,8 @@ describe("Transcript", () => {
         body: "Player reply",
         tool_name: null,
         tool_args: null,
+        workstream_id: null,
+        mentions: [],
       },
       {
         id: "m3",
@@ -111,6 +115,8 @@ describe("Transcript", () => {
         body: "Latest AI bubble — should have the amber ring.",
         tool_name: "broadcast",
         tool_args: null,
+        workstream_id: null,
+        mentions: [],
       },
     ];
     const { container } = render(

--- a/frontend/src/__tests__/Transcript.typing.test.tsx
+++ b/frontend/src/__tests__/Transcript.typing.test.tsx
@@ -133,6 +133,8 @@ describe("Transcript typing label (issue #77)", () => {
         ts: "2026-05-01T00:00:00Z",
         tool_name: null,
         tool_args: null,
+        workstream_id: null,
+        mentions: [],
       },
       {
         id: "m2",
@@ -142,6 +144,8 @@ describe("Transcript typing label (issue #77)", () => {
         ts: "2026-05-01T00:00:01Z",
         tool_name: null,
         tool_args: null,
+        workstream_id: null,
+        mentions: [],
       },
     ];
     const { container } = render(

--- a/frontend/src/__tests__/Transcript.workstream.test.tsx
+++ b/frontend/src/__tests__/Transcript.workstream.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MessageView, RoleView, WorkstreamView } from "../api/client";
+import { Transcript } from "../components/Transcript";
+
+const ROLES: RoleView[] = [
+  {
+    id: "role-soc",
+    label: "SOC",
+    display_name: "Bo",
+    kind: "player",
+    is_creator: false,
+    token_version: 0,
+  },
+  {
+    id: "role-ciso",
+    label: "CISO",
+    display_name: "Alex",
+    kind: "player",
+    is_creator: true,
+    token_version: 0,
+  },
+];
+
+const WORKSTREAMS: WorkstreamView[] = [
+  {
+    id: "containment",
+    label: "Containment",
+    lead_role_id: null,
+    state: "open",
+    created_at: "2026-05-04T13:50:00Z",
+    closed_at: null,
+  },
+  {
+    id: "comms",
+    label: "Comms",
+    lead_role_id: null,
+    state: "open",
+    created_at: "2026-05-04T13:50:00Z",
+    closed_at: null,
+  },
+];
+
+function msg(
+  partial: Partial<MessageView> & Pick<MessageView, "id" | "kind" | "ts" | "body">,
+): MessageView {
+  return {
+    role_id: null,
+    tool_name: null,
+    tool_args: null,
+    workstream_id: null,
+    mentions: [],
+    ...partial,
+  };
+}
+
+describe("Transcript — workstream chrome (Phase B)", () => {
+  it("stamps `data-workstream-id` on AI bubbles for declared workstreams", () => {
+    const messages: MessageView[] = [
+      msg({
+        id: "m1",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:00Z",
+        body: "@SOC isolate now",
+        workstream_id: "containment",
+        mentions: ["role-soc"],
+      }),
+    ];
+    render(
+      <Transcript messages={messages} roles={ROLES} workstreams={WORKSTREAMS} />,
+    );
+    const article = document.getElementById("msg-m1");
+    expect(article).not.toBeNull();
+    expect(article?.getAttribute("data-workstream-id")).toBe("containment");
+  });
+
+  it("renders the @YOU badge when mentions includes selfRoleId", () => {
+    // Plan §5.1 — the badge is gated on the structural ``mentions[]``
+    // list, NOT body regex. Even though the body says "@SOC", what
+    // drives the badge is the AI dispatch stamping ``mentions=["role-soc"]``.
+    const messages: MessageView[] = [
+      msg({
+        id: "m1",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:00Z",
+        body: "isolate the affected segment",
+        workstream_id: "containment",
+        mentions: ["role-soc"],
+      }),
+    ];
+    render(
+      <Transcript
+        messages={messages}
+        roles={ROLES}
+        workstreams={WORKSTREAMS}
+        selfRoleId="role-soc"
+      />,
+    );
+    const article = document.getElementById("msg-m1")!;
+    expect(within(article).getByText("@YOU")).toBeInTheDocument();
+  });
+
+  it("does NOT render the @YOU badge when mentions is empty (no body regex)", () => {
+    // Even though the body literally contains "@you" or "@SOC" text,
+    // the highlight is structural — empty ``mentions`` ⇒ no badge.
+    const messages: MessageView[] = [
+      msg({
+        id: "m1",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:00Z",
+        body: "@SOC @you please respond",
+        mentions: [],
+      }),
+    ];
+    render(
+      <Transcript
+        messages={messages}
+        roles={ROLES}
+        workstreams={WORKSTREAMS}
+        selfRoleId="role-soc"
+      />,
+    );
+    expect(screen.queryByText("@YOU")).toBeNull();
+  });
+
+  it("emits a synthetic 'opened by' landmark before the first message of a track", () => {
+    // Two messages in containment, one in comms. Two landmarks
+    // expected: one before m1 (containment-open) and one before m3
+    // (comms-open). m2 stays inside containment so no second landmark
+    // for it.
+    const messages: MessageView[] = [
+      msg({
+        id: "m1",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:00Z",
+        body: "@SOC isolate",
+        workstream_id: "containment",
+        mentions: ["role-soc"],
+        role_id: null,
+      }),
+      msg({
+        id: "m2",
+        kind: "player",
+        ts: "2026-05-04T14:00:30Z",
+        role_id: "role-soc",
+        body: "isolating",
+        workstream_id: "containment",
+      }),
+      msg({
+        id: "m3",
+        kind: "ai_text",
+        ts: "2026-05-04T14:01:00Z",
+        body: "@CISO statement",
+        workstream_id: "comms",
+        mentions: ["role-ciso"],
+      }),
+    ];
+    render(
+      <Transcript messages={messages} roles={ROLES} workstreams={WORKSTREAMS} />,
+    );
+    expect(screen.getByText(/#Containment/)).toBeInTheDocument();
+    expect(screen.getByText(/#Comms/)).toBeInTheDocument();
+    // The "opened by" copy fires for both.
+    const openedBy = screen.getAllByText(/opened by/);
+    expect(openedBy.length).toBe(2);
+  });
+
+  it("renders sticky minute-anchor rows at minute boundaries", () => {
+    const messages: MessageView[] = [
+      msg({
+        id: "m1",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:00Z",
+        body: "first",
+      }),
+      msg({
+        id: "m2",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:45Z",
+        body: "second",
+      }),
+      msg({
+        id: "m3",
+        kind: "ai_text",
+        ts: "2026-05-04T14:01:00Z",
+        body: "third",
+      }),
+    ];
+    const { container } = render(
+      <Transcript messages={messages} roles={ROLES} workstreams={[]} />,
+    );
+    // One anchor per minute boundary crossed. m1 starts a new minute
+    // (always — first message), m3 crosses into the next minute. m2
+    // stays in the same minute as m1, so no new anchor.
+    const stickyAnchors = container.querySelectorAll(".sticky.top-0");
+    expect(stickyAnchors.length).toBe(2);
+  });
+
+  it("falls back to slate stripe for unscoped messages", () => {
+    const messages: MessageView[] = [
+      msg({
+        id: "m1",
+        kind: "ai_text",
+        ts: "2026-05-04T14:00:00Z",
+        body: "general broadcast",
+        workstream_id: null,
+      }),
+    ];
+    render(
+      <Transcript messages={messages} roles={ROLES} workstreams={WORKSTREAMS} />,
+    );
+    const article = document.getElementById("msg-m1");
+    // ``data-workstream-id`` is the empty string when unscoped. The
+    // stripe color is decided in JS — no easy DOM assertion for the
+    // exact oklch value, but the fact that the article carries
+    // ``data-workstream-id=""`` confirms the unscoped path landed.
+    expect(article?.getAttribute("data-workstream-id")).toBe("");
+  });
+});

--- a/frontend/src/__tests__/TranscriptFilters.test.tsx
+++ b/frontend/src/__tests__/TranscriptFilters.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { MessageView, WorkstreamView } from "../api/client";
+import { TranscriptFilters } from "../components/TranscriptFilters";
+import { DEFAULT_FILTER, FilterState } from "../lib/transcriptFilters";
+
+const SELF = "role-soc";
+
+const WORKSTREAMS: WorkstreamView[] = [
+  {
+    id: "containment",
+    label: "Containment",
+    lead_role_id: null,
+    state: "open",
+    created_at: "2026-05-04T13:50:00Z",
+    closed_at: null,
+  },
+  {
+    id: "comms",
+    label: "Comms",
+    lead_role_id: null,
+    state: "open",
+    created_at: "2026-05-04T13:50:00Z",
+    closed_at: null,
+  },
+];
+
+function msg(
+  partial: Partial<MessageView> & Pick<MessageView, "id" | "kind" | "ts">,
+): MessageView {
+  return {
+    role_id: null,
+    body: "",
+    tool_name: null,
+    tool_args: null,
+    workstream_id: null,
+    mentions: [],
+    ...partial,
+  };
+}
+
+const MESSAGES: MessageView[] = [
+  msg({
+    id: "m1",
+    kind: "ai_text",
+    ts: "2026-05-04T14:00:00Z",
+    body: "@SOC isolate",
+    workstream_id: "containment",
+    mentions: ["role-soc"],
+  }),
+  msg({
+    id: "m2",
+    kind: "ai_text",
+    ts: "2026-05-04T14:01:00Z",
+    body: "@Comms statement",
+    workstream_id: "comms",
+    mentions: ["role-comms"],
+  }),
+  msg({
+    id: "m3",
+    kind: "critical_inject",
+    ts: "2026-05-04T14:01:30Z",
+    body: "Reporter call",
+  }),
+];
+
+function Harness({
+  initialState = DEFAULT_FILTER,
+  workstreams = WORKSTREAMS,
+}: {
+  initialState?: FilterState;
+  workstreams?: WorkstreamView[];
+}) {
+  const [state, setState] = useState<FilterState>(initialState);
+  return (
+    <TranscriptFilters
+      messages={MESSAGES}
+      workstreams={workstreams}
+      selfRoleId={SELF}
+      state={state}
+      onChange={setState}
+    />
+  );
+}
+
+describe("TranscriptFilters", () => {
+  it("renders pills with counts in declared order", () => {
+    render(<Harness />);
+    // Pills carry their count in the aria-label for screen readers.
+    expect(screen.getByRole("button", { name: /^All \(3\)$/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Mentions of you \(1\)/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Critical \(1\)$/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Containment \(1\)$/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Comms \(1\)$/ })).toBeInTheDocument();
+  });
+
+  it("hides the workstream-pill row when no workstreams declared", () => {
+    render(<Harness workstreams={[]} />);
+    expect(screen.queryByText("AND")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Containment/ })).not.toBeInTheDocument();
+  });
+
+  it("flips quality-pill aria-pressed when clicked", () => {
+    render(<Harness />);
+    const me = screen.getByRole("button", { name: /Mentions of you/ });
+    expect(me).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(me);
+    expect(me).toHaveAttribute("aria-pressed", "true");
+    // 'All' should have flipped to false.
+    expect(
+      screen.getByRole("button", { name: /^All / }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("track pills toggle independently and accumulate", () => {
+    render(<Harness />);
+    const cont = screen.getByRole("button", { name: /^Containment / });
+    const comms = screen.getByRole("button", { name: /^Comms / });
+    fireEvent.click(cont);
+    fireEvent.click(comms);
+    expect(cont).toHaveAttribute("aria-pressed", "true");
+    expect(comms).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(cont);
+    expect(cont).toHaveAttribute("aria-pressed", "false");
+    expect(comms).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("'Reset filters' link clears any active filter", () => {
+    render(<Harness initialState={{ quality: "critical", tracks: new Set() }} />);
+    // Two buttons match "clear all transcript filters" once the
+    // hidden-mentions banner is showing (the row-level link + the
+    // banner-level link). We want the row-level one — it's the first
+    // match in DOM order. ``getAllByRole``[0] is robust to both.
+    const buttons = screen.getAllByRole("button", {
+      name: /clear all transcript filters/i,
+    });
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(buttons[0]);
+    expect(screen.getByRole("button", { name: /^All / })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /^Critical / })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("renders the hidden-mentions banner when current filter hides a mention-of-self", () => {
+    render(<Harness initialState={{ quality: "critical", tracks: new Set() }} />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(/1 @-mention for you hidden/);
+    expect(status).toHaveTextContent(/Critical/);
+    // User-persona review H3: banner offers TWO recovery actions —
+    // "Show those" (jumps to @Me) and "Reset filters" (nukes
+    // everything). Verify both are present and the jump action
+    // routes to the @Me filter rather than clearing.
+    const showThose = within(status).getByRole("button", {
+      name: /switch filter to mentions of you/i,
+    });
+    fireEvent.click(showThose);
+    // After "Show those", the @Me pill is pressed.
+    expect(
+      screen.getByRole("button", { name: /Mentions of you/ }),
+    ).toHaveAttribute("aria-pressed", "true");
+    // Banner is gone (m1 — the only mention — is now visible under
+    // the @Me filter).
+    expect(screen.queryByText(/@-mentions? for you hidden/)).toBeNull();
+  });
+
+  it("hidden-mentions banner 'Reset filters' button clears the filter", () => {
+    render(<Harness initialState={{ quality: "critical", tracks: new Set() }} />);
+    const status = screen.getByRole("status");
+    const reset = within(status).getByRole("button", {
+      name: /clear all transcript filters/i,
+    });
+    fireEvent.click(reset);
+    expect(screen.getByRole("button", { name: /^All / })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("does not render the hidden-mentions banner on the default filter", () => {
+    render(<Harness />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/transcriptFilters.test.ts
+++ b/frontend/src/__tests__/transcriptFilters.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { MessageView } from "../api/client";
+import {
+  DEFAULT_FILTER,
+  countFilters,
+  countHiddenMentions,
+  filterMessages,
+  isDefaultFilter,
+} from "../lib/transcriptFilters";
+
+const SELF = "role-soc";
+
+function msg(
+  partial: Partial<MessageView> & Pick<MessageView, "id" | "kind" | "ts">,
+): MessageView {
+  return {
+    role_id: null,
+    body: "",
+    tool_name: null,
+    tool_args: null,
+    workstream_id: null,
+    mentions: [],
+    ...partial,
+  };
+}
+
+const FIXTURES: MessageView[] = [
+  // Containment beat — AI addresses SOC.
+  msg({
+    id: "m1",
+    kind: "ai_text",
+    ts: "2026-05-04T14:00:00Z",
+    body: "@SOC: confirm isolation",
+    workstream_id: "containment",
+    mentions: ["role-soc"],
+  }),
+  // Containment beat — SOC reply.
+  msg({
+    id: "m2",
+    kind: "player",
+    ts: "2026-05-04T14:00:30Z",
+    role_id: "role-soc",
+    body: "Isolating now",
+    workstream_id: "containment",
+  }),
+  // Comms beat — AI addresses Comms.
+  msg({
+    id: "m3",
+    kind: "ai_text",
+    ts: "2026-05-04T14:01:00Z",
+    body: "@Comms: prepare statement",
+    workstream_id: "comms",
+    mentions: ["role-comms"],
+  }),
+  // Critical inject (no workstream).
+  msg({
+    id: "m4",
+    kind: "critical_inject",
+    ts: "2026-05-04T14:01:30Z",
+    body: "Reporter call",
+  }),
+  // Unscoped broadcast (#main).
+  msg({
+    id: "m5",
+    kind: "ai_text",
+    ts: "2026-05-04T14:02:00Z",
+    body: "Beat 2 starts now",
+  }),
+];
+
+describe("isDefaultFilter", () => {
+  it("returns true for the default filter and false otherwise", () => {
+    expect(isDefaultFilter(DEFAULT_FILTER)).toBe(true);
+    expect(isDefaultFilter({ quality: "me", tracks: new Set() })).toBe(false);
+    expect(
+      isDefaultFilter({ quality: "all", tracks: new Set(["containment"]) }),
+    ).toBe(false);
+  });
+});
+
+describe("filterMessages", () => {
+  it("returns the input list unchanged on the default filter", () => {
+    expect(filterMessages(FIXTURES, DEFAULT_FILTER, SELF)).toEqual(FIXTURES);
+  });
+
+  it("'me' keeps only mentions of self (NOT messages authored by self)", () => {
+    // Plan §6.1: @Me is strictly "addressed to me". A self-authored
+    // post (m2) is NOT a mention; only m1 (which mentions SOC via the
+    // structural ``mentions[]`` list) qualifies. User-persona review
+    // H4 confirmed this matches operator expectations.
+    const filtered = filterMessages(
+      FIXTURES,
+      { quality: "me", tracks: new Set() },
+      SELF,
+    );
+    expect(filtered.map((m) => m.id)).toEqual(["m1"]);
+  });
+
+  it("'critical' keeps only critical_inject", () => {
+    const filtered = filterMessages(
+      FIXTURES,
+      { quality: "critical", tracks: new Set() },
+      SELF,
+    );
+    expect(filtered.map((m) => m.id)).toEqual(["m4"]);
+  });
+
+  it("track filter is OR within the set", () => {
+    const filtered = filterMessages(
+      FIXTURES,
+      { quality: "all", tracks: new Set(["containment", "comms"]) },
+      SELF,
+    );
+    expect(filtered.map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("track filter excludes #main / unscoped messages", () => {
+    const filtered = filterMessages(
+      FIXTURES,
+      { quality: "all", tracks: new Set(["containment"]) },
+      SELF,
+    );
+    // m4 (critical, unscoped) and m5 (broadcast, unscoped) drop out.
+    expect(filtered.map((m) => m.id)).toEqual(["m1", "m2"]);
+  });
+
+  it("AND-combines quality with tracks", () => {
+    // @Me ∩ #containment = the SOC-mentioned message in containment.
+    // m2 (self-authored, no mention) drops out per the strict @Me
+    // semantics.
+    const filtered = filterMessages(
+      FIXTURES,
+      { quality: "me", tracks: new Set(["containment"]) },
+      SELF,
+    );
+    expect(filtered.map((m) => m.id)).toEqual(["m1"]);
+  });
+
+  it("'me' is a no-op when selfRoleId is null", () => {
+    expect(
+      filterMessages(FIXTURES, { quality: "me", tracks: new Set() }, null),
+    ).toEqual([]);
+  });
+});
+
+describe("countFilters", () => {
+  it("counts all/me/critical and per-track buckets", () => {
+    const counts = countFilters(FIXTURES, ["containment", "comms"], SELF);
+    expect(counts.all).toBe(5);
+    // Strict @Me: only m1 mentions SOC; m2 is self-authored and not
+    // counted.
+    expect(counts.me).toBe(1);
+    expect(counts.critical).toBe(1);
+    expect(counts.perTrack).toEqual({ containment: 2, comms: 1 });
+  });
+
+  it("returns zero per-track when no workstreams declared", () => {
+    const counts = countFilters(FIXTURES, [], SELF);
+    expect(counts.perTrack).toEqual({});
+    expect(counts.all).toBe(5);
+  });
+});
+
+describe("countHiddenMentions", () => {
+  it("returns 0 on the default filter", () => {
+    expect(countHiddenMentions(FIXTURES, DEFAULT_FILTER, SELF)).toBe(0);
+  });
+
+  it("counts mention-of-self messages dropped by the active filter", () => {
+    // 'critical' filter hides m1 (which mentions SOC) — that's the
+    // hidden-mentions banner case from plan §4.7.
+    expect(
+      countHiddenMentions(
+        FIXTURES,
+        { quality: "critical", tracks: new Set() },
+        SELF,
+      ),
+    ).toBe(1);
+  });
+
+  it("counts hidden mentions due to track filter", () => {
+    // Filter only #comms — m1 (SOC-mention, containment) is hidden.
+    expect(
+      countHiddenMentions(
+        FIXTURES,
+        { quality: "all", tracks: new Set(["comms"]) },
+        SELF,
+      ),
+    ).toBe(1);
+  });
+
+  it("returns 0 when selfRoleId is null", () => {
+    expect(
+      countHiddenMentions(
+        FIXTURES,
+        { quality: "critical", tracks: new Set() },
+        null,
+      ),
+    ).toBe(0);
+  });
+});

--- a/frontend/src/__tests__/transcriptFilters.test.ts
+++ b/frontend/src/__tests__/transcriptFilters.test.ts
@@ -136,7 +136,9 @@ describe("filterMessages", () => {
     expect(filtered.map((m) => m.id)).toEqual(["m1"]);
   });
 
-  it("'me' is a no-op when selfRoleId is null", () => {
+  it("'me' returns [] when selfRoleId is null", () => {
+    // No self ⇒ no message can match @Me; the filter collapses to
+    // an empty list rather than no-op-ing back to the input.
     expect(
       filterMessages(FIXTURES, { quality: "me", tracks: new Set() }, null),
     ).toEqual([]);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,6 +23,24 @@ export interface SessionSnapshot {
    * why it picked a turn's actions. ``null`` for non-creator roles.
    */
   decision_log?: DecisionLogEntry[] | null;
+  /**
+   * Phase B chat-declutter (docs/plans/chat-decluttering.md §4.1):
+   * AI-declared workstreams for this session. Empty list = no
+   * categorization (single ``#main`` bucket); populated when the AI
+   * called ``declare_workstreams`` during setup. Visible to every
+   * participant so the TranscriptFilters pills + colored stripe
+   * palette can assign deterministic colors in declaration order.
+   */
+  workstreams: WorkstreamView[];
+}
+
+export interface WorkstreamView {
+  id: string;
+  label: string;
+  lead_role_id: string | null;
+  state: "open" | "closed";
+  created_at: string;
+  closed_at: string | null;
 }
 
 export interface DecisionLogEntry {
@@ -82,6 +100,28 @@ export interface MessageView {
    * transcript renders a "sidebar" badge so it isn't confused with a
    * turn submission. */
   is_interjection?: boolean;
+  /**
+   * Phase B chat-declutter (docs/plans/chat-decluttering.md §4.1):
+   * one of the session's declared ``Workstream.id`` values, or
+   * ``null`` for the synthetic ``#main`` (unscoped) bucket. Validated
+   * server-side at dispatch time; the frontend renders the colored
+   * track-bar stripe directly off this field — no body parsing.
+   *
+   * Per CLAUDE.md "no backwards compat": the snapshot endpoint
+   * always emits this field (Phase A), so the frontend type makes
+   * it required. ``null`` is the canonical "no workstream" value.
+   */
+  workstream_id: string | null;
+  /**
+   * Phase B chat-declutter (plan §5.1): structural source for the
+   * @-highlight. Each entry is a real ``role_id`` from the roster or
+   * the literal ``"facilitator"`` token. The frontend renders the
+   * amber outline + ``(@you)`` badge from this list — **never** by
+   * regex-scanning ``body``. Empty list when nobody is mentioned.
+   *
+   * Required (no-back-compat): the wire contract always emits this.
+   */
+  mentions: string[];
 }
 
 export interface CostSnapshot {

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -16,6 +16,12 @@ interface Props {
    * scratchpad in v2, etc.) can drop in without changing this file.
    */
   notepad?: ReactNode;
+  /**
+   * Phase B chat-declutter: forwarded to ``Timeline`` so the parent
+   * page can clear an active filter when a Timeline-pin click would
+   * otherwise dead-no-op against a hidden message. Optional.
+   */
+  onScrollMissed?: (messageId: string) => void;
 }
 
 /**
@@ -28,7 +34,12 @@ interface Props {
  * with few or zero pinned beats produce a small Timeline panel that
  * still ate ~60px of header chrome under the previous layout).
  */
-export function RightSidebar({ messages, roles, notepad }: Props) {
+export function RightSidebar({
+  messages,
+  roles,
+  notepad,
+  onScrollMissed,
+}: Props) {
   return (
     <>
       <aside className="hidden flex-col gap-4 lg:flex lg:min-h-0 lg:overflow-y-auto lg:pr-1">
@@ -36,7 +47,11 @@ export function RightSidebar({ messages, roles, notepad }: Props) {
           title="TIMELINE"
           persistKey="crittable.rail.timeline.collapsed"
         >
-          <Timeline messages={messages} roles={roles} />
+          <Timeline
+            messages={messages}
+            roles={roles}
+            onScrollMissed={onScrollMissed}
+          />
         </CollapsibleRailPanel>
         {notepad ?? null}
       </aside>
@@ -48,7 +63,11 @@ export function RightSidebar({ messages, roles, notepad }: Props) {
           TIMELINE &amp; NOTES
         </summary>
         <div className="flex flex-col gap-3 border-t border-dashed border-ink-600 p-3">
-          <Timeline messages={messages} roles={roles} />
+          <Timeline
+            messages={messages}
+            roles={roles}
+            onScrollMissed={onScrollMissed}
+          />
           {notepad ?? null}
         </div>
       </details>

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -4,6 +4,16 @@ import { MessageView, RoleView } from "../api/client";
 interface Props {
   messages: MessageView[];
   roles: RoleView[];
+  /**
+   * Phase B chat-declutter (UI/UX review HIGH): invoked when a
+   * Timeline pin's target ``msg-{id}`` is missing from the DOM —
+   * typically because a transcript filter is hiding it. The parent
+   * page owns the filter state and can clear it then re-attempt the
+   * scroll, surface a recovery toast, etc. Optional — without a
+   * handler the click degrades to a console warning + no-op (the
+   * pre-Phase-B behaviour).
+   */
+  onScrollMissed?: (messageId: string) => void;
 }
 
 interface TimelineEntry {
@@ -54,7 +64,11 @@ const BEAT_RE = /\b(beat|phase|stage)\s+(\d{1,2})\b/i;
  * Each entry is a button — clicking scrolls the transcript to the originating
  * message bubble (which has ``id="msg-{id}"``).
  */
-export function Timeline({ messages, roles: _roles }: Props) {
+export function Timeline({
+  messages,
+  roles: _roles,
+  onScrollMissed,
+}: Props) {
   // ``_roles`` kept in the prop signature so the parent doesn't need to
   // change; the timeline currently doesn't render role labels because the
   // entries are already attributed in the AI's title.
@@ -190,7 +204,21 @@ export function Timeline({ messages, roles: _roles }: Props) {
 
   function scrollTo(id: string) {
     const el = document.getElementById(`msg-${id}`);
-    if (!el) return;
+    if (!el) {
+      // Phase B chat-declutter (UI/UX review HIGH): a Timeline pin
+      // whose target message is filtered out of the transcript would
+      // silently no-op pre-fix, leaving the operator wondering whether
+      // the click registered. ``onScrollMissed`` lets the parent (the
+      // page, which owns the filter state) surface a recovery —
+      // typically by clearing the filter and re-trying. Without a
+      // handler we still log so the next operator can see the silent
+      // no-op in their browser console.
+      console.warn(
+        `[timeline] msg-${id} not in DOM — likely hidden by an active transcript filter`,
+      );
+      onScrollMissed?.(id);
+      return;
+    }
     el.scrollIntoView({ behavior: "smooth", block: "start" });
     setFlashing(id);
     el.setAttribute("data-flash", "1");

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -1,12 +1,26 @@
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { MessageView, RoleView } from "../api/client";
+import { MessageView, RoleView, WorkstreamView } from "../api/client";
+import { colorForWorkstream } from "../lib/workstreamPalette";
 import { ChatIndicator } from "./ChatIndicator";
 import { TableScroll } from "./TableScroll";
 
 interface Props {
   messages: MessageView[];
   roles: RoleView[];
+  /**
+   * Phase B chat-declutter (docs/plans/chat-decluttering.md §4.7):
+   * declared workstreams for this session, in declaration order. The
+   * 6-slot color palette is assigned by index here, so the same id
+   * resolves to the same stripe color across the filter pills, the
+   * track-bar, and the synthetic "track opened" landmark row. Empty
+   * list = no categorization (single ``#main`` bucket); messages get
+   * the slate-gray stripe but no synthetic rows render. Optional —
+   * callers that don't have a session snapshot (e.g. a tests-only
+   * harness) can omit it; the transcript falls back to slate.
+   */
+  workstreams?: WorkstreamView[];
   /**
    * Live AI text streaming: previously this prop fed a green
    * "AI Facilitator (streaming…)" bubble that rendered the
@@ -74,6 +88,21 @@ interface Props {
 function roleCode(label: string): string {
   const first = label.trim().split(/\s+/)[0] ?? "";
   return first.toUpperCase().slice(0, 4) || "—";
+}
+
+/**
+ * Phase B chat-declutter — bucket a message timestamp by wall-clock
+ * minute. Used by the sticky minute-anchor row so a scrolled-up
+ * reader can tell "what time is this" without hunting for a
+ * timestamp on every bubble. ``Intl.DateTimeFormat`` so the user's
+ * locale picks 12h vs 24h, but we constrain the components to the
+ * minute resolution (no seconds).
+ */
+function minuteKey(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 /**
@@ -160,6 +189,7 @@ function MarkdownBody({ body }: { body: string }) {
 export function Transcript({
   messages,
   roles,
+  workstreams,
   // streamingText is intentionally not destructured — see the prop
   // docstring. We accept it so existing callers don't break, but we
   // never render partial chunk text.
@@ -170,6 +200,10 @@ export function Transcript({
   selfRoleId,
 }: Props) {
   const roleById = new Map(roles.map((r) => [r.id, r]));
+  const declaredOrder = (workstreams ?? []).map((w) => w.id);
+  const workstreamLabelById = new Map(
+    (workstreams ?? []).map((w) => [w.id, w.label]),
+  );
   // Find the index of the latest AI-authored bubble (ai_text or
   // critical_inject). Only that one gets the focus ring; an older AI
   // message in the transcript stays visually neutral.
@@ -180,6 +214,44 @@ export function Transcript({
       lastAiIndex = i;
       break;
     }
+  }
+  // Phase B chat-declutter — landmark synthesis. Walk the messages
+  // once, emitting a "track opened by ROLE at HH:MM:SS" row before
+  // the first message of each declared workstream and a sticky
+  // minute-anchor row each time the wall-clock minute boundary
+  // crosses. Both are pure derived chrome — no server state, no
+  // backend round-trip. The row pre-computation lives outside the
+  // render JSX so the render path stays a flat map without a
+  // useEffect dance to track previous values.
+  type Landmark =
+    | { kind: "track_open"; key: string; workstreamId: string; ts: string; roleLabel: string }
+    | { kind: "minute"; key: string; minute: string };
+  const landmarksByMessageId = new Map<string, Landmark[]>();
+  const seenWorkstreams = new Set<string>();
+  let lastMinute: string | null = null;
+  for (const m of messages) {
+    const out: Landmark[] = [];
+    const minute = minuteKey(m.ts);
+    if (lastMinute !== minute) {
+      out.push({ kind: "minute", key: `min-${m.id}`, minute });
+      lastMinute = minute;
+    }
+    if (m.workstream_id && !seenWorkstreams.has(m.workstream_id)) {
+      const ws = workstreamLabelById.get(m.workstream_id);
+      if (ws) {
+        const role = m.role_id ? roleById.get(m.role_id) : null;
+        const roleLabel = role ? role.label : "AI Facilitator";
+        out.push({
+          kind: "track_open",
+          key: `track-${m.id}`,
+          workstreamId: m.workstream_id,
+          ts: m.ts,
+          roleLabel,
+        });
+      }
+      seenWorkstreams.add(m.workstream_id);
+    }
+    if (out.length > 0) landmarksByMessageId.set(m.id, out);
   }
   const typing = (typingRoleIds ?? []).flatMap((id) => {
     const r = roleById.get(id);
@@ -230,26 +302,48 @@ export function Transcript({
             ? "ring-2 ring-warn ring-offset-1 ring-offset-ink-900 shadow-[0_0_0_2px_color-mix(in_oklch,var(--warn)_15%,transparent)]"
             : "";
         const ts = new Date(m.ts).toLocaleTimeString();
+        // Phase B chat-declutter — track-bar stripe + structural
+        // @-highlight. The stripe is 3 px on the left edge of the
+        // bubble; ``colorForWorkstream`` falls back to slate gray
+        // for ``#main`` / unknown ids. The mention-flag drives the
+        // amber outline + ``(@you)`` badge ONLY from the structural
+        // ``mentions[]`` list — we never regex the body, per plan
+        // §5.1.
+        const stripeColor = colorForWorkstream(m.workstream_id, declaredOrder);
+        const isMentioned =
+          selfRoleId != null && (m.mentions ?? []).includes(selfRoleId);
+        const mentionRing = isMentioned && !isCritical
+          ? "ring-2 ring-warn ring-offset-1 ring-offset-ink-900"
+          : "";
+        const landmarks = landmarksByMessageId.get(m.id) ?? [];
 
         if (isSystem) {
           // SystemBeat — center-aligned mono uppercase divider, lifted
-          // from app-screens.jsx <SystemBeat>.
+          // from app-screens.jsx <SystemBeat>. Landmarks (minute /
+          // track-open) render BEFORE the system row so the chrome
+          // sequence reads naturally: "[14:32]" → "track opened" →
+          // SYSTEM beat.
           return (
-            <article
-              key={m.id}
-              id={`msg-${m.id}`}
-              data-kind={m.kind}
-              data-message-id={m.id}
-              data-highlightable="true"
-              data-message-kind="system"
-              className="mono scroll-mt-24 select-text border-y border-dashed border-ink-600 px-2 py-1.5 text-center text-[10px] font-bold uppercase tracking-[0.16em] text-ink-400"
+            <Landmarks
+              key={`grp-${m.id}`}
+              entries={landmarks}
+              declaredOrder={declaredOrder}
+              workstreamLabelById={workstreamLabelById}
             >
-              <span className="tabular-nums text-ink-500">
-                {ts}
-              </span>
-              <span className="mx-2 text-ink-600">·</span>
-              <span>{m.body}</span>
-            </article>
+              <article
+                key={m.id}
+                id={`msg-${m.id}`}
+                data-kind={m.kind}
+                data-message-id={m.id}
+                data-highlightable="true"
+                data-message-kind="system"
+                className="mono scroll-mt-24 select-text border-y border-dashed border-ink-600 px-2 py-1.5 text-center text-[10px] font-bold uppercase tracking-[0.16em] text-ink-400"
+              >
+                <span className="tabular-nums text-ink-500">{ts}</span>
+                <span className="mx-2 text-ink-600">·</span>
+                <span>{m.body}</span>
+              </article>
+            </Landmarks>
           );
         }
 
@@ -257,69 +351,101 @@ export function Transcript({
           // AIBubble — left mark avatar (36 px square, signal-deep
           // bordered) + right column with FACILITATOR · TURN N header
           // and a signal-bordered body. Critical injects swap the signal
-          // border + dot for crit equivalents.
+          // border + dot for crit equivalents. The 3 px workstream
+          // stripe is layered onto the left border via inline style
+          // (Tailwind has no arbitrary-color border util that survives
+          // dark-mode oklch tokens). For critical injects we keep the
+          // crit-red border at the bubble level — the workstream stripe
+          // sits OUTSIDE that border on a dedicated rail so the two
+          // signals don't collide (UI/UX review specifically asked we
+          // avoid recoloring the critical-inject red).
           const dotColor = isCritical ? "bg-crit" : "bg-signal";
           const labelColor = isCritical ? "text-crit" : "text-signal";
           const borderClass = isCritical
             ? "border border-crit border-l-2 bg-crit-bg"
-            : "border border-ink-600 border-l-2 border-l-signal bg-ink-800";
+            : "border border-ink-600 bg-ink-800";
+          // Outer ring stacks: focus-ring (active turn) + mention-ring
+          // (you got @-tagged). Both fade gracefully via Tailwind's
+          // ring composition; we never apply both simultaneously
+          // because the active-turn role is also the most likely
+          // mention target — collapsing to one amber ring is cleaner.
+          const outerRing = focusRing || mentionRing;
           return (
-            <article
-              key={m.id}
-              id={`msg-${m.id}`}
-              data-kind={m.kind}
-              data-message-id={m.id}
-              className={`scroll-mt-24 flex min-w-0 gap-3 ${focusRing}`}
+            <Landmarks
+              key={`grp-${m.id}`}
+              entries={landmarks}
+              declaredOrder={declaredOrder}
+              workstreamLabelById={workstreamLabelById}
             >
-              <div
-                aria-hidden="true"
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-r-1 border border-signal-deep bg-ink-800"
+              <article
+                key={m.id}
+                id={`msg-${m.id}`}
+                data-kind={m.kind}
+                data-message-id={m.id}
+                data-workstream-id={m.workstream_id ?? ""}
+                className={`scroll-mt-24 flex min-w-0 gap-3 ${outerRing}`}
               >
-                <img
-                  src="/logo/svg/mark-encounter-01-dark.svg"
-                  alt=""
-                  width={26}
-                  height={26}
-                  // Inline ``style`` rather than the HTML attrs alone:
-                  // Tailwind preflight resets ``img { height: auto }``
-                  // which overrides the height attribute and forces
-                  // the image back to its intrinsic SVG viewBox size.
-                  // Inline style wins over preflight specificity-wise.
-                  style={{ height: 26, width: 26 }}
-                  className="block"
-                />
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                <header className="mono flex items-baseline gap-2 text-[10px] font-bold uppercase tracking-[0.14em]">
-                  <span
-                    aria-hidden="true"
-                    className={`inline-block h-1.5 w-1.5 rounded-full ${dotColor}`}
-                  />
-                  <span className={`tracking-[0.16em] ${labelColor}`}>
-                    {isCritical ? "CRITICAL INJECT" : "AI FACILITATOR"}
-                  </span>
-                  <span className="ml-auto tabular-nums text-ink-500">
-                    {ts}
-                  </span>
-                </header>
                 <div
-                  className={`min-w-0 break-words rounded-r-2 px-4 py-3 text-ink-100 ${borderClass}`}
-                  // Issue #98: AI / inject bubbles must be highlight-pinnable
-                  // — they're the artifact users most want to capture into
-                  // their notepad timeline.
-                  data-highlightable="true"
-                  data-message-id={m.id}
-                  data-message-kind="ai"
+                  aria-hidden="true"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-r-1 border border-signal-deep bg-ink-800"
                 >
-                  <MarkdownBody body={m.body} />
-                  {m.tool_name ? (
-                    <p className="mono mt-2 text-[10px] uppercase tracking-[0.10em] text-ink-400">
-                      tool · {m.tool_name}
-                    </p>
-                  ) : null}
+                  <img
+                    src="/logo/svg/mark-encounter-01-dark.svg"
+                    alt=""
+                    width={26}
+                    height={26}
+                    style={{ height: 26, width: 26 }}
+                    className="block"
+                  />
                 </div>
-              </div>
-            </article>
+                <div
+                  aria-hidden="true"
+                  className="shrink-0 self-stretch"
+                  style={{ width: 3, background: stripeColor, borderRadius: 2 }}
+                  title={
+                    m.workstream_id
+                      ? `Workstream: #${workstreamLabelById.get(m.workstream_id) ?? m.workstream_id}`
+                      : "Unscoped (#main)"
+                  }
+                />
+                <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                  <header className="mono flex items-baseline gap-2 text-[10px] font-bold uppercase tracking-[0.14em]">
+                    <span
+                      aria-hidden="true"
+                      className={`inline-block h-1.5 w-1.5 rounded-full ${dotColor}`}
+                    />
+                    <span className={`tracking-[0.16em] ${labelColor}`}>
+                      {isCritical ? "CRITICAL INJECT" : "AI FACILITATOR"}
+                    </span>
+                    {isMentioned ? (
+                      <span
+                        className="rounded-r-1 border border-warn bg-warn-bg px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-[0.10em] text-warn"
+                        title="This message mentions you"
+                      >
+                        @YOU
+                      </span>
+                    ) : null}
+                    <span className="ml-auto tabular-nums text-ink-500">{ts}</span>
+                  </header>
+                  <div
+                    className={`min-w-0 break-words rounded-r-2 px-4 py-3 text-ink-100 ${borderClass}`}
+                    // Issue #98: AI / inject bubbles must be highlight-pinnable
+                    // — they're the artifact users most want to capture into
+                    // their notepad timeline.
+                    data-highlightable="true"
+                    data-message-id={m.id}
+                    data-message-kind="ai"
+                  >
+                    <MarkdownBody body={m.body} />
+                    {m.tool_name ? (
+                      <p className="mono mt-2 text-[10px] uppercase tracking-[0.10em] text-ink-400">
+                        tool · {m.tool_name}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </article>
+            </Landmarks>
           );
         }
 
@@ -334,71 +460,93 @@ export function Transcript({
         const bubbleColour = isSelf
           ? "border border-signal-deep bg-signal-tint"
           : "border border-ink-600 bg-ink-800";
+        const playerOuterRing = mentionRing; // focus-ring is AI-only
         return (
-          <article
-            key={m.id}
-            id={`msg-${m.id}`}
-            data-kind={m.kind}
-            data-message-id={m.id}
-            className="scroll-mt-24 flex min-w-0 gap-3 pl-6"
+          <Landmarks
+            key={`grp-${m.id}`}
+            entries={landmarks}
+            declaredOrder={declaredOrder}
+            workstreamLabelById={workstreamLabelById}
           >
-            <div className="flex min-w-0 flex-1 flex-col items-end gap-1.5">
-              <header className="mono flex flex-wrap items-baseline justify-end gap-2 text-[10px] font-bold uppercase tracking-[0.14em]">
-                {isInterjection ? (
-                  <span
-                    className="mono rounded-r-1 border border-ink-500 bg-ink-700 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.10em] leading-none text-ink-200"
-                    title="Posted while not on the active turn — a sidebar comment, not a turn answer."
-                  >
-                    SIDEBAR
-                  </span>
-                ) : (
-                  <span className="text-signal tracking-[0.16em]">
-                    ✓ SUBMITTED
-                  </span>
-                )}
-                <span className="tracking-[0.10em] text-ink-100">
-                  {roleLabel}
-                </span>
-                {displayName ? (
-                  <span className="font-semibold tabular-nums text-ink-400">
-                    {displayName}
-                  </span>
-                ) : null}
-                {isSelf ? (
-                  <span className="text-signal tracking-[0.16em]">
-                    · YOU
-                  </span>
-                ) : null}
-                <span className="tabular-nums text-ink-500">{ts}</span>
-              </header>
-              <div
-                className={`min-w-0 break-words rounded-r-2 px-4 py-3 text-left text-sm leading-relaxed text-ink-100 ${bubbleColour}`}
-                data-highlightable="true"
-                data-message-id={m.id}
-                data-message-kind={isPlayer ? "chat" : m.kind === "ai_text" ? "ai" : "system"}
-              >
-                <p className="whitespace-pre-wrap">{m.body}</p>
-                {m.tool_name ? (
-                  <p className="mono mt-2 text-[10px] uppercase tracking-[0.10em] text-ink-400">
-                    tool · {m.tool_name}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-            {/* Role-code avatar — fixed 36×36 circle. Distinct geometry
-                from the rectangular bubble + ink-700 chips so it reads
-                as identity, not a continuation of the message body. */}
-            <div
-              aria-hidden="true"
-              className={`mono flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[10px] font-bold uppercase leading-none tracking-[0.04em] ${
-                isSelf
-                  ? "border border-signal-deep bg-signal-tint text-signal"
-                  : "border border-ink-500 bg-ink-700 text-ink-100"
-              }`}
+            <article
+              key={m.id}
+              id={`msg-${m.id}`}
+              data-kind={m.kind}
+              data-message-id={m.id}
+              data-workstream-id={m.workstream_id ?? ""}
+              className={`scroll-mt-24 flex min-w-0 gap-3 pl-6 ${playerOuterRing}`}
             >
-              {code}
-            </div>
-          </article>
+              <div className="flex min-w-0 flex-1 flex-col items-end gap-1.5">
+                <header className="mono flex flex-wrap items-baseline justify-end gap-2 text-[10px] font-bold uppercase tracking-[0.14em]">
+                  {isInterjection ? (
+                    <span
+                      className="mono rounded-r-1 border border-ink-500 bg-ink-700 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.10em] leading-none text-ink-200"
+                      title="Posted while not on the active turn — a sidebar comment, not a turn answer."
+                    >
+                      SIDEBAR
+                    </span>
+                  ) : (
+                    <span className="text-signal tracking-[0.16em]">✓ SUBMITTED</span>
+                  )}
+                  <span className="tracking-[0.10em] text-ink-100">{roleLabel}</span>
+                  {displayName ? (
+                    <span className="font-semibold tabular-nums text-ink-400">
+                      {displayName}
+                    </span>
+                  ) : null}
+                  {isSelf ? (
+                    <span className="text-signal tracking-[0.16em]">· YOU</span>
+                  ) : null}
+                  {isMentioned ? (
+                    <span
+                      className="rounded-r-1 border border-warn bg-warn-bg px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-[0.10em] text-warn"
+                      title="This message mentions you"
+                    >
+                      @YOU
+                    </span>
+                  ) : null}
+                  <span className="tabular-nums text-ink-500">{ts}</span>
+                </header>
+                <div
+                  className={`min-w-0 break-words rounded-r-2 px-4 py-3 text-left text-sm leading-relaxed text-ink-100 ${bubbleColour}`}
+                  data-highlightable="true"
+                  data-message-id={m.id}
+                  data-message-kind={isPlayer ? "chat" : m.kind === "ai_text" ? "ai" : "system"}
+                >
+                  <p className="whitespace-pre-wrap">{m.body}</p>
+                  {m.tool_name ? (
+                    <p className="mono mt-2 text-[10px] uppercase tracking-[0.10em] text-ink-400">
+                      tool · {m.tool_name}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                className="shrink-0 self-stretch"
+                style={{ width: 3, background: stripeColor, borderRadius: 2 }}
+                title={
+                  m.workstream_id
+                    ? `Workstream: #${workstreamLabelById.get(m.workstream_id) ?? m.workstream_id}`
+                    : "Unscoped (#main)"
+                }
+              />
+              {/* Role-code avatar — fixed 36×36 circle. Distinct
+                  geometry from the rectangular bubble + ink-700 chips
+                  so it reads as identity, not a continuation of the
+                  message body. */}
+              <div
+                aria-hidden="true"
+                className={`mono flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[10px] font-bold uppercase leading-none tracking-[0.04em] ${
+                  isSelf
+                    ? "border border-signal-deep bg-signal-tint text-signal"
+                    : "border border-ink-500 bg-ink-700 text-ink-100"
+                }`}
+              >
+                {code}
+              </div>
+            </article>
+          </Landmarks>
         );
       })}
       {aiThinking ? (
@@ -420,5 +568,78 @@ export function Transcript({
         <ChatIndicator label={typingLabel} tone="player" silent />
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Phase B chat-declutter — render the synthetic landmark rows
+ * (minute anchor + "track opened by …") that precede a message in
+ * the transcript. Wraps the bubble in a Fragment so the
+ * ``messages.map`` keeps returning a single child per message
+ * (React's rule, not ours).
+ *
+ * The minute anchor uses ``position: sticky`` inside the scrolling
+ * region — a reader who has scrolled up by 50 messages still sees
+ * "what minute am I in" pinned at the top until the next anchor
+ * scrolls into view and replaces it. Pure CSS, no IntersectionObserver.
+ *
+ * The track-open row is purely decorative chrome — ``role="presentation"``
+ * + ``aria-hidden="false"`` because it's still useful context for a
+ * screen-reader user navigating the transcript ("track opened by
+ * SOC at 14:33"); we just don't want it announced as a list item or
+ * a heading. NVDA reads it as plain text.
+ */
+function Landmarks({
+  entries,
+  declaredOrder,
+  workstreamLabelById,
+  children,
+}: {
+  entries: ReadonlyArray<
+    | { kind: "track_open"; key: string; workstreamId: string; ts: string; roleLabel: string }
+    | { kind: "minute"; key: string; minute: string }
+  >;
+  declaredOrder: readonly string[];
+  workstreamLabelById: Map<string, string>;
+  children: ReactNode;
+}) {
+  if (entries.length === 0) return <>{children}</>;
+  return (
+    <>
+      {entries.map((entry) => {
+        if (entry.kind === "minute") {
+          return (
+            <div
+              key={entry.key}
+              className="mono sticky top-0 z-10 -mx-1 select-none border-b border-dashed border-ink-700 bg-ink-850/95 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-ink-300 backdrop-blur"
+              aria-hidden="false"
+            >
+              <span className="tabular-nums">{entry.minute}</span>
+            </div>
+          );
+        }
+        const color = colorForWorkstream(entry.workstreamId, declaredOrder);
+        const label = workstreamLabelById.get(entry.workstreamId) ?? entry.workstreamId;
+        const ts = new Date(entry.ts).toLocaleTimeString();
+        return (
+          <div
+            key={entry.key}
+            className="mono flex select-none items-center gap-2 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-ink-300"
+            role="presentation"
+          >
+            <span
+              aria-hidden="true"
+              className="inline-block h-2 w-8 rounded-r-0"
+              style={{ background: color }}
+            />
+            <span style={{ color }}>#{label}</span>
+            <span className="text-ink-500">opened by</span>
+            <span className="text-ink-100">{entry.roleLabel}</span>
+            <span className="ml-auto tabular-nums text-ink-500">{ts}</span>
+          </div>
+        );
+      })}
+      {children}
+    </>
   );
 }

--- a/frontend/src/components/TranscriptFilters.tsx
+++ b/frontend/src/components/TranscriptFilters.tsx
@@ -1,0 +1,280 @@
+import { CSSProperties } from "react";
+import { MessageView, WorkstreamView } from "../api/client";
+import {
+  DEFAULT_FILTER,
+  FilterState,
+  QualityFilter,
+  countFilters,
+  countHiddenMentions,
+  isDefaultFilter,
+} from "../lib/transcriptFilters";
+import { colorForWorkstream } from "../lib/workstreamPalette";
+
+interface Props {
+  /** Full (unfiltered) message list. Used to compute pill counts. */
+  messages: MessageView[];
+  workstreams: WorkstreamView[];
+  selfRoleId: string | null;
+  state: FilterState;
+  onChange: (next: FilterState) => void;
+}
+
+interface PillProps {
+  label: string;
+  count: number;
+  active: boolean;
+  tone: "default" | "warn" | "crit";
+  onClick: () => void;
+  ariaLabel?: string;
+}
+
+function FilterPill({ label, count, active, tone, onClick, ariaLabel }: PillProps) {
+  const toneClasses: Record<typeof tone, { active: string; idle: string }> = {
+    default: {
+      active:
+        "border-signal-deep bg-signal-tint text-signal-bright",
+      idle: "border-ink-500 bg-ink-700 text-ink-200 hover:border-ink-400 hover:text-ink-100",
+    },
+    warn: {
+      active: "border-warn bg-warn-bg text-warn",
+      idle: "border-ink-500 bg-ink-700 text-ink-200 hover:border-warn hover:text-warn",
+    },
+    crit: {
+      active: "border-crit bg-crit-bg text-crit",
+      idle: "border-ink-500 bg-ink-700 text-ink-200 hover:border-crit hover:text-crit",
+    },
+  };
+  const cls = active ? toneClasses[tone].active : toneClasses[tone].idle;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={ariaLabel ?? `${label} (${count})`}
+      className={`mono inline-flex items-center gap-1.5 rounded-r-1 border px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.10em] leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal focus-visible:ring-offset-1 focus-visible:ring-offset-ink-900 ${cls}`}
+    >
+      <span>{label}</span>
+      <span
+        className="rounded-r-1 bg-ink-900/40 px-1 py-0.5 text-[10px] tabular-nums"
+        aria-hidden="true"
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+interface TrackPillProps {
+  ws: WorkstreamView;
+  count: number;
+  active: boolean;
+  color: string;
+  onToggle: () => void;
+}
+
+function TrackPill({ ws, count, active, color, onToggle }: TrackPillProps) {
+  // User-persona review H1: keep the color swatch visible in BOTH
+  // states. Pre-fix the active state dropped the swatch, leaving the
+  // operator with no recall cue for "which color is this track" right
+  // when the mapping matters most (when filtering on it). Now the
+  // swatch + label always renders together — the active vs idle
+  // distinction is signaled by the border color + tinted background
+  // alone.
+  const styles: CSSProperties = active
+    ? {
+        borderColor: color,
+        background: `color-mix(in oklch, ${color} 16%, transparent)`,
+        color,
+      }
+    : {};
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      aria-label={`${ws.label} (${count})`}
+      style={styles}
+      className={`mono inline-flex items-center gap-1.5 rounded-r-1 border px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.10em] leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal focus-visible:ring-offset-1 focus-visible:ring-offset-ink-900 ${
+        active
+          ? ""
+          : "border-ink-500 bg-ink-700 text-ink-200 hover:border-ink-300 hover:text-ink-050"
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-block h-2.5 w-2.5 shrink-0 rounded-r-0"
+        style={{ background: color }}
+      />
+      <span>#{ws.label}</span>
+      <span
+        className="rounded-r-1 bg-ink-900/40 px-1 py-0.5 text-[10px] tabular-nums"
+        aria-hidden="true"
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+export function TranscriptFilters({
+  messages,
+  workstreams,
+  selfRoleId,
+  state,
+  onChange,
+}: Props) {
+  const declaredOrder = workstreams.map((ws) => ws.id);
+  const counts = countFilters(messages, declaredOrder, selfRoleId);
+  const hidden = countHiddenMentions(messages, state, selfRoleId);
+
+  function setQuality(q: QualityFilter) {
+    onChange({ quality: q, tracks: state.tracks });
+  }
+  function toggleTrack(id: string) {
+    const next = new Set(state.tracks);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange({ quality: state.quality, tracks: next });
+  }
+  function clearAll() {
+    onChange(DEFAULT_FILTER);
+  }
+
+  const showAllVisible = !isDefaultFilter(state);
+  const trackPillsVisible = workstreams.length > 0;
+  // Plan §4.7 + iter-3 noise feedback: hard cap is 8 workstreams. We
+  // wrap the pills in flex-wrap so a 6-7-pill row degrades gracefully
+  // before any overflow popover is needed; UI/UX review specifically
+  // asked we don't let 5+ workstreams force a horizontal scroll.
+
+  // Build the active-filter description used by the screen-reader
+  // announcement on the hidden-mentions banner. Operator-voice short
+  // form, no marketing copy.
+  const activeDescription = describeFilter(state, workstreams);
+
+  return (
+    <div
+      className="flex shrink-0 flex-col gap-2 border-b border-ink-700 bg-ink-850 px-3 py-2"
+      role="group"
+      aria-label="Transcript filters"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <FilterPill
+          label="All"
+          count={counts.all}
+          active={state.quality === "all"}
+          tone="default"
+          onClick={() => setQuality("all")}
+        />
+        <FilterPill
+          label="@Me"
+          count={counts.me}
+          active={state.quality === "me"}
+          tone="warn"
+          onClick={() => setQuality("me")}
+          ariaLabel={`Mentions of you (${counts.me})`}
+        />
+        <FilterPill
+          label="Critical"
+          count={counts.critical}
+          active={state.quality === "critical"}
+          tone="crit"
+          onClick={() => setQuality("critical")}
+        />
+        {showAllVisible ? (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="mono ml-auto rounded-r-1 border border-transparent px-2 py-1 text-[11px] font-bold uppercase tracking-[0.10em] leading-none text-signal hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal focus-visible:ring-offset-1 focus-visible:ring-offset-ink-900"
+            aria-label="Clear all transcript filters"
+          >
+            Reset filters
+          </button>
+        ) : null}
+      </div>
+      {trackPillsVisible ? (
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="Workstream filters — combined with the quality pill above (any selected track is shown)"
+        >
+          <span
+            className="mono text-[10px] font-bold uppercase tracking-[0.16em] text-ink-400"
+            // sr-only-equivalent: hide the visual word from AT
+            // (replaced by the role="group" aria-label above), but
+            // keep the visual hint for sighted users.
+            aria-hidden="true"
+          >
+            AND TRACKS:
+          </span>
+          {workstreams.map((ws) => (
+            <TrackPill
+              key={ws.id}
+              ws={ws}
+              count={counts.perTrack[ws.id] ?? 0}
+              active={state.tracks.has(ws.id)}
+              color={colorForWorkstream(ws.id, declaredOrder)}
+              onToggle={() => toggleTrack(ws.id)}
+            />
+          ))}
+        </div>
+      ) : null}
+      {hidden > 0 ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex flex-wrap items-center gap-2 rounded-r-1 border border-info bg-info-bg px-2.5 py-1.5 text-[12px] text-info"
+        >
+          <span aria-hidden="true">ⓘ</span>
+          <span>
+            {hidden} @-mention{hidden === 1 ? "" : "s"} for you hidden by the
+            current filter
+            {activeDescription ? ` (${activeDescription})` : ""}
+          </span>
+          {/*
+            User-persona review H3: a single "Show all" was a nuke
+            button — clearing my Comms-track focus to find a
+            Containment mention. The "Show those" affordance jumps
+            directly to the @Me filter (clearing the other quality
+            filter and any track filters), so the operator can read
+            the missed mentions and then return to their previous
+            filter manually. Two distinct exits beat one.
+          */}
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() =>
+                onChange({ quality: "me", tracks: new Set<string>() })
+              }
+              className="mono rounded-r-1 border border-info px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.10em] leading-none text-info hover:bg-ink-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal focus-visible:ring-offset-1 focus-visible:ring-offset-ink-900"
+              aria-label="Switch filter to mentions of you"
+            >
+              Show those
+            </button>
+            <button
+              type="button"
+              onClick={clearAll}
+              className="mono rounded-r-1 border border-info px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.10em] leading-none text-info hover:bg-ink-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal focus-visible:ring-offset-1 focus-visible:ring-offset-ink-900"
+              aria-label="Clear all transcript filters"
+            >
+              Reset filters
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function describeFilter(
+  state: FilterState,
+  workstreams: WorkstreamView[],
+): string {
+  const parts: string[] = [];
+  if (state.quality === "me") parts.push("@Me");
+  else if (state.quality === "critical") parts.push("Critical");
+  for (const ws of workstreams) {
+    if (state.tracks.has(ws.id)) parts.push(`#${ws.label}`);
+  }
+  return parts.join(", ");
+}

--- a/frontend/src/lib/transcriptFilters.ts
+++ b/frontend/src/lib/transcriptFilters.ts
@@ -1,0 +1,145 @@
+/**
+ * Phase B chat-declutter (docs/plans/chat-decluttering.md §4.7):
+ * filtering helpers for ``TranscriptFilters`` + ``Transcript``.
+ *
+ * Filter contract:
+ *   * Quality filter is single-valued: ``"all"`` | ``"me"`` | ``"critical"``.
+ *   * Track filter is a Set of workstream ids; OR within the set,
+ *     AND-combined with the quality pill.
+ *   * Empty track filter = no track filtering active (does NOT mean
+ *     "show only ``#main``" — there's no ``#main`` pill in this
+ *     iteration; the ``#main`` bucket is implicit / unfiltered).
+ *
+ * Two pure helpers:
+ *   * ``filterMessages`` — applies the active filter to the message
+ *     list. Used to compute the messages handed to ``Transcript``.
+ *   * ``countFilters`` — returns counts for each pill so the UI can
+ *     render badges without re-iterating in the component itself.
+ */
+
+import type { MessageView } from "../api/client";
+
+export type QualityFilter = "all" | "me" | "critical";
+
+export interface FilterState {
+  quality: QualityFilter;
+  tracks: ReadonlySet<string>;
+}
+
+export const DEFAULT_FILTER: FilterState = {
+  quality: "all",
+  tracks: new Set<string>(),
+};
+
+export function isDefaultFilter(state: FilterState): boolean {
+  return state.quality === "all" && state.tracks.size === 0;
+}
+
+function passesQuality(
+  msg: MessageView,
+  quality: QualityFilter,
+  selfRoleId: string | null,
+): boolean {
+  if (quality === "all") return true;
+  if (quality === "critical") return msg.kind === "critical_inject";
+  // Plan §6.1 (and User-persona review H4): ``@Me`` is strictly
+  // "messages aimed AT me" — i.e. ``mentions.includes(selfRoleId)``.
+  // Earlier draft also matched ``msg.role_id === selfRoleId`` (my own
+  // posts), but that diluted the count badge and confused the
+  // semantic ("@Me" should mean "addressed to me", not "my thread").
+  // The structural source of mentions is server-stamped at dispatch
+  // time from the routing tools' role_id arg — never body-parsed.
+  if (quality === "me") {
+    if (selfRoleId == null) return false;
+    return (msg.mentions ?? []).includes(selfRoleId);
+  }
+  return true;
+}
+
+function passesTrack(msg: MessageView, tracks: ReadonlySet<string>): boolean {
+  if (tracks.size === 0) return true;
+  // ``null`` workstream_id (the ``#main`` bucket) never matches a
+  // track filter. Plan §4.7 calls out that selecting any track pill
+  // hides ``#main`` — that's the whole point of "show me only the
+  // Containment thread".
+  return msg.workstream_id != null && tracks.has(msg.workstream_id);
+}
+
+export function filterMessages(
+  messages: MessageView[],
+  state: FilterState,
+  selfRoleId: string | null,
+): MessageView[] {
+  if (isDefaultFilter(state)) return messages;
+  return messages.filter(
+    (m) =>
+      passesQuality(m, state.quality, selfRoleId) &&
+      passesTrack(m, state.tracks),
+  );
+}
+
+export interface FilterCounts {
+  all: number;
+  me: number;
+  critical: number;
+  /** Per-workstream message counts; only populated for declared ids. */
+  perTrack: Record<string, number>;
+}
+
+export function countFilters(
+  messages: MessageView[],
+  declaredTrackIds: readonly string[],
+  selfRoleId: string | null,
+): FilterCounts {
+  const counts: FilterCounts = {
+    all: messages.length,
+    me: 0,
+    critical: 0,
+    perTrack: Object.fromEntries(declaredTrackIds.map((id) => [id, 0])),
+  };
+  for (const m of messages) {
+    if (m.kind === "critical_inject") counts.critical += 1;
+    // Plan §6.1: ``@Me`` count mirrors the filter — strictly
+    // "messages addressed to me", i.e. ``mentions.includes(self)``.
+    if (selfRoleId != null && (m.mentions ?? []).includes(selfRoleId)) {
+      counts.me += 1;
+    }
+    // Object.prototype.hasOwnProperty guard (Security review LOW3):
+    // ``in`` walks the prototype chain. While the AI-declared ids are
+    // regex-constrained to ``^[a-z][a-z0-9_]*$`` (so ``toString`` /
+    // ``constructor`` would slip through), defensive iteration via
+    // ``hasOwnProperty.call`` makes the check stable against any
+    // future schema relaxation.
+    const wsId = m.workstream_id;
+    if (
+      wsId != null &&
+      Object.prototype.hasOwnProperty.call(counts.perTrack, wsId)
+    ) {
+      counts.perTrack[wsId] += 1;
+    }
+  }
+  return counts;
+}
+
+/**
+ * How many ``mentions.includes(selfRoleId)`` messages does the active
+ * filter currently hide? Drives the sky-blue "N @-mentions for you
+ * hidden" banner above the transcript (plan §4.7).
+ */
+export function countHiddenMentions(
+  messages: MessageView[],
+  state: FilterState,
+  selfRoleId: string | null,
+): number {
+  if (selfRoleId == null) return 0;
+  if (isDefaultFilter(state)) return 0;
+  let hidden = 0;
+  for (const m of messages) {
+    if (!(m.mentions ?? []).includes(selfRoleId)) continue;
+    const passes =
+      passesQuality(m, state.quality, selfRoleId) &&
+      passesTrack(m, state.tracks);
+    if (!passes) hidden += 1;
+  }
+  return hidden;
+}

--- a/frontend/src/lib/workstreamPalette.ts
+++ b/frontend/src/lib/workstreamPalette.ts
@@ -1,0 +1,73 @@
+/**
+ * Phase B chat-declutter (docs/plans/chat-decluttering.md §4.7):
+ * deterministic 6-slot color palette for declared workstreams.
+ *
+ * Assignment rule: workstreams are colored in declaration order
+ * (slot 0 → slot 5). The 7th and 8th workstreams (the schema's hard
+ * cap is 8 — see ``declare_workstreams.input_schema.maxItems``) wrap
+ * back to slots 0–1; the operator iter-3 visual-noise feedback is
+ * mitigated server-side by the soft cap of 5, so wrap-around is a
+ * legitimate edge that doesn't deserve dedicated chrome.
+ *
+ * The synthetic ``#main`` (unscoped) bucket gets slate gray —
+ * deliberately picked to read as "neutral / unassigned" rather than
+ * one of the named tracks.
+ *
+ * Color values are inline oklch literals rather than design tokens
+ * because the palette is a *runtime* allocation (slot N → declared
+ * workstream N), not a brand role. The brand tokens (signal / crit /
+ * warn / info) keep their reserved meanings; the workstream palette
+ * is intentionally orthogonal so a "containment" stripe doesn't
+ * collide with the critical-inject red bubble or the active-turn
+ * amber ring.
+ */
+
+/** Slate gray for ``#main`` / unscoped messages. Reads as neutral. */
+export const MAIN_TRACK_COLOR = "oklch(0.55 0.025 240)";
+
+/**
+ * Six declaration-order slots. Hues are picked to avoid collision
+ * with the reserved brand tokens — UI/UX review HIGH H3 specifically
+ * flagged that an earlier draft put slot 4 at hue 90 (mustard, ΔH=15
+ * from ``--warn`` at 75), and a mustard-tracked message that also
+ * mentioned the viewer rendered three amber signals on the same edge
+ * (stripe + mention ring + ``@YOU`` badge). Hues here keep:
+ *
+ *   * ≥ 50 deg from ``--warn`` (75)  — slot 4 lands at olive 125.
+ *   * ≥ 30 deg from ``--crit`` (25)  — slot 5 (rust 55) is the
+ *     closest; the L/C envelope keeps it visually distinct.
+ *   * ≥ 30 deg from ``--signal`` (245) — teal slot 0 at 195 is the
+ *     closest, again the L/C delta keeps separation.
+ *   * ≥ 30 deg from ``--info`` (232) — same teal/signal proximity is
+ *     the binding constraint.
+ *
+ * Adding a 7th/8th slot wraps back to slot 0 (workstreams cap at 8;
+ * the soft cap is 5, so wrap-around is rare).
+ */
+export const WORKSTREAM_PALETTE: readonly string[] = [
+  "oklch(0.70 0.13 195)", // teal
+  "oklch(0.70 0.18 295)", // violet
+  "oklch(0.72 0.16 340)", // magenta
+  "oklch(0.74 0.15 145)", // green
+  "oklch(0.74 0.13 125)", // olive   (≥ 50 deg from --warn at 75)
+  "oklch(0.66 0.16 55)",  // rust    (distinct from --crit at 25)
+] as const;
+
+/**
+ * Resolve the stripe color for a message given the session's declared
+ * workstream registry. ``null`` workstream_id ⇒ ``#main`` slate.
+ *
+ * Returns ``MAIN_TRACK_COLOR`` for unknown ids too — a stale id that
+ * survived dispatch validation (e.g. a snapshot from before a flag
+ * flip) shouldn't crash the renderer; falling back to neutral is the
+ * safest visual.
+ */
+export function colorForWorkstream(
+  workstreamId: string | null | undefined,
+  declaredOrder: readonly string[],
+): string {
+  if (!workstreamId) return MAIN_TRACK_COLOR;
+  const index = declaredOrder.indexOf(workstreamId);
+  if (index < 0) return MAIN_TRACK_COLOR;
+  return WORKSTREAM_PALETTE[index % WORKSTREAM_PALETTE.length];
+}

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -5,7 +5,27 @@
 export type ServerEvent =
   | { type: "state_changed"; state: string; active_role_ids: string[]; turn_index: number | null }
   | { type: "message_chunk"; turn_id: string; text: string }
-  | { type: "message_complete"; kind: string; body: string; tool_name: string | null; turn_id: string | null }
+  | {
+      type: "message_complete";
+      kind: string;
+      body: string;
+      tool_name: string | null;
+      turn_id: string | null;
+      /**
+       * Phase B chat-declutter (docs/plans/chat-decluttering.md §4.8):
+       * server-validated workstream tag. ``null`` = synthetic ``#main``
+       * (unscoped) bucket. The colored track-bar stripe in
+       * ``Transcript.tsx`` reads this field directly.
+       */
+      workstream_id?: string | null;
+      /**
+       * Phase B chat-declutter (plan §5.1): structural source for the
+       * @-highlight (amber outline + ``(@you)`` badge). Each entry is
+       * a real ``role_id`` from the roster or the literal
+       * ``"facilitator"`` token. **Never** regex'd from ``body``.
+       */
+      mentions?: string[];
+    }
   | { type: "turn_changed"; turn_index: number; active_role_ids: string[] }
   | { type: "tool_invocation"; tool: string; args: Record<string, unknown> }
   | { type: "participant_joined"; role_id: string; label: string; display_name: string | null; kind: string }
@@ -121,6 +141,25 @@ export type ServerEvent =
     }
   | { type: "notepad_lock_pending"; locks_in_seconds: number }
   | { type: "notepad_locked"; locked_at: string | null }
+  /**
+   * Phase A chat-declutter (docs/plans/chat-decluttering.md §4.8):
+   * AI declared one or more workstreams during setup (the new tool
+   * ``declare_workstreams``). Recorded server-side so a late joiner
+   * still sees the registry replay through their snapshot fetch.
+   * ``record=True`` so reconnecting tabs stay in sync with the
+   * filter UI's available pills.
+   */
+  | {
+      type: "workstream_declared";
+      workstreams: {
+        id: string;
+        label: string;
+        lead_role_id: string | null;
+        state: "open" | "closed";
+        created_at: string;
+        closed_at: string | null;
+      }[];
+    }
   | { type: "error"; scope: string; message: string };
 
 export type ClientEvent =

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -20,6 +20,12 @@ import { RolesPanel } from "../components/RolesPanel";
 import { SessionActivityPanel } from "../components/SessionActivityPanel";
 import { SetupChat } from "../components/SetupChat";
 import { Transcript } from "../components/Transcript";
+import { TranscriptFilters } from "../components/TranscriptFilters";
+import {
+  DEFAULT_FILTER,
+  FilterState,
+  filterMessages,
+} from "../lib/transcriptFilters";
 import { BottomActionBar } from "../components/brand/BottomActionBar";
 import { DieLoader } from "../components/brand/DieLoader";
 import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
@@ -253,6 +259,12 @@ export function Facilitator() {
   // 3-second client-side cooldown on force-advance — paired with the
   // backend in-flight gate in ``manager.force_advance``. See issue #63.
   const [forceAdvanceCooldown, setForceAdvanceCooldown] = useState(false);
+  // Phase B chat-declutter (docs/plans/chat-decluttering.md §4.7):
+  // creator-side filter state for the TranscriptFilters component
+  // above the chat. Mirrors the player-side state in ``Play.tsx`` so
+  // the same filter logic drives both surfaces.
+  const [transcriptFilter, setTranscriptFilter] =
+    useState<FilterState>(DEFAULT_FILTER);
   // Live AI decision rationale stream (issue #55). Entries arrive via
   // ``decision_logged`` events as the AI calls
   // ``record_decision_rationale``; on snapshot refresh we replace the
@@ -1193,6 +1205,24 @@ export function Facilitator() {
             an operator literally couldn't reach the "Approve plan" button.
           */}
           {/*
+            Phase B chat-declutter (UI/UX review BLOCK):
+            ``TranscriptFilters`` lives OUTSIDE the scroll region so the
+            filter pills + hidden-mentions banner stay reachable as the
+            creator scrolls down through the transcript. Pre-fix the
+            component was nested inside ``scrollRegionRef`` and scrolled
+            out of view mid-exercise — the player view (``Play.tsx``)
+            already had this layout right; the creator view didn't.
+          */}
+          {phase === "play" ? (
+            <TranscriptFilters
+              messages={snapshot.messages}
+              workstreams={snapshot.workstreams ?? []}
+              selfRoleId={state.creatorRoleId}
+              state={transcriptFilter}
+              onChange={setTranscriptFilter}
+            />
+          ) : null}
+          {/*
             Scroll region: holds whatever scrolls within a phase. For
             setup/ready/ended this is the entire phase content. For play
             the *transcript only* lives here so the Composer (a sibling
@@ -1258,8 +1288,13 @@ export function Facilitator() {
                 </div>
               ) : null}
               <Transcript
-                messages={snapshot.messages}
+                messages={filterMessages(
+                  snapshot.messages,
+                  transcriptFilter,
+                  state.creatorRoleId,
+                )}
                 roles={snapshot.roles}
+                workstreams={snapshot.workstreams ?? []}
                 aiThinking={
                   // Authoritative: any LLM call boundary in flight, or
                   // an active stream, lights the typing indicator. The
@@ -1484,6 +1519,10 @@ export function Facilitator() {
           <RightSidebar
             messages={snapshot.messages}
             roles={snapshot.roles}
+            // Phase B chat-declutter: same recovery as the player path
+            // — Timeline pin against a filtered-out message clears the
+            // filter so the next click lands.
+            onScrollMissed={() => setTranscriptFilter(DEFAULT_FILTER)}
             notepad={
               wsClient ? (
                 <SharedNotepad

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -13,6 +13,12 @@ import { RightSidebar } from "../components/RightSidebar";
 import { RoleRoster } from "../components/RoleRoster";
 import { SharedNotepad } from "../components/SharedNotepad";
 import { Transcript } from "../components/Transcript";
+import { TranscriptFilters } from "../components/TranscriptFilters";
+import {
+  DEFAULT_FILTER,
+  FilterState,
+  filterMessages,
+} from "../lib/transcriptFilters";
 import { DieLoader } from "../components/brand/DieLoader";
 import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
@@ -127,6 +133,14 @@ export function Play({ sessionId, token }: Props) {
   // can sit idle and the notepad never mounts. Issue surfaced during
   // manual smoke for #98.
   const [wsClient, setWsClient] = useState<WsClient | null>(null);
+  // Phase B chat-declutter (docs/plans/chat-decluttering.md §4.7):
+  // local filter state for the TranscriptFilters component above the
+  // chat. Quality is single-valued (All / @Me / Critical); track set
+  // is multi-select OR within the set, AND-combined with quality.
+  // Default = ``"all" + empty set`` = no filtering = identical
+  // behaviour to the pre-Phase-B chat.
+  const [transcriptFilter, setTranscriptFilter] =
+    useState<FilterState>(DEFAULT_FILTER);
   const forceAdvanceTimerRef = useRef<number | null>(null);
 
   // Determine self by inspecting snapshot.roles and matching the role with the
@@ -1143,13 +1157,25 @@ export function Play({ sessionId, token }: Props) {
             region while Composer + notice + error live below as a
             shrink-0 footer.
           */}
+          <TranscriptFilters
+            messages={snapshot.messages}
+            workstreams={snapshot.workstreams ?? []}
+            selfRoleId={selfRoleId}
+            state={transcriptFilter}
+            onChange={setTranscriptFilter}
+          />
           <div
             ref={scrollRegionRef}
             className="flex min-w-0 flex-col gap-3 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1"
           >
             <Transcript
-              messages={snapshot.messages}
+              messages={filterMessages(
+                snapshot.messages,
+                transcriptFilter,
+                selfRoleId,
+              )}
               roles={snapshot.roles}
+              workstreams={snapshot.workstreams ?? []}
               aiThinking={showAiThinking}
               aiStatusLabel={
                 aiStatusLabel ?? (streamingActive ? "Typing…" : undefined)
@@ -1278,6 +1304,11 @@ export function Play({ sessionId, token }: Props) {
           <RightSidebar
             messages={snapshot.messages}
             roles={snapshot.roles}
+            // Phase B chat-declutter: clear the transcript filter
+            // when a Timeline pin's target is hidden, then the user
+            // can click the pin again. UI/UX review HIGH — pre-fix
+            // was a silent no-op that read as "the app is broken".
+            onScrollMissed={() => setTranscriptFilter(DEFAULT_FILTER)}
             notepad={
               wsClient && selfRoleId ? (
                 <SharedNotepad


### PR DESCRIPTION
## Summary

Ships the **visible filter chrome** for the chat-declutter feature. The metadata pipeline already lands through the backend (Phase A); this PR makes it visible to users in the transcript.

Cites plan **§3.1 (deferred tools)** and **§4.7 (UI delta)** in `docs/plans/chat-decluttering.md`.

### Backend (small)

- Extend `pose_choice` / `share_data` / `inject_critical_event` with the optional `workstream_id` field, factored through a shared `_WORKSTREAM_ID_FIELD` schema. Dispatch validation reuses the existing `_validate_workstream_id` helper. Strict-retry semantics preserved (invalid id → `tool_result is_error=True`; the model self-corrects).
- API snapshot endpoint serializes `Message.workstream_id`, `Message.mentions[]`, and a session-level `workstreams[]` list (visible to every participant — the filter pills need the same registry the creator sees).
- Implements **plan §4.4 player-reply workstream inheritance**: a player's reply inherits the most recent AI-addressed-to-them workstream so the filter doesn't fragment a coherent thread when toggled.
- `_WORKSTREAMS_PLAY_NOTE` in `prompts.py` updated to mention all four workstream-aware tools (was: only `address_role`).

### Frontend (the bulk)

- New **`TranscriptFilters` component** above the chat:
  - Top row: All / @Me / Critical pills with counts.
  - Second row (when any workstreams declared): per-workstream multi-select pills.
  - "Reset filters" link clears everything.
  - Sky-blue **hidden-mentions banner** with two recovery actions: "Show those" (jumps to @Me) and "Reset filters".
- **`Transcript.tsx`** chrome:
  - 3 px workstream-colored stripe per message (slate gray for `#main` / unscoped).
  - Structural `@`-highlight from `Message.mentions[]` — amber outline + `@YOU` badge. **Never** regex on `body` (plan §5.1).
  - Synthetic "track opened by ROLE at HH:MM:SS" landmark rows (frontend-computed, single walk).
  - Sticky minute-anchor rows.
- Wired into both `Play.tsx` (player) and `Facilitator.tsx` (creator).
- Timeline pin × filter dead-click resolved via `onScrollMissed` callback that clears the filter when a missed scroll target is filtered out.

### Decisions locked in (plan §10)

- 6-slot color palette in declaration order, slate gray for `#main`. Hue spacing chosen to avoid collision with `--signal` / `--crit` / `--warn` / `--info` (slot 4 moved from mustard 90 to olive 125 after UI/UX review flagged the ΔH=15 collision with `--warn`).
- Track multi-select is OR within the set, AND-combined with the quality pill.
- Hidden-mentions banner is the only "missed something" affordance.

### Out of scope (deferred per mandate)

- Right-rail tabs (Artifacts / Action items / Timeline)
- Manual workstream override on messages
- Export buttons
- Flipping `WORKSTREAMS_ENABLED` to `True`
- Anything pause-toggle related

### Sub-agent reviews (per CLAUDE.md)

All six ran. **BLOCK + every HIGH addressed in this commit.** LOWs deferred.

- **Product / App-Owner** → PASS. All 7 mandate items implemented; no out-of-scope work snuck in.
- **QA** → HIGH §4.4 inheritance: shipped (`_inherit_workstream_id` in `manager.py` + tests). HIGH Transcript rendering tests: added (`Transcript.workstream.test.tsx`).
- **Security Engineer** → LOW: workstream_id audit echoes length-capped to 120 chars; `MessageView` types tightened to required (no-back-compat); `perTrack` count uses `hasOwnProperty.call` (prototype-chain safe).
- **UI/UX** → BLOCK: filter row moved OUT of Facilitator scroll region. HIGH: focus rings → `focus-visible:`; track-pill swatch stays visible in active state; `AND TRACKS:` row got an `aria-label`; palette slot 4 hue moved 90→125; banner glyph ⚠→ⓘ (info-tone consistent).
- **User Agent (creator persona)** → HIGH: `@Me` filter is strict-mentions only (drops self-author bubbles per plan §6.1); hidden-mentions banner now offers `Show those` jump + `Reset filters`; `Show all` button renamed `Reset filters` to avoid label collision with the `All` quality pill; track-pill swatch always visible.
- **Prompt Expert** → HIGH: `_WORKSTREAMS_PLAY_NOTE` updated to mention all four workstream-aware tools; no new prose in tool descriptions; only the input_schema grew.

### Scenario lifecycle

No new `MessageKind` / tool name / state transition / message field beyond Phase A. The existing recorded scenarios round-trip; the new tool extensions only add an optional input-schema field. No scenario JSON edits needed.

## Test plan

- [x] `cd backend && /tmp/venv/bin/python -m pytest -q` → **592 passed, 42 skipped**
- [x] `cd backend && ruff check . && mypy app` → clean
- [x] `cd frontend && npm test -- --run` → **321 passed**
- [x] `cd frontend && npm run lint && npm run typecheck` → clean
- [x] New tests: `tests/test_chat_declutter_phase_b.py` (13 dispatch + inheritance), `frontend/src/__tests__/transcriptFilters.test.ts` (filter logic), `TranscriptFilters.test.tsx` (UI), `Transcript.workstream.test.tsx` (chrome rendering).
- [ ] Manual smoke against a live multi-track session (filter pills, hidden-mentions banner, stripe colors, landmark rows) — pending operator session.
- [ ] Visual regression on 1080p / 1440p / mobile viewports — pending.

https://claude.ai/code/session_01DdcGkLbrz7fe7CDne79rRe

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdcGkLbrz7fe7CDne79rRe)_