### PR TITLE
setup-wizard: extend chrome through setup+ready, move creator role to step 3

### DIFF
--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -118,13 +118,14 @@ describe("Facilitator intro — Roles to invite (issue #61)", () => {
 
   it("warns when the creator label collides with an invitee chip", () => {
     render(<Facilitator />);
-    // Creator role lives on step 1; collision warning shows on step 3.
-    // Pre-fill the label, then advance to roles.
+    // Issue #159: creator role + display name live on Step 3 (Roles)
+    // alongside the invitee chips, not on Step 1 (Scenario). Advance
+    // to roles first, then edit the creator label.
+    advanceToRoles();
     const labelInput = screen.getByPlaceholderText(
       /Your role label/i,
     ) as HTMLInputElement;
     fireEvent.change(labelInput, { target: { value: "IR Lead" } });
-    advanceToRoles();
     expect(
       screen.getByText(/won't be auto-added as a separate invitee/i),
     ).toBeInTheDocument();

--- a/frontend/src/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/__tests__/SetupWizard.test.tsx
@@ -1,0 +1,231 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SetupWizard, type SetupParts } from "../components/setup/SetupWizard";
+import type { ScenarioPlan, SessionSnapshot } from "../api/client";
+
+/**
+ * Unit-level coverage for the wizard's phase routing — fixes the
+ * "QA HIGH: no integration test for the new setup/ready branch"
+ * finding from PR review on issue #113. The Facilitator owns all
+ * the stateful machinery (snapshot, ws, presence); the wizard
+ * itself is presentational + a local introStep state. Testing the
+ * wizard directly with mocked snapshots covers the load-bearing
+ * step 4↔5↔6 routing without needing to mock the full api/ws
+ * surface.
+ */
+
+const EMPTY_PARTS: SetupParts = {
+  scenario: "",
+  team: "",
+  environment: "",
+  constraints: "",
+};
+
+function fakeSnapshot(overrides: {
+  state: string;
+  plan?: ScenarioPlan | null;
+  playerCount?: number;
+}): SessionSnapshot {
+  return {
+    id: "session_test",
+    state: overrides.state,
+    created_at: "2026-05-05T00:00:00Z",
+    scenario_prompt: "test scenario",
+    plan: overrides.plan ?? null,
+    roles: [],
+    current_turn: null,
+    messages: [],
+    setup_notes: [],
+    cost: null,
+    workstreams: [],
+  };
+}
+
+function fakePlan(): ScenarioPlan {
+  return {
+    title: "Test plan",
+    executive_summary: "summary",
+    key_objectives: ["obj 1"],
+    guardrails: [],
+    success_criteria: [],
+    out_of_scope: [],
+    narrative_arc: [],
+    injects: [{ trigger: "T+10", type: "info", summary: "ping" }],
+  };
+}
+
+function baseProps() {
+  return {
+    setupParts: { ...EMPTY_PARTS },
+    setSetupParts: vi.fn(),
+    creatorLabel: "CISO",
+    setCreatorLabel: vi.fn(),
+    creatorDisplayName: "Alice",
+    setCreatorDisplayName: vi.fn(),
+    setupRoles: ["IR Lead"],
+    setSetupRoles: vi.fn(),
+    setupRoleDraft: "",
+    setSetupRoleDraft: vi.fn(),
+    devMode: false,
+    setDevMode: vi.fn(),
+    busy: false,
+    busyMessage: null,
+    error: null,
+    onSubmit: vi.fn((e) => e.preventDefault()),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SetupWizard — phase routing (issue #113)", () => {
+  it("intro: highlights step 01 and renders the intro form", () => {
+    render(<SetupWizard phase="intro" {...baseProps()} />);
+    // Rail + main panel should both reflect Step 1 (Scenario).
+    expect(screen.getByText("01")).toBeInTheDocument();
+    expect(screen.getByText("Scenario")).toBeInTheDocument();
+    expect(screen.getByText(/Set the scene/i)).toBeInTheDocument();
+  });
+
+  it("setup: highlights step 04 (Injects & schedule) and renders the slot content", () => {
+    render(
+      <SetupWizard
+        phase="setup"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "SETUP" })}
+        playerCount={1}
+        postCreationContent={<div data-testid="setup-slot">setup-slot</div>}
+      />,
+    );
+    // Eyebrow lower-cased in PostCreationBody — match insensitively.
+    expect(
+      screen.getByText(/step 04 · injects & schedule/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/AI is drafting the plan/i)).toBeInTheDocument();
+    expect(screen.getByTestId("setup-slot")).toBeInTheDocument();
+  });
+
+  it("ready + no plan: highlights step 05 (Invite players)", () => {
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "READY", plan: null })}
+        playerCount={3}
+        postCreationContent={<div data-testid="lobby-slot">lobby</div>}
+      />,
+    );
+    expect(screen.getByText(/step 05 · invite players/i)).toBeInTheDocument();
+    expect(screen.getByTestId("lobby-slot")).toBeInTheDocument();
+  });
+
+  it("ready + plan but <2 players: still step 05 (gate not met)", () => {
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
+        playerCount={1}
+        postCreationContent={<div data-testid="lobby-slot">lobby</div>}
+      />,
+    );
+    expect(screen.getByText(/step 05 · invite players/i)).toBeInTheDocument();
+    expect(screen.queryByText(/step 06/i)).not.toBeInTheDocument();
+  });
+
+  it("ready + plan + ≥2 players: highlights step 06 (Review & launch)", () => {
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
+        playerCount={2}
+        postCreationContent={<div data-testid="review-slot">review</div>}
+      />,
+    );
+    expect(screen.getByText(/step 06 · review & launch/i)).toBeInTheDocument();
+    expect(screen.getByTestId("review-slot")).toBeInTheDocument();
+  });
+});
+
+describe("SetupWizard — rail back-nav (User HIGH#2)", () => {
+  it("intro: completed steps are clickable buttons that jump back", () => {
+    render(<SetupWizard phase="intro" {...baseProps()} />);
+    // Advance to step 2 then step 3 by clicking NEXT.
+    fireEvent.click(
+      screen.getByRole("button", { name: /NEXT · ENVIRONMENT/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /NEXT · ROLES/i }));
+    // Now on Step 3. Step 1 should be a button (completed → clickable).
+    const step1 = screen.getByRole("button", { name: /Step 1: Scenario/i });
+    expect(step1).toBeInTheDocument();
+    fireEvent.click(step1);
+    // After clicking Step 1, the body should re-render Step 1's
+    // "Set the scene" header.
+    expect(screen.getByText(/Set the scene/i)).toBeInTheDocument();
+  });
+
+  it("post-creation: rail steps are NOT clickable (no rewind path)", () => {
+    render(
+      <SetupWizard
+        phase="setup"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "SETUP" })}
+        playerCount={1}
+        postCreationContent={null}
+      />,
+    );
+    // Step 1 / 2 / 3 are all "done" but rendered as inert <div>s,
+    // not buttons, since there's no backwards transition path.
+    expect(
+      screen.queryByRole("button", { name: /Step 1: Scenario/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("SetupWizard — ABANDON SESSION placement (UI/UX BLOCK#2)", () => {
+  it("intro: no ABANDON button (no session to abandon)", () => {
+    render(<SetupWizard phase="intro" {...baseProps()} />);
+    expect(
+      screen.queryByRole("button", { name: /ABANDON SESSION/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("post-creation with handler: ABANDON renders inside the rail (not the panel)", () => {
+    const onAbandon = vi.fn();
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
+        playerCount={2}
+        postCreationContent={null}
+        onAbandonSession={onAbandon}
+      />,
+    );
+    const rail = screen.getByRole("complementary", { name: /Setup steps/i });
+    const abandon = within(rail).getByRole("button", {
+      name: /ABANDON SESSION/i,
+    });
+    fireEvent.click(abandon);
+    expect(onAbandon).toHaveBeenCalledOnce();
+  });
+});
+
+describe("SetupWizard — error display (UI/UX HIGH#3)", () => {
+  it("post-creation: surfaces page-level error inside the panel", () => {
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        error="failed to copy join link"
+        snapshot={fakeSnapshot({ state: "READY" })}
+        playerCount={1}
+        postCreationContent={null}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/failed to copy join link/i);
+  });
+});

--- a/frontend/src/components/setup/SetupLobbyView.tsx
+++ b/frontend/src/components/setup/SetupLobbyView.tsx
@@ -78,6 +78,17 @@ export function SetupLobbyView(props: Props) {
     }
   }
 
+  // Both surface (a) the page-level error banner via ``onError`` AND
+  // (b) a console.warn breadcrumb. Per CLAUDE.md's logging rules,
+  // every page-level setError call should be paired with a
+  // matching console.warn so a user pasting their console into a bug
+  // report has the failure context.
+  function reportError(action: string, err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[SetupLobbyView] ${action} failed`, msg, err);
+    props.onError(msg);
+  }
+
   async function handleAdd(e: FormEvent) {
     e.preventDefault();
     if (!newRole.trim()) return;
@@ -91,7 +102,7 @@ export function SetupLobbyView(props: Props) {
       if (ok) markCopied(r.role_id);
       props.onRoleAdded();
     } catch (err) {
-      props.onError(err instanceof Error ? err.message : String(err));
+      reportError("add role", err);
     }
   }
 
@@ -105,7 +116,7 @@ export function SetupLobbyView(props: Props) {
       const url = `${origin}/play/${props.sessionId}/${encodeURIComponent(r.token)}`;
       if (await writeUrl(url)) markCopied(roleId);
     } catch (err) {
-      props.onError(err instanceof Error ? err.message : String(err));
+      reportError("reissue role", err);
     }
   }
 
@@ -127,7 +138,7 @@ export function SetupLobbyView(props: Props) {
       if (await writeUrl(url)) markCopied(roleId);
       props.onRoleChanged();
     } catch (err) {
-      props.onError(err instanceof Error ? err.message : String(err));
+      reportError("revoke role", err);
     }
   }
 
@@ -137,7 +148,7 @@ export function SetupLobbyView(props: Props) {
       await api.removeRole(props.sessionId, props.creatorToken, roleId);
       props.onRoleChanged();
     } catch (err) {
-      props.onError(err instanceof Error ? err.message : String(err));
+      reportError("remove role", err);
     }
   }
 

--- a/frontend/src/components/setup/SetupLobbyView.tsx
+++ b/frontend/src/components/setup/SetupLobbyView.tsx
@@ -1,0 +1,494 @@
+import { FormEvent, ReactNode, useState } from "react";
+import { RoleView, ScenarioPlan, api } from "../../api/client";
+import { Eyebrow } from "../brand/Eyebrow";
+
+/**
+ * Step 5 (Invite players) panel for the setup wizard. Brand mock
+ * reference: ``AppLobby`` in design/handoff/source/app-screens.jsx
+ * (lines 786-888).
+ *
+ * Layout (≥ 960 px):
+ *   ┌────────────────────────┬─────────────────────┐
+ *   │ Helper copy            │  Scenario sidecar:  │
+ *   │ ┌────────────────────┐ │  - Plan title       │
+ *   │ │ Wide role rows:    │ │  - Roster counts    │
+ *   │ │  CODE | name | ●   │ │  - Status hint      │
+ *   │ │  | actions...      │ │                     │
+ *   │ │ + ADD ROLE form    │ │                     │
+ *   │ └────────────────────┘ │                     │
+ *   └────────────────────────┴─────────────────────┘
+ *
+ * Per the issue #113 acceptance criterion, this is intentionally
+ * wider + less dense than the in-session ``<RolesPanel/>`` (which
+ * lives in a 240 px sidebar). The action handlers (copy / kick /
+ * remove / add) call the same ``api.*`` functions ``<RolesPanel/>``
+ * does — we render in a different layout, not via different state.
+ */
+const COPIED_FLASH_MS = 2000;
+
+interface Props {
+  sessionId: string;
+  creatorToken: string;
+  roles: RoleView[];
+  busy: boolean;
+  plan: ScenarioPlan | null;
+  playerCount: number;
+  connectedRoleIds: ReadonlySet<string>;
+  onRoleAdded: () => void;
+  onRoleChanged: () => void;
+  onError: (msg: string) => void;
+}
+
+export function SetupLobbyView(props: Props) {
+  const [newRole, setNewRole] = useState("");
+  const [copiedRoleIds, setCopiedRoleIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const origin = window.location.origin;
+  const joinedCount = props.roles.filter((r) =>
+    props.connectedRoleIds.has(r.id),
+  ).length;
+  const needPlayers = props.playerCount < 2;
+  const needPlan = !props.plan;
+
+  function markCopied(roleId: string) {
+    setCopiedRoleIds((prev) => new Set(prev).add(roleId));
+    setTimeout(() => {
+      setCopiedRoleIds((prev) => {
+        if (!prev.has(roleId)) return prev;
+        const next = new Set(prev);
+        next.delete(roleId);
+        return next;
+      });
+    }, COPIED_FLASH_MS);
+  }
+
+  async function writeUrl(url: string): Promise<boolean> {
+    if (typeof navigator.clipboard?.writeText !== "function") {
+      console.warn("[SetupLobbyView] clipboard API unavailable");
+      return false;
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      return true;
+    } catch (err) {
+      console.warn("[SetupLobbyView] clipboard write failed", err);
+      return false;
+    }
+  }
+
+  async function handleAdd(e: FormEvent) {
+    e.preventDefault();
+    if (!newRole.trim()) return;
+    try {
+      const r = await api.addRole(props.sessionId, props.creatorToken, {
+        label: newRole.trim(),
+      });
+      const url = `${origin}/play/${props.sessionId}/${encodeURIComponent(r.token)}`;
+      const ok = await writeUrl(url);
+      setNewRole("");
+      if (ok) markCopied(r.role_id);
+      props.onRoleAdded();
+    } catch (err) {
+      props.onError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function handleCopy(roleId: string) {
+    try {
+      const r = await api.reissueRole(
+        props.sessionId,
+        props.creatorToken,
+        roleId,
+      );
+      const url = `${origin}/play/${props.sessionId}/${encodeURIComponent(r.token)}`;
+      if (await writeUrl(url)) markCopied(roleId);
+    } catch (err) {
+      props.onError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function handleKick(roleId: string, label: string) {
+    if (
+      !confirm(
+        `Kick the player using "${label}"? Their tab will be disconnected and a new join link will be generated.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      const r = await api.revokeRole(
+        props.sessionId,
+        props.creatorToken,
+        roleId,
+      );
+      const url = `${origin}/play/${props.sessionId}/${encodeURIComponent(r.token)}`;
+      if (await writeUrl(url)) markCopied(roleId);
+      props.onRoleChanged();
+    } catch (err) {
+      props.onError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function handleRemove(roleId: string, label: string) {
+    if (!confirm(`Remove the "${label}" role from this session?`)) return;
+    try {
+      await api.removeRole(props.sessionId, props.creatorToken, roleId);
+      props.onRoleChanged();
+    } catch (err) {
+      props.onError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    // Stack to a single column below ``md`` so a narrow viewport
+    // doesn't wrap the sidecar BELOW the role list at unpredictable
+    // widths — at ``md`` and up restore the brand-mock 1.2fr/1fr
+    // layout.
+    <div
+      className="grid grid-cols-1 gap-6 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,1fr)] md:items-start"
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 16, minWidth: 0 }}>
+        <p
+          className="sans"
+          style={{
+            margin: 0,
+            fontSize: 14,
+            color: "var(--ink-300)",
+            lineHeight: 1.55,
+            maxWidth: 720,
+          }}
+        >
+          Share each role's join link. Players land on a per-role
+          briefing — they don't pick a seat from a list. Add or remove
+          seats here too; the change is live for everyone in the lobby.
+        </p>
+        <h2
+          className="sans"
+          style={{
+            margin: 0,
+            fontSize: 18,
+            fontWeight: 600,
+            color: "var(--ink-050)",
+          }}
+        >
+          Lobby · {joinedCount} of {props.roles.length} joined
+        </h2>
+        <div
+          style={{
+            background: "var(--ink-850)",
+            border: "1px solid var(--ink-600)",
+            borderRadius: 4,
+          }}
+        >
+          {props.roles.map((r, i) => (
+            <LobbyRow
+              key={r.id}
+              role={r}
+              joined={props.connectedRoleIds.has(r.id)}
+              copied={copiedRoleIds.has(r.id)}
+              busy={props.busy}
+              last={i === props.roles.length - 1}
+              onCopy={() => handleCopy(r.id)}
+              onKick={() => handleKick(r.id, r.label)}
+              onRemove={() => handleRemove(r.id, r.label)}
+            />
+          ))}
+        </div>
+        <form
+          onSubmit={handleAdd}
+          style={{
+            display: "flex",
+            gap: 8,
+            alignItems: "stretch",
+          }}
+        >
+          <input
+            type="text"
+            value={newRole}
+            onChange={(e) => setNewRole(e.target.value)}
+            placeholder="e.g. Threat Intel"
+            aria-label="New role label"
+            style={{
+              flex: 1,
+              background: "var(--ink-900)",
+              border: "1px solid var(--ink-600)",
+              borderRadius: 2,
+              padding: "10px 14px",
+              color: "var(--ink-100)",
+              fontFamily: "var(--font-sans)",
+              fontSize: 13,
+              outline: "none",
+            }}
+          />
+          <button
+            type="submit"
+            disabled={props.busy || !newRole.trim()}
+            className="mono"
+            style={{
+              background: "var(--signal)",
+              color: "var(--ink-900)",
+              border: "none",
+              padding: "0 22px",
+              borderRadius: 2,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.18em",
+              cursor: props.busy || !newRole.trim() ? "not-allowed" : "pointer",
+              opacity: props.busy || !newRole.trim() ? 0.5 : 1,
+            }}
+          >
+            + ADD ROLE
+          </button>
+        </form>
+      </div>
+      <aside
+        aria-label="Lobby summary"
+        className="md:sticky md:top-0"
+        style={{
+          background: "var(--ink-850)",
+          border: "1px solid var(--ink-600)",
+          borderRadius: 4,
+          padding: 20,
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
+      >
+        <Eyebrow color="var(--signal)">
+          {needPlan ? "scenario · drafting" : "scenario · ready"}
+        </Eyebrow>
+        <div
+          className="sans"
+          style={{ fontSize: 18, color: "var(--ink-050)", fontWeight: 600 }}
+        >
+          {props.plan?.title ?? "Plan still drafting…"}
+        </div>
+        <SidecarStat label="ROLES SEATED" value={String(props.roles.length)} />
+        <SidecarStat label="JOINED" value={`${joinedCount} of ${props.roles.length}`} />
+        <SidecarStat label="PLAYERS" value={String(props.playerCount)} />
+        {props.plan ? (
+          <>
+            <SidecarStat label="INJECTS" value={String(props.plan.injects.length)} />
+            <SidecarStat
+              label="OBJECTIVES"
+              value={String(props.plan.key_objectives.length)}
+            />
+          </>
+        ) : null}
+        <div
+          className="mono"
+          style={{
+            marginTop: 4,
+            padding: "10px 12px",
+            background:
+              needPlan || needPlayers ? "var(--warn-bg)" : "var(--signal-tint)",
+            border: `1px solid ${needPlan || needPlayers ? "var(--warn)" : "var(--signal-deep)"}`,
+            borderRadius: 3,
+            fontSize: 11,
+            color: needPlan || needPlayers ? "var(--warn)" : "var(--signal)",
+            letterSpacing: "0.06em",
+            lineHeight: 1.5,
+          }}
+        >
+          {needPlan
+            ? "Plan not finalized yet — finish setup in step 04."
+            : needPlayers
+              ? `Need at least 2 player roles before launch (currently ${props.playerCount}).`
+              : "Ready — advance to step 06 to review and launch."}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function LobbyRow({
+  role,
+  joined,
+  copied,
+  busy,
+  last,
+  onCopy,
+  onKick,
+  onRemove,
+}: {
+  role: RoleView;
+  joined: boolean;
+  copied: boolean;
+  busy: boolean;
+  last: boolean;
+  onCopy: () => void;
+  onKick: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div
+      style={{
+        padding: "14px 18px",
+        borderBottom: last ? "none" : "1px solid var(--ink-600)",
+        display: "flex",
+        alignItems: "center",
+        gap: 16,
+        flexWrap: "wrap",
+      }}
+    >
+      <div
+        className="mono"
+        style={{
+          minWidth: 96,
+          fontSize: 12,
+          fontWeight: 700,
+          color: "var(--ink-100)",
+          letterSpacing: "0.10em",
+          textTransform: "uppercase",
+          wordBreak: "break-word",
+        }}
+        title={role.label}
+      >
+        {role.label}
+      </div>
+      <div style={{ flex: 1, minWidth: 120 }}>
+        <div
+          className="sans"
+          style={{
+            fontSize: 14,
+            color: role.display_name ? "var(--ink-100)" : "var(--ink-400)",
+            fontWeight: 500,
+            wordBreak: "break-word",
+          }}
+        >
+          {role.display_name ?? "— pending invite —"}
+          {role.is_creator ? (
+            <span
+              className="mono"
+              style={{
+                color: "var(--signal)",
+                marginLeft: 8,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: "0.18em",
+              }}
+            >
+              · YOU
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <span
+        className="mono"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "4px 10px",
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: "0.16em",
+          background: joined ? "var(--signal-tint)" : "var(--ink-800)",
+          border: `1px solid ${joined ? "var(--signal-deep)" : "var(--ink-500)"}`,
+          color: joined ? "var(--signal)" : "var(--ink-300)",
+          borderRadius: 2,
+        }}
+        title={joined ? "Player has opened the join link" : "Join link not opened yet"}
+      >
+        <span aria-hidden="true">{joined ? "●" : "◐"}</span>
+        {joined ? "JOINED" : "INVITE"}
+      </span>
+      {!role.is_creator ? (
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={busy}
+            aria-label={`Copy join link for ${role.label}`}
+            className="mono"
+            style={{
+              background: copied ? "var(--signal-tint)" : "transparent",
+              color: copied ? "var(--signal)" : "var(--ink-200)",
+              border: `1px ${joined ? "solid" : "dashed"} ${copied ? "var(--signal)" : "var(--ink-500)"}`,
+              padding: "5px 12px",
+              borderRadius: 2,
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: "0.16em",
+              cursor: busy ? "not-allowed" : "pointer",
+              opacity: busy ? 0.5 : 1,
+            }}
+            title="Re-mint and copy this role's join link."
+          >
+            {copied ? "COPIED!" : joined ? "COPY LINK" : "+ COPY INVITE"}
+          </button>
+          {joined ? (
+            <button
+              type="button"
+              onClick={onKick}
+              disabled={busy}
+              className="mono"
+              style={{
+                background: "transparent",
+                color: "var(--warn)",
+                border: "1px solid var(--warn)",
+                padding: "5px 12px",
+                borderRadius: 2,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: "0.16em",
+                cursor: busy ? "not-allowed" : "pointer",
+                opacity: busy ? 0.5 : 1,
+              }}
+              title="Disconnect anyone using the current link and issue a new link."
+            >
+              KICK
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={busy}
+            className="mono"
+            style={{
+              background: "transparent",
+              color: "var(--crit)",
+              border: "1px solid var(--crit)",
+              padding: "5px 12px",
+              borderRadius: 2,
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: "0.16em",
+              cursor: busy ? "not-allowed" : "pointer",
+              opacity: busy ? 0.5 : 1,
+            }}
+            title="Remove this role from the session."
+          >
+            REMOVE
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SidecarStat({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div
+      className="mono"
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "baseline",
+        fontSize: 11,
+        color: "var(--ink-300)",
+        letterSpacing: "0.10em",
+      }}
+    >
+      <span>{label}</span>
+      <span
+        className="tabular-nums"
+        style={{ color: "var(--ink-100)", fontWeight: 600 }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/setup/SetupReviewView.tsx
+++ b/frontend/src/components/setup/SetupReviewView.tsx
@@ -1,0 +1,230 @@
+import { RoleView, ScenarioPlan } from "../../api/client";
+import { Eyebrow } from "../brand/Eyebrow";
+
+/**
+ * Step 6 (Review & launch) panel for the setup wizard. Brand mock
+ * reference: ``AppLobby`` sidecar in app-screens.jsx (the
+ * "scenario · ready" card with the START SESSION CTA).
+ *
+ * Reached when both gates are clear: plan finalized AND ≥ 2 player
+ * roles. The wizard's own ``current`` memo decides step 5 vs 6, so
+ * by the time this renders the user can launch — the START SESSION
+ * button is the panel's primary CTA, owned by the panel rather
+ * than the bottom action bar (which is hidden during wizard chrome).
+ */
+interface Props {
+  roles: RoleView[];
+  plan: ScenarioPlan;
+  playerCount: number;
+  connectedRoleIds: ReadonlySet<string>;
+  busy: boolean;
+  onStart: () => void;
+}
+
+export function SetupReviewView(props: Props) {
+  const joinedCount = props.roles.filter((r) =>
+    props.connectedRoleIds.has(r.id),
+  ).length;
+
+  return (
+    // Stack to a single column below ``md`` so the START SESSION
+    // sidecar doesn't auto-wrap UNDER the plan summary at narrow
+    // desktops (the prior layout pushed the primary CTA below the
+    // fold). ``order`` keeps the launch sidecar visually first on
+    // small viewports too.
+    <div
+      className="grid grid-cols-1 gap-6 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,1fr)] md:items-start"
+    >
+      <section
+        // ``order-2 md:order-none`` pushes the plan summary BELOW
+        // the launch sidecar on narrow viewports so START SESSION
+        // is the first thing the operator sees (was below-the-fold
+        // when the grid auto-wrapped pre-fix).
+        className="order-2 md:order-none"
+        style={{
+          background: "var(--ink-850)",
+          border: "1px solid var(--ink-600)",
+          borderRadius: 4,
+          padding: 24,
+          display: "flex",
+          flexDirection: "column",
+          gap: 18,
+          minWidth: 0,
+        }}
+      >
+        <header style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <Eyebrow color="var(--signal)">plan · finalized</Eyebrow>
+          <h2
+            className="sans"
+            style={{
+              margin: 0,
+              fontSize: 22,
+              fontWeight: 600,
+              color: "var(--ink-050)",
+              letterSpacing: "-0.01em",
+              wordBreak: "break-word",
+            }}
+          >
+            {props.plan.title}
+          </h2>
+        </header>
+        {props.plan.executive_summary ? (
+          <p
+            className="sans"
+            style={{
+              margin: 0,
+              fontSize: 13,
+              color: "var(--ink-200)",
+              lineHeight: 1.6,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {props.plan.executive_summary}
+          </p>
+        ) : null}
+
+        {props.plan.key_objectives.length > 0 ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <Eyebrow color="var(--ink-300)">key objectives</Eyebrow>
+            <ul
+              className="sans"
+              style={{
+                margin: 0,
+                paddingLeft: 18,
+                fontSize: 13,
+                color: "var(--ink-100)",
+                lineHeight: 1.55,
+              }}
+            >
+              {props.plan.key_objectives.map((o, i) => (
+                <li key={i}>{o}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <Eyebrow color="var(--ink-300)">roster · {props.roles.length} seated</Eyebrow>
+          <ul
+            style={{
+              margin: 0,
+              padding: 0,
+              listStyle: "none",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 6,
+            }}
+          >
+            {props.roles.map((r) => {
+              const joined = props.connectedRoleIds.has(r.id);
+              return (
+                <li
+                  key={r.id}
+                  className="mono"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "5px 10px",
+                    background: "var(--ink-900)",
+                    border: `1px solid ${joined ? "var(--signal-deep)" : "var(--ink-500)"}`,
+                    borderRadius: 2,
+                    fontSize: 11,
+                    color: "var(--ink-100)",
+                    letterSpacing: "0.06em",
+                  }}
+                  title={joined ? "Joined" : "Not joined yet"}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      display: "inline-block",
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: joined ? "var(--signal)" : "var(--ink-500)",
+                    }}
+                  />
+                  {r.label}
+                  {r.is_creator ? (
+                    <span style={{ color: "var(--warn)" }} title="Creator">
+                      ★
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </section>
+
+      <aside
+        aria-label="Launch summary"
+        // Sticky only at ``md`` and up — on small viewports the
+        // sidecar is the first item in the column and stays in
+        // normal flow above the plan summary.
+        className="md:sticky md:top-0"
+        style={{
+          background: "var(--ink-850)",
+          border: "1px solid var(--signal-deep)",
+          borderRadius: 4,
+          padding: 24,
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+      >
+        <Eyebrow color="var(--signal)">scenario · ready</Eyebrow>
+        <div
+          className="mono"
+          style={{
+            fontSize: 11,
+            color: "var(--ink-300)",
+            lineHeight: 1.7,
+            letterSpacing: "0.04em",
+          }}
+        >
+          {props.roles.length} ROLES · {props.playerCount} PLAYERS
+          <br />
+          {joinedCount} JOINED
+          <br />
+          {props.plan.injects.length} INJECTS QUEUED
+          <br />
+          {props.plan.key_objectives.length} OBJECTIVES
+        </div>
+        <div style={{ flex: 1 }} />
+        <button
+          type="button"
+          onClick={props.onStart}
+          disabled={props.busy}
+          className="mono"
+          style={{
+            background: "var(--signal)",
+            color: "var(--ink-900)",
+            border: "none",
+            padding: "14px",
+            borderRadius: 2,
+            fontWeight: 700,
+            fontSize: 13,
+            letterSpacing: "0.20em",
+            cursor: props.busy ? "not-allowed" : "pointer",
+            opacity: props.busy ? 0.6 : 1,
+          }}
+        >
+          {props.busy ? "STARTING…" : "START SESSION →"}
+        </button>
+        <div
+          className="mono"
+          style={{
+            fontSize: 10,
+            color: "var(--ink-400)",
+            textAlign: "center",
+            letterSpacing: "0.10em",
+          }}
+        >
+          STATE → BRIEFING → AI_PROCESSING
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -67,10 +67,11 @@ interface Props {
   playerCount?: number;
   /**
    * Discard the current session and return to the intro form.
-   * Rendered as a small "Abandon session" link at the bottom of the
-   * post-creation panel — gives the operator an out without forcing
-   * them to navigate back through the lockup link in the rail. Skip
-   * this prop on the intro phase (no session to abandon).
+   * Forwarded to ``WizardRail``'s ABANDON SESSION button at the
+   * bottom of the rail (see WizardRail.tsx) — placed there
+   * post-creation so it's never adjacent to step 06's
+   * ``START SESSION`` button. Skip this prop on the intro phase
+   * (no session to abandon).
    */
   onAbandonSession?: () => void;
 }

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -27,11 +27,13 @@ export interface SetupParts {
  *     creator info) lives in <Facilitator/> and is passed through
  *     here as props. Once the user submits step 3 we call onSubmit
  *     and the existing handleCreate flow runs unchanged.
- *   - Post-creation steps render the existing SetupView /
- *     ReadyView-style content via the ``children`` slot. The wizard
- *     just provides the chrome (left rail + main panel header +
- *     footer nav). This keeps the engine-side state machine
- *     untouched.
+ *   - Post-creation steps render their content via the
+ *     ``postCreationContent`` slot — the wizard provides only the
+ *     chrome (left rail + main panel header). The slot's content
+ *     decides its own primary CTA (e.g. step 06's
+ *     ``SetupReviewView`` owns the START SESSION button, since the
+ *     ``BottomActionBar`` isn't rendered inside wizard chrome).
+ *     This keeps the engine-side state machine untouched.
  */
 
 export type WizardPhase = "intro" | "setup" | "ready";
@@ -63,6 +65,14 @@ interface Props {
   snapshot?: SessionSnapshot | null;
   /** Player count from snapshot — used to decide step 5 vs 6. */
   playerCount?: number;
+  /**
+   * Discard the current session and return to the intro form.
+   * Rendered as a small "Abandon session" link at the bottom of the
+   * post-creation panel — gives the operator an out without forcing
+   * them to navigate back through the lockup link in the rail. Skip
+   * this prop on the intro phase (no session to abandon).
+   */
+  onAbandonSession?: () => void;
 }
 
 const ROLE_DEFAULTS = ["IR Lead", "Legal", "Comms"] as const;
@@ -105,25 +115,38 @@ export function SetupWizard(props: Props) {
     return s;
   }, [props.phase, introStep, current]);
 
+  // Intro-phase rail back-nav: clicking a completed step returns to
+  // it without losing form state. Post-creation we leave it disabled
+  // (the step is derived from backend state and there's no
+  // backwards transition path).
+  const onJumpToStep = (id: WizardStepId) => {
+    if (props.phase !== "intro") return;
+    if (id !== 1 && id !== 2 && id !== 3) return;
+    setIntroStep(id);
+  };
+
   return (
     <main
-      style={{
-        minHeight: "100vh",
-        display: "grid",
-        gridTemplateColumns: "260px 1fr",
-        background: "var(--ink-900)",
-      }}
+      // Tailwind responsive grid: stack rail on top below ``lg``
+      // (≤ 1023 px) so a 390 px viewport still gets a usable panel,
+      // sit it on the left at ``lg`` and up. ``min-h-screen`` keeps
+      // the rail+panel filling the viewport at any size.
+      className="grid min-h-screen grid-cols-1 lg:grid-cols-[260px_minmax(0,1fr)]"
+      style={{ background: "var(--ink-900)" }}
     >
-      <WizardRail current={current} done={done} />
+      <WizardRail
+        current={current}
+        done={done}
+        onJumpToStep={props.phase === "intro" ? onJumpToStep : undefined}
+        onAbandonSession={
+          props.phase !== "intro" ? props.onAbandonSession : undefined
+        }
+      />
       <section
-        style={{
-          padding: "32px 48px",
-          display: "flex",
-          flexDirection: "column",
-          gap: 20,
-          minHeight: 0,
-          overflow: "auto",
-        }}
+        // Smaller padding at narrow viewports so the panel breathes;
+        // restore brand-mock 32/48 spacing at ``lg`` and above.
+        className="flex flex-col gap-5 overflow-auto p-5 lg:p-8 lg:px-12"
+        style={{ minHeight: 0 }}
       >
         {props.phase === "intro" ? (
           <IntroStepBody
@@ -132,7 +155,11 @@ export function SetupWizard(props: Props) {
             {...props}
           />
         ) : (
-          <PostCreationBody current={current} content={props.postCreationContent} />
+          <PostCreationBody
+            current={current}
+            content={props.postCreationContent}
+            error={props.error}
+          />
         )}
       </section>
     </main>
@@ -142,9 +169,11 @@ export function SetupWizard(props: Props) {
 function PostCreationBody({
   current,
   content,
+  error,
 }: {
   current: WizardStepId;
   content: ReactNode;
+  error: string | null;
 }) {
   const titles: Record<WizardStepId, { eyebrow: string; title: string }> = {
     1: { eyebrow: "STEP 01 · SCENARIO", title: "Scenario" },
@@ -175,9 +204,31 @@ function PostCreationBody({
           {t.title}
         </h1>
       </header>
+      {/* Surface page-level error from Facilitator state during post-
+          creation steps too — the intro path renders this inside the
+          form's NavRow, but the wizard's post-creation slot otherwise
+          had nowhere to show api-call failures (kick / role-add /
+          finalize errors got swallowed visually). */}
+      {error ? (
+        <p
+          className="mono"
+          role="alert"
+          style={{
+            margin: 0,
+            color: "var(--crit)",
+            fontSize: 12,
+            letterSpacing: "0.04em",
+          }}
+        >
+          {error}
+        </p>
+      ) : null}
       <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
         {content}
       </div>
+      {/* ABANDON SESSION lives in the rail (WizardRail) post-creation
+          so it never sits adjacent to step-06's START SESSION button —
+          the two right-hand actions had a misclick adjacency risk. */}
     </>
   );
 }
@@ -388,10 +439,9 @@ function NavRow({
 }
 
 /**
- * Step 1 — Scenario brief + creator-role inputs + dev-mode toggle.
- * The team / constraints fields are kept on this step too so a
- * minimal session can be created in 30 seconds (the user just fills
- * step 1 and clicks NEXT through the rest with empty fields).
+ * Step 1 — Scenario brief + dev-mode toggle. Creator-role / display-name
+ * inputs moved to Step 3 (Roles) per issue #159 — "Set the scene"
+ * shouldn't ask about who you are, only about what happened.
  */
 function Step1Body(props: IntroBodyProps) {
   return (
@@ -420,28 +470,6 @@ function Step1Body(props: IntroBodyProps) {
         onChange={(v) => props.setSetupParts((p) => ({ ...p, team: v }))}
         placeholder="Roles, seniority, on-call posture."
       />
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr",
-          gap: 12,
-        }}
-      >
-        <MonoInput
-          label="CREATOR ROLE"
-          required
-          value={props.creatorLabel}
-          onChange={props.setCreatorLabel}
-          placeholder="Your role label (e.g. CISO)"
-        />
-        <MonoInput
-          label="DISPLAY NAME"
-          required
-          value={props.creatorDisplayName}
-          onChange={props.setCreatorDisplayName}
-          placeholder="Your display name"
-        />
-      </div>
     </>
   );
 }
@@ -491,18 +519,84 @@ function Step3Body(props: IntroBodyProps) {
     props.setupRoles.length === ROLE_DEFAULTS.length &&
     ROLE_DEFAULTS.every((d, i) => props.setupRoles[i] === d);
   return (
-    <fieldset
-      aria-label="Roles to invite"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 10,
-        padding: 14,
-        border: "1px solid var(--ink-600)",
-        borderRadius: 4,
-        background: "var(--ink-850)",
-      }}
-    >
+    <>
+      {/* Creator's own seat — moved from Step 1 (issue #159). The
+          collision-with-invitee warning lives in the fieldset below
+          and reacts immediately as the user edits either field.
+          Border tinted ``--signal-deep`` (vs the invitee fieldset's
+          ``--ink-600``) so the operator instantly sees this block is
+          about THEM, not the team. */}
+      <fieldset
+        aria-label="Your seat"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+          padding: 14,
+          border: "1px solid var(--signal-deep)",
+          borderRadius: 4,
+          background: "var(--ink-850)",
+        }}
+      >
+        <legend
+          className="mono"
+          style={{
+            padding: "0 6px",
+            fontSize: 10,
+            color: "var(--signal)",
+            letterSpacing: "0.20em",
+            fontWeight: 700,
+          }}
+        >
+          Your seat
+        </legend>
+        <p
+          className="sans"
+          style={{
+            margin: 0,
+            fontSize: 12,
+            color: "var(--ink-300)",
+            lineHeight: 1.45,
+          }}
+        >
+          You play one of the roles too. Pick a label and how you want
+          to appear in the transcript.
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 12,
+          }}
+        >
+          <MonoInput
+            label="CREATOR ROLE"
+            required
+            value={props.creatorLabel}
+            onChange={props.setCreatorLabel}
+            placeholder="Your role label (e.g. CISO)"
+          />
+          <MonoInput
+            label="DISPLAY NAME"
+            required
+            value={props.creatorDisplayName}
+            onChange={props.setCreatorDisplayName}
+            placeholder="Your display name"
+          />
+        </div>
+      </fieldset>
+      <fieldset
+        aria-label="Roles to invite"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+          padding: 14,
+          border: "1px solid var(--ink-600)",
+          borderRadius: 4,
+          background: "var(--ink-850)",
+        }}
+      >
       <legend
         className="mono"
         style={{
@@ -702,6 +796,7 @@ function Step3Body(props: IntroBodyProps) {
         </div>
       ) : null}
     </fieldset>
+    </>
   );
 }
 

--- a/frontend/src/components/setup/WizardRail.tsx
+++ b/frontend/src/components/setup/WizardRail.tsx
@@ -20,8 +20,12 @@ import { Eyebrow } from "../brand/Eyebrow";
  * action in the rail keeps it geographically distant from step 06's
  * START SESSION button (which lives in the main panel sidecar).
  *
- * Below the ``lg`` breakpoint the rail collapses into a horizontal
- * top strip so a 390 px viewport doesn't lose the entire panel area.
+ * Responsive behaviour is owned by ``SetupWizard``'s parent grid:
+ * below the ``lg`` breakpoint the grid switches from
+ * ``[260px_1fr]`` to a single column so the rail stacks ABOVE the
+ * panel as a vertical strip (NOT a horizontal top bar — the rail's
+ * own children stay in column flow). At ``lg`` and up the rail
+ * sits on the left as designed in the brand mock.
  */
 export const WIZARD_STEPS = [
   { id: 1, name: "Scenario" },

--- a/frontend/src/components/setup/WizardRail.tsx
+++ b/frontend/src/components/setup/WizardRail.tsx
@@ -1,3 +1,4 @@
+import { confirmLeaveSession } from "../../lib/leaveGuard";
 import { Eyebrow } from "../brand/Eyebrow";
 
 /**
@@ -10,11 +11,17 @@ import { Eyebrow } from "../brand/Eyebrow";
  *   05 Invite players    (post-creation: lobby + join links)
  *   06 Review & launch   (post-creation: scenario summary + START SESSION)
  *
- * The rail is purely presentational — `current` and `done` are
- * computed by the parent (`SetupWizard`) from the frontend phase
- * (intro / setup / ready) plus user navigation through the 3
- * pre-creation steps. Steps after `current` render dimmed; `done`
- * steps get a signal-blue ✓ marker.
+ * The rail is presentational + a few navigation hooks: ``onJumpToStep``
+ * lets the parent surface back-nav for completed intro steps (1-3
+ * before the session is created — once the session exists the steps
+ * are derived from backend state and can't be rewound), and
+ * ``onAbandonSession`` adds a destructive "ABANDON SESSION" button at
+ * the bottom of the rail post-creation. Putting the destructive
+ * action in the rail keeps it geographically distant from step 06's
+ * START SESSION button (which lives in the main panel sidecar).
+ *
+ * Below the ``lg`` breakpoint the rail collapses into a horizontal
+ * top strip so a 390 px viewport doesn't lose the entire panel area.
  */
 export const WIZARD_STEPS = [
   { id: 1, name: "Scenario" },
@@ -31,12 +38,22 @@ interface Props {
   current: WizardStepId;
   /** Set of step ids the user has completed (rendered with a ✓). */
   done: Set<WizardStepId>;
+  /**
+   * Optional click handler for a step. Only wired by the parent for
+   * intro-phase back-nav (steps 1-3 before session creation); always
+   * undefined post-creation since the post-creation step is derived
+   * from backend state and can't be rewound from the UI.
+   */
+  onJumpToStep?: (id: WizardStepId) => void;
+  /** Bottom-of-rail "ABANDON SESSION" CTA — only rendered when a session exists. */
+  onAbandonSession?: () => void;
 }
 
-export function WizardRail({ current, done }: Props) {
+export function WizardRail({ current, done, onJumpToStep, onAbandonSession }: Props) {
   return (
     <aside
-      className="dotgrid"
+      aria-label="Setup steps"
+      className="dotgrid wizard-rail"
       style={{
         background: "var(--ink-850)",
         borderRight: "1px solid var(--ink-600)",
@@ -44,11 +61,19 @@ export function WizardRail({ current, done }: Props) {
         display: "flex",
         flexDirection: "column",
         gap: 4,
+        minWidth: 0,
       }}
     >
       <a
         href="/"
         aria-label="Crittable home"
+        // Wizard chrome is the only chrome shown during setup/ready
+        // (issue #113). An accidental click on the lockup would
+        // silently destroy the operator's local session state (token,
+        // sessionId, draft setup parts, in-flight reply) — the same
+        // pattern Facilitator's TopBar / Play.tsx / AAR-popup lockups
+        // already guard against with this helper.
+        onClick={confirmLeaveSession}
         style={{
           display: "flex",
           alignItems: "center",
@@ -86,39 +111,27 @@ export function WizardRail({ current, done }: Props) {
         </span>
       </div>
 
-      <div
+      <ol
         style={{
           marginTop: 6,
           display: "flex",
           flexDirection: "column",
           gap: 2,
+          listStyle: "none",
+          padding: 0,
         }}
       >
         {WIZARD_STEPS.map((s) => {
           const isCurrent = s.id === current;
           const isDone = done.has(s.id);
+          const isClickable = Boolean(onJumpToStep) && (isDone || isCurrent);
           const c = isDone
             ? "var(--ink-300)"
             : isCurrent
               ? "var(--signal)"
               : "var(--ink-500)";
-          return (
-            <div
-              key={s.id}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 12,
-                padding: "10px 12px",
-                borderRadius: 3,
-                background: isCurrent
-                  ? "color-mix(in oklch, var(--signal) 8%, transparent)"
-                  : "transparent",
-                border: isCurrent
-                  ? "1px solid var(--signal-deep)"
-                  : "1px solid transparent",
-              }}
-            >
+          const inner = (
+            <>
               <span
                 className="mono"
                 style={{
@@ -151,14 +164,80 @@ export function WizardRail({ current, done }: Props) {
                     color: "var(--signal)",
                     fontSize: 12,
                   }}
+                  aria-hidden="true"
                 >
                   ✓
                 </span>
               ) : null}
-            </div>
+            </>
+          );
+          const baseStyle = {
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "10px 12px",
+            borderRadius: 3,
+            background: isCurrent
+              ? "color-mix(in oklch, var(--signal) 8%, transparent)"
+              : "transparent",
+            border: isCurrent
+              ? "1px solid var(--signal-deep)"
+              : "1px solid transparent",
+            width: "100%",
+            textAlign: "left" as const,
+            font: "inherit",
+            color: "inherit",
+          };
+          return (
+            <li key={s.id}>
+              {isClickable ? (
+                <button
+                  type="button"
+                  onClick={() => onJumpToStep!(s.id)}
+                  aria-current={isCurrent ? "step" : undefined}
+                  aria-label={`Step ${s.id}: ${s.name}${isDone ? " (completed)" : isCurrent ? " (current)" : ""}`}
+                  style={{ ...baseStyle, cursor: "pointer" }}
+                >
+                  {inner}
+                </button>
+              ) : (
+                <div
+                  aria-current={isCurrent ? "step" : undefined}
+                  style={baseStyle}
+                >
+                  {inner}
+                </div>
+              )}
+            </li>
           );
         })}
-      </div>
+      </ol>
+
+      {onAbandonSession ? (
+        <>
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            onClick={onAbandonSession}
+            className="mono"
+            style={{
+              marginTop: 12,
+              background: "transparent",
+              color: "var(--ink-400)",
+              border: "1px dashed var(--ink-500)",
+              padding: "8px 12px",
+              borderRadius: 2,
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: "0.16em",
+              cursor: "pointer",
+            }}
+            title="Discard the current draft session and return to the new-session form."
+          >
+            ABANDON SESSION
+          </button>
+        </>
+      ) : null}
     </aside>
   );
 }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1206,29 +1206,44 @@ export function Facilitator() {
       );
     }
     return (
-      <SetupWizard
-        phase={phase}
-        setupParts={setupParts}
-        setSetupParts={setSetupParts}
-        creatorLabel={creatorLabel}
-        setCreatorLabel={setCreatorLabel}
-        creatorDisplayName={creatorDisplayName}
-        setCreatorDisplayName={setCreatorDisplayName}
-        setupRoles={setupRoles}
-        setSetupRoles={setSetupRoles}
-        setupRoleDraft={setupRoleDraft}
-        setSetupRoleDraft={setSetupRoleDraft}
-        devMode={devMode}
-        setDevMode={onToggleDevMode}
-        busy={busy}
-        busyMessage={busyMessage}
-        error={error}
-        onSubmit={handleCreate}
-        snapshot={snapshot}
-        playerCount={playerCount}
-        postCreationContent={postCreationContent}
-        onAbandonSession={handleNewSession}
-      />
+      <>
+        {/* CriticalEventBanner has to render here too — the in-session
+            <main> wrapper isn't reached during the setup/ready early
+            return, so without this, ``critical_event`` WS frames
+            during the lobby (e.g. an inject-as-warning, an admin
+            interject) would set ``criticalBanner`` state and the user
+            would never see it. Same component + dismiss handler as
+            the in-session render below. */}
+        {criticalBanner ? (
+          <CriticalEventBanner
+            {...criticalBanner}
+            onAcknowledge={() => setCriticalBanner(null)}
+          />
+        ) : null}
+        <SetupWizard
+          phase={phase}
+          setupParts={setupParts}
+          setSetupParts={setSetupParts}
+          creatorLabel={creatorLabel}
+          setCreatorLabel={setCreatorLabel}
+          creatorDisplayName={creatorDisplayName}
+          setCreatorDisplayName={setCreatorDisplayName}
+          setupRoles={setupRoles}
+          setSetupRoles={setSetupRoles}
+          setupRoleDraft={setupRoleDraft}
+          setSetupRoleDraft={setSetupRoleDraft}
+          devMode={devMode}
+          setDevMode={onToggleDevMode}
+          busy={busy}
+          busyMessage={busyMessage}
+          error={error}
+          onSubmit={handleCreate}
+          snapshot={snapshot}
+          playerCount={playerCount}
+          postCreationContent={postCreationContent}
+          onAbandonSession={handleNewSession}
+        />
+      </>
     );
   }
 

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -34,6 +34,8 @@ import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
 import { TurnStateRail } from "../components/brand/TurnStateRail";
 import { SetupWizard } from "../components/setup/SetupWizard";
+import { SetupLobbyView } from "../components/setup/SetupLobbyView";
+import { SetupReviewView } from "../components/setup/SetupReviewView";
 import {
   buildImpersonateOptions,
   countUnjoinedImpersonateOptions,
@@ -1143,6 +1145,93 @@ export function Facilitator() {
   const isMyTurn = activeRoleIds.includes(state.creatorRoleId);
   const playerCount = snapshot.roles.filter((r) => r.kind === "player").length;
 
+  // Issue #113: keep the wizard chrome up through setup/ready so the
+  // operator sees rail steps 04-06 instead of being dumped into the
+  // in-session view the moment the session is created. Each post-
+  // creation phase renders its own ``postCreationContent`` slot:
+  //   - setup → existing <SetupView/> (AI dialogue + plan preview)
+  //   - ready, plan unfinished or < 2 players → <SetupLobbyView/>
+  //   - ready, plan finalized + ≥ 2 players → <SetupReviewView/>
+  //     (owns its own START SESSION button — the BottomActionBar
+  //      isn't rendered inside wizard chrome)
+  // The wizard's internal ``current`` memo derives the same step
+  // 5 vs 6 distinction for the rail highlight; we just have to pick
+  // the matching panel content here.
+  if (phase === "setup" || phase === "ready") {
+    const wizardReadyForReview =
+      phase === "ready" && Boolean(snapshot.plan) && playerCount >= 2;
+    let postCreationContent;
+    if (phase === "setup") {
+      postCreationContent = (
+        <SetupView
+          snapshot={snapshot}
+          setupReply={setupReply}
+          setSetupReply={setSetupReply}
+          onSubmit={handleSetupReply}
+          onLooksReady={handleLooksReady}
+          onApprovePlan={handleApprovePlan}
+          onSkipSetup={handleSkipSetup}
+          onPickOption={(opt) =>
+            callSetup(opt, "Sending your selection to the AI…")
+          }
+          busy={busy}
+          busyMessage={busyMessage}
+        />
+      );
+    } else if (wizardReadyForReview && snapshot.plan) {
+      postCreationContent = (
+        <SetupReviewView
+          roles={snapshot.roles}
+          plan={snapshot.plan}
+          playerCount={playerCount}
+          connectedRoleIds={presence}
+          busy={busy}
+          onStart={handleStart}
+        />
+      );
+    } else {
+      postCreationContent = (
+        <SetupLobbyView
+          sessionId={state.sessionId}
+          creatorToken={state.token}
+          roles={snapshot.roles}
+          busy={busy}
+          plan={snapshot.plan}
+          playerCount={playerCount}
+          connectedRoleIds={presence}
+          onRoleAdded={refreshSnapshot}
+          onRoleChanged={refreshSnapshot}
+          onError={setError}
+        />
+      );
+    }
+    return (
+      <SetupWizard
+        phase={phase}
+        setupParts={setupParts}
+        setSetupParts={setSetupParts}
+        creatorLabel={creatorLabel}
+        setCreatorLabel={setCreatorLabel}
+        creatorDisplayName={creatorDisplayName}
+        setCreatorDisplayName={setCreatorDisplayName}
+        setupRoles={setupRoles}
+        setSetupRoles={setSetupRoles}
+        setupRoleDraft={setupRoleDraft}
+        setSetupRoleDraft={setSetupRoleDraft}
+        devMode={devMode}
+        setDevMode={onToggleDevMode}
+        busy={busy}
+        busyMessage={busyMessage}
+        error={error}
+        onSubmit={handleCreate}
+        snapshot={snapshot}
+        playerCount={playerCount}
+        postCreationContent={postCreationContent}
+        onAbandonSession={handleNewSession}
+      />
+    );
+  }
+
   return (
     <main className="flex min-h-screen flex-col lg:h-screen lg:min-h-0 lg:overflow-hidden">
       {criticalBanner ? (
@@ -1259,23 +1348,9 @@ export function Facilitator() {
             ref={scrollRegionRef}
             className="flex min-w-0 flex-col gap-3 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1"
           >
-          {phase === "setup" ? (
-            <SetupView
-              snapshot={snapshot}
-              setupReply={setupReply}
-              setSetupReply={setSetupReply}
-              onSubmit={handleSetupReply}
-              onLooksReady={handleLooksReady}
-              onApprovePlan={handleApprovePlan}
-              onSkipSetup={handleSkipSetup}
-              onPickOption={(opt) => callSetup(opt, "Sending your selection to the AI…")}
-              busy={busy}
-              busyMessage={busyMessage}
-            />
-          ) : null}
-          {phase === "ready" ? (
-            <ReadyView plan={snapshot.plan} sessionId={state.sessionId} />
-          ) : null}
+          {/* Issue #113: setup + ready phases now render in the
+              wizard chrome (see early-return above), not in this
+              in-session 3-col layout. Only play / ended reach here. */}
           {phase === "ended" ? (
             <EndedView
               sessionId={state.sessionId}
@@ -1995,19 +2070,18 @@ function SetupView({
 
   return (
     <div className="flex flex-col gap-3">
-      <div>
-        <p className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-signal">
-          STEP 02 · SETUP DIALOGUE
-        </p>
-        <h2 className="mt-1 text-lg font-semibold tracking-[-0.01em] text-ink-050">
-          Answer the AI's setup questions
-        </h2>
-        <p className="mt-1 text-xs text-ink-300 leading-relaxed">
-          Answer briefly. When you have shared enough background, click{" "}
-          <em>"Looks ready — propose the plan"</em> to nudge it to draft. Once a plan is on the
-          table, click <em>"Approve plan"</em> to commit it.
-        </p>
-      </div>
+      {/* Issue #113: SetupView is now nested inside the wizard's
+          <PostCreationBody/> which already supplies the eyebrow +
+          title (STEP 04 · INJECTS & SCHEDULE → "AI is drafting the
+          plan"). The pre-PR inner header (STEP 02 · SETUP DIALOGUE)
+          stamped a second, conflicting step number on the same
+          screen — deleted. The helper paragraph stays since it
+          explains the LOOKS READY / APPROVE buttons below. */}
+      <p className="mt-1 text-xs text-ink-300 leading-relaxed">
+        Answer briefly. When you have shared enough background, click{" "}
+        <em>"Looks ready — propose the plan"</em> to nudge it to draft. Once a plan is on the
+        table, click <em>"Approve plan"</em> to commit it.
+      </p>
 
       {notes.length === 0 && !busy ? (
         <div className="flex flex-col items-center gap-3 rounded-r-3 border border-warn bg-warn-bg p-6">
@@ -2533,33 +2607,8 @@ function AARPopup({
 }
 
 
-function ReadyView({
-  plan,
-  sessionId,
-}: {
-  plan: SessionSnapshot["plan"];
-  sessionId?: string;
-}) {
-  return (
-    <div className="flex flex-col gap-3">
-      <p className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-signal">
-        STEP 04 · READY
-      </p>
-      <h2 className="text-lg font-semibold tracking-[-0.01em] text-ink-050">
-        Plan finalized — ready to start
-      </h2>
-      {plan ? (
-        <div className="rounded-r-3 border border-ink-600 bg-ink-850 p-4">
-          <PlanView plan={plan} sessionId={sessionId} />
-        </div>
-      ) : null}
-      <p className="mono text-[11px] uppercase tracking-[0.06em] text-ink-300">
-        Add at least 2 roles, then click{" "}
-        <span className="mono font-bold tracking-[0.16em] text-signal">
-          START SESSION
-        </span>{" "}
-        in the bottom action bar.
-      </p>
-    </div>
-  );
-}
+// Issue #113: ReadyView removed — phase === "ready" now renders
+// inside the wizard chrome (SetupLobbyView / SetupReviewView), so
+// the in-session ReadyView is never reached. SetupReviewView owns
+// the post-finalize "ready to launch" surface, START SESSION CTA
+// included.


### PR DESCRIPTION
## Summary

Closes #113.
Closes #159.

- **#113 — wizard chrome cliff.** The setup wizard now stays mounted through `phase==="setup"` and `phase==="ready"` (steps 4-6), instead of dropping to the in-session 3-col view the moment the session is created. New `SetupLobbyView` (step 5 — wide LobbyRows + scenario sidecar, matches the `AppLobby` brand mock) and `SetupReviewView` (step 6 — plan summary + roster + sticky `START SESSION →` sidecar). The review panel owns its own primary CTA since the `BottomActionBar` isn't rendered inside wizard chrome. `ABANDON SESSION` lives at the bottom of the rail post-creation so it never sits adjacent to `START SESSION`.
- **#159 — creator role placement.** `CREATOR ROLE` + `DISPLAY NAME` inputs moved from Step 1 to Step 3 (Roles), inside a new `--signal-deep`-tinted "Your seat" fieldset above the existing "Roles to invite" fieldset.
- **No engine-side / backend changes.** Phase derivation from `snapshot.state` unchanged.

## Sub-agent review pass

All six reviews ran in parallel. Every CRITICAL / BLOCK / HIGH addressed in this PR:

| Severity | Reviewer | Finding | Fix |
|---|---|---|---|
| HIGH | Security | `WizardRail` lockup `<a href="/">` bypassed `confirmLeaveSession` | Added `onClick={confirmLeaveSession}` to match TopBar / Play.tsx / AAR-popup pattern. |
| HIGH | Product | Step 5 reused dense `<RolesPanel/>` instead of the brand mock's wider rows | Rewrote `SetupLobbyView` with a dedicated wide `LobbyRow` (mono code badge, name, JOINED/INVITE chip, COPY/KICK/REMOVE actions). |
| HIGH | User#1 | `SetupView` inner "STEP 02 · SETUP DIALOGUE" header collided with wizard's "STEP 04 · INJECTS & SCHEDULE" | Removed the inner header. |
| HIGH | User#2 | Rail items looked clickable but weren't | Wired back-nav for completed intro steps via `onJumpToStep`; post-creation steps remain inert. |
| BLOCK | UI/UX#1 | Hardcoded `260px 1fr` made the panel ~130 px on a 390 px viewport | Switched to Tailwind responsive (`grid-cols-1 lg:grid-cols-[260px_1fr]`); lobby/review grids stack to single column below `md`. |
| BLOCK | UI/UX#2 | `ABANDON SESSION` adjacent to `START SESSION` when sidecar wrapped | Moved `ABANDON` to rail bottom; reordered `SetupReviewView` so the launch sidecar is FIRST on small viewports. |
| HIGH | UI/UX#1 | Three unlabeled `<aside>` landmarks | Added `aria-label`s ("Setup steps" / "Lobby summary" / "Launch summary"). |
| HIGH | UI/UX#3 | Page-level error only rendered in intro form | Added error display to `PostCreationBody`. |
| HIGH | UI/UX#4 | Indentation mismatch in `Step3Body` | Corrected. |
| HIGH | QA | No integration coverage for the new phase routing | Added `__tests__/SetupWizard.test.tsx` (10 tests covering step 4↔5↔6 transitions, intro back-nav, ABANDON placement, error surface). |

**Deferred** (low risk, design decision needed):
- User HIGH#3 — post-creation BACK navigation ("go back to step 3 to fix roles"). Needs a separate design discussion; left as a follow-up.
- User MEDIUM 4-6 — `SKIP SETUP` button prominence, `Step 5` sidecar copy ambiguity. Cosmetic.

**Prompt review:** clean. Pure UI / chrome change; no backend prompt or tool surface area touched.

## Test plan

- [x] `cd frontend && npm test -- --run` — 347 tests pass (was 337; added 10).
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — production build succeeds.
- [ ] Visual smoke in a browser — could not perform from this CLI session; please verify wizard step 4 → 5 → 6 transitions + mobile (390 px) layout before merge.
- [ ] Verify `START SESSION` from step 6 transitions to play (in-session view) and `ABANDON SESSION` from rail returns to intro.

## Files

- New: `frontend/src/components/setup/SetupLobbyView.tsx`, `frontend/src/components/setup/SetupReviewView.tsx`, `frontend/src/__tests__/SetupWizard.test.tsx`.
- Modified: `frontend/src/components/setup/SetupWizard.tsx`, `frontend/src/components/setup/WizardRail.tsx`, `frontend/src/pages/Facilitator.tsx`, `frontend/src/__tests__/Facilitator.intro.test.tsx`.

## Scenario coverage

Pure UI / chrome change. No `SessionState` transitions, no turn-pump paths, no input gates, no `MessageKind` / tool-name / message-field additions. Phase derivation from `snapshot.state` unchanged. No `backend/scenarios/*.json` update required per the CLAUDE.md scenario rule.

https://claude.ai/code/session_01CGJrqV5oRkZQknchBJEz6W

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGJrqV5oRkZQknchBJEz6W)_