### PR TITLE
frontend: collapse triple "notepad locked" indicators into one

### DIFF
--- a/frontend/src/__tests__/notepadProvider.test.ts
+++ b/frontend/src/__tests__/notepadProvider.test.ts
@@ -175,7 +175,7 @@ describe("WsYjsProvider — lock-state handling (issue #160)", () => {
     provider.stop();
   });
 
-  it("preserves non-notepad-scope error pass-through (locked or not)", () => {
+  it("ignores non-notepad-scope error frames entirely (those belong to the parent page)", () => {
     const fake = makeFakeWs();
     const { provider, onError } = makeProvider(fake);
     provider.start();
@@ -187,8 +187,9 @@ describe("WsYjsProvider — lock-state handling (issue #160)", () => {
       message: "boom",
     });
 
-    // The provider only inspects scope:"notepad" errors. Other scopes
-    // are intentionally ignored (the parent page handles them).
+    // The provider's ``onError`` is for notepad-scope errors only.
+    // Other scopes are not its concern — the page-level WS handler
+    // surfaces those. (Copilot review on PR #171, LOW.)
     expect(onError).not.toHaveBeenCalled();
     provider.stop();
   });
@@ -244,5 +245,163 @@ describe("WsYjsProvider — lock-state handling (issue #160)", () => {
     expect(onLockPending).toHaveBeenCalledWith(5);
     expect(provider.isLocked).toBe(false);
     provider.stop();
+  });
+
+  // ---- Idempotent lock transition (Copilot review on PR #171, HIGH) ----
+
+  it("fires onLocked exactly ONCE across multiple lock signals (replay buffer + live event)", () => {
+    const fake = makeFakeWs();
+    const { provider, onLocked } = makeProvider(fake);
+    provider.start();
+
+    // Replay buffer (sync-response with locked=true) followed by the
+    // live notepad_locked event — both common in reconnect scenarios.
+    fake.emit({
+      type: "notepad_sync_response",
+      state: "",
+      locked: true,
+      template_id: null,
+    });
+    fake.emit({ type: "notepad_locked", locked_at: null });
+    fake.emit({ type: "notepad_locked", locked_at: null });
+
+    expect(onLocked).toHaveBeenCalledTimes(1);
+    expect(provider.isLocked).toBe(true);
+    provider.stop();
+  });
+
+  it("fires onLocked exactly ONCE for repeated notepad_locked events", () => {
+    const fake = makeFakeWs();
+    const { provider, onLocked } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({ type: "notepad_locked", locked_at: null });
+    fake.emit({ type: "notepad_locked", locked_at: null });
+    fake.emit({ type: "notepad_locked", locked_at: null });
+
+    expect(onLocked).toHaveBeenCalledTimes(1);
+    provider.stop();
+  });
+
+  // ---- Initial sync-request retry (Copilot review on PR #171, BLOCK) ----
+
+  it("retries the initial sync_request when the WS is not yet open, until it succeeds", async () => {
+    vi.useFakeTimers();
+    try {
+      // Start with send() throwing (WS not open yet), then flip the
+      // fake's send to succeed after the first scheduled retry. We
+      // assert that the request is re-sent once the WS opens.
+      let openYet = false;
+      const sent: ClientEvent[] = [];
+      const fake = {
+        send(event: ClientEvent): void {
+          if (!openYet) throw new Error("websocket not open");
+          sent.push(event);
+        },
+        subscribe(): () => void {
+          return () => {};
+        },
+      };
+      const provider = new WsYjsProvider(
+        new Y.Doc(),
+        new Awareness(new Y.Doc()),
+        fake as unknown as WsClient,
+        () => {},
+        () => {},
+        () => {},
+      );
+      provider.start();
+
+      // First attempt during start() failed silently; nothing sent yet.
+      expect(sent).toHaveLength(0);
+
+      // WS opens — advance past the first 100ms backoff.
+      openYet = true;
+      vi.advanceTimersByTime(100);
+
+      expect(sent.some((e) => e.type === "notepad_sync_request")).toBe(true);
+      provider.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up the initial sync_request after MAX_SYNC_RETRIES with a warn log", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fake = {
+        send(): void {
+          throw new Error("websocket not open");
+        },
+        subscribe(): () => void {
+          return () => {};
+        },
+      };
+      const provider = new WsYjsProvider(
+        new Y.Doc(),
+        new Awareness(new Y.Doc()),
+        fake as unknown as WsClient,
+        () => {},
+        () => {},
+        () => {},
+      );
+      provider.start();
+
+      // 100 + 200 + 400 + 800 + 1600 = 3100 ms covers all 5 retries.
+      vi.advanceTimersByTime(4000);
+
+      expect(
+        warnSpy.mock.calls.some(
+          (c) =>
+            typeof c[0] === "string" &&
+            c[0].includes("initial sync_request gave up"),
+        ),
+      ).toBe(true);
+      provider.stop();
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stop() cancels the pending sync-request retry timer", () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fake = {
+        send(): void {
+          throw new Error("websocket not open");
+        },
+        subscribe(): () => void {
+          return () => {};
+        },
+      };
+      const provider = new WsYjsProvider(
+        new Y.Doc(),
+        new Awareness(new Y.Doc()),
+        fake as unknown as WsClient,
+        () => {},
+        () => {},
+        () => {},
+      );
+      provider.start();
+      provider.stop();
+
+      // Advance past every backoff window — no further send calls or
+      // give-up warns should fire because stop() cleared the timer.
+      vi.advanceTimersByTime(4000);
+
+      expect(
+        warnSpy.mock.calls.some(
+          (c) =>
+            typeof c[0] === "string" &&
+            c[0].includes("initial sync_request gave up"),
+        ),
+      ).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/__tests__/notepadProvider.test.ts
+++ b/frontend/src/__tests__/notepadProvider.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for ``WsYjsProvider``'s lock-suppression logic
+ * (issue #160 — "Notepad locked shows twice").
+ *
+ * The provider mirrors the server's lock state so that, once the
+ * server has told us the notepad is locked:
+ *   1. Outbound Yjs / awareness updates are dropped at the source.
+ *   2. Any subsequent ``scope:"notepad"`` error frame is silenced
+ *      (the parent UI's chip already conveys the lock; the user
+ *      cannot act on the error).
+ *
+ * These tests drive a fake ``WsClient`` through both lock-arrival
+ * orderings and assert the expected callbacks fire / don't fire.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { Awareness } from "y-protocols/awareness";
+import * as Y from "yjs";
+
+import { WsYjsProvider } from "../lib/notepadProvider";
+import type { ClientEvent, ServerEvent, WsClient } from "../lib/ws";
+
+interface FakeWsClient {
+  client: WsClient;
+  emit: (evt: ServerEvent) => void;
+  sent: ClientEvent[];
+}
+
+function makeFakeWs(opts: { sendThrows?: boolean } = {}): FakeWsClient {
+  const sent: ClientEvent[] = [];
+  let listener: ((evt: ServerEvent) => void) | null = null;
+  const fake = {
+    send(event: ClientEvent): void {
+      if (opts.sendThrows) throw new Error("websocket not open");
+      sent.push(event);
+    },
+    subscribe(handler: (evt: ServerEvent) => void): () => void {
+      listener = handler;
+      return () => {
+        listener = null;
+      };
+    },
+  };
+  return {
+    client: fake as unknown as WsClient,
+    emit: (evt: ServerEvent) => listener?.(evt),
+    sent,
+  };
+}
+
+function makeProvider(fake: FakeWsClient): {
+  provider: WsYjsProvider;
+  doc: Y.Doc;
+  awareness: Awareness;
+  onLocked: ReturnType<typeof vi.fn>;
+  onLockPending: ReturnType<typeof vi.fn>;
+  onError: ReturnType<typeof vi.fn>;
+} {
+  const doc = new Y.Doc();
+  const awareness = new Awareness(doc);
+  const onLocked = vi.fn();
+  const onLockPending = vi.fn();
+  const onError = vi.fn();
+  const provider = new WsYjsProvider(
+    doc,
+    awareness,
+    fake.client,
+    onLocked,
+    onLockPending,
+    onError,
+  );
+  return { provider, doc, awareness, onLocked, onLockPending, onError };
+}
+
+describe("WsYjsProvider — lock-state handling (issue #160)", () => {
+  it("starts unlocked", () => {
+    const fake = makeFakeWs();
+    const { provider } = makeProvider(fake);
+    provider.start();
+    expect(provider.isLocked).toBe(false);
+    provider.stop();
+  });
+
+  it("flips locked=true on a notepad_locked event", () => {
+    const fake = makeFakeWs();
+    const { provider, onLocked } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({ type: "notepad_locked", locked_at: null });
+
+    expect(provider.isLocked).toBe(true);
+    expect(onLocked).toHaveBeenCalledTimes(1);
+    provider.stop();
+  });
+
+  it("flips locked=true on notepad_sync_response with locked=true", () => {
+    const fake = makeFakeWs();
+    const { provider, onLocked } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({
+      type: "notepad_sync_response",
+      state: "",
+      locked: true,
+      template_id: null,
+    });
+
+    expect(provider.isLocked).toBe(true);
+    expect(onLocked).toHaveBeenCalledTimes(1);
+    provider.stop();
+  });
+
+  it("does NOT lock on notepad_sync_response with locked=false", () => {
+    const fake = makeFakeWs();
+    const { provider, onLocked } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({
+      type: "notepad_sync_response",
+      state: "",
+      locked: false,
+      template_id: null,
+    });
+
+    expect(provider.isLocked).toBe(false);
+    expect(onLocked).not.toHaveBeenCalled();
+    provider.stop();
+  });
+
+  it("LOCK-THEN-ERROR race: suppresses subsequent notepad-scope error frames", () => {
+    const fake = makeFakeWs();
+    const { provider, onError } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({ type: "notepad_locked", locked_at: null });
+    fake.emit({
+      type: "error",
+      scope: "notepad",
+      message: "notepad is locked",
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    provider.stop();
+  });
+
+  it("LOCK-THEN-ERROR race: suppresses ANY notepad-scope error post-lock (not just locked-string)", () => {
+    // Per QA review M1: keying on the exact server message string
+    // ("notepad is locked") was brittle. The widened policy is to
+    // suppress any notepad-scope error once we know we're locked,
+    // since none of them are user-actionable at that point.
+    const fake = makeFakeWs();
+    const { provider, onError } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({ type: "notepad_locked", locked_at: null });
+    fake.emit({ type: "error", scope: "notepad", message: "rate limited" });
+    fake.emit({ type: "error", scope: "notepad", message: "update too large" });
+
+    expect(onError).not.toHaveBeenCalled();
+    provider.stop();
+  });
+
+  it("ERROR-BEFORE-LOCK: surfaces the error normally (parent clears it on its own onLocked)", () => {
+    const fake = makeFakeWs();
+    const { provider, onError } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({
+      type: "error",
+      scope: "notepad",
+      message: "notepad is locked",
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith("notepad is locked");
+    provider.stop();
+  });
+
+  it("preserves non-notepad-scope error pass-through (locked or not)", () => {
+    const fake = makeFakeWs();
+    const { provider, onError } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({ type: "notepad_locked", locked_at: null });
+    fake.emit({
+      type: "error",
+      scope: "submission",
+      message: "boom",
+    });
+
+    // The provider only inspects scope:"notepad" errors. Other scopes
+    // are intentionally ignored (the parent page handles them).
+    expect(onError).not.toHaveBeenCalled();
+    provider.stop();
+  });
+
+  it("stops sending notepad_update once locked", () => {
+    const fake = makeFakeWs();
+    const { provider, doc } = makeProvider(fake);
+    provider.start();
+
+    // Drain the initial sync_request the provider sends on start.
+    fake.sent.length = 0;
+
+    // Pre-lock: a local Yjs change produces a notepad_update.
+    doc.getMap("pre").set("k", "v");
+    expect(fake.sent.some((e) => e.type === "notepad_update")).toBe(true);
+
+    fake.sent.length = 0;
+    fake.emit({ type: "notepad_locked", locked_at: null });
+
+    // Post-lock: a local Yjs change produces NOTHING.
+    doc.getMap("post").set("k", "v");
+    expect(fake.sent).toHaveLength(0);
+    provider.stop();
+  });
+
+  it("stops sending notepad_awareness once locked", () => {
+    const fake = makeFakeWs();
+    const { provider, awareness } = makeProvider(fake);
+    provider.start();
+
+    fake.sent.length = 0;
+
+    // Pre-lock: an awareness change produces a notepad_awareness.
+    awareness.setLocalState({ cursor: 1 });
+    expect(fake.sent.some((e) => e.type === "notepad_awareness")).toBe(true);
+
+    fake.sent.length = 0;
+    fake.emit({ type: "notepad_locked", locked_at: null });
+
+    // Post-lock: an awareness change produces NOTHING.
+    awareness.setLocalState({ cursor: 2 });
+    expect(fake.sent).toHaveLength(0);
+    provider.stop();
+  });
+
+  it("forwards notepad_lock_pending to the parent unchanged", () => {
+    const fake = makeFakeWs();
+    const { provider, onLockPending } = makeProvider(fake);
+    provider.start();
+
+    fake.emit({ type: "notepad_lock_pending", locks_in_seconds: 5 });
+
+    expect(onLockPending).toHaveBeenCalledWith(5);
+    expect(provider.isLocked).toBe(false);
+    provider.stop();
+  });
+});

--- a/frontend/src/components/SharedNotepad.tsx
+++ b/frontend/src/components/SharedNotepad.tsx
@@ -19,7 +19,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { EditorContent, useEditor } from "@tiptap/react";
 import type { Editor, Extension } from "@tiptap/core";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Awareness, applyAwarenessUpdate, encodeAwarenessUpdate } from "y-protocols/awareness";
+import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
 
 import { CollapsibleRailPanel } from "./brand/CollapsibleRailPanel";
@@ -38,7 +38,8 @@ import {
 } from "../lib/notepad";
 import type { NotepadTemplate } from "../lib/notepad";
 import { appendPinToEditor, relativeStamp } from "../lib/notepadEditor";
-import type { ServerEvent, WsClient } from "../lib/ws";
+import { WsYjsProvider } from "../lib/notepadProvider";
+import type { WsClient } from "../lib/ws";
 
 interface Props {
   sessionId: string;
@@ -78,161 +79,6 @@ function roleColor(roleId: string): string {
     h = (h * 31 + roleId.charCodeAt(i)) >>> 0;
   }
   return palette[h % palette.length];
-}
-
-/**
- * Minimal Yjs <-> WsClient bridge. Replaces the standard y-websocket
- * provider so we don't need a separate Yjs server.
- *
- * On open: send notepad_sync_request. The server replies with the
- * current encoded state.
- *
- * On local Yjs update: send notepad_update with the binary payload
- * base64-encoded.
- *
- * On incoming notepad_update: apply to local doc. Yjs is idempotent,
- * so the sender's own update is a no-op when echoed back.
- */
-class WsYjsProvider {
-  private unsub: (() => void) | null = null;
-  private yObserver: ((u: Uint8Array, origin: unknown) => void) | null = null;
-  private awarenessObserver:
-    | ((args: { added: number[]; updated: number[]; removed: number[] }, origin: unknown) => void)
-    | null = null;
-  private isOriginRemote = Symbol("notepad-remote");
-
-  constructor(
-    public readonly doc: Y.Doc,
-    public readonly awareness: Awareness,
-    private readonly ws: WsClient,
-    public readonly onLocked: () => void,
-    public readonly onLockPending: (secs: number) => void,
-    public readonly onError: (msg: string) => void,
-  ) {}
-
-  start(): void {
-    this.yObserver = (update: Uint8Array, origin: unknown) => {
-      if (origin === this.isOriginRemote) return;
-      try {
-        this.ws.send({ type: "notepad_update", update: bytesToBase64(update) });
-      } catch (err) {
-        console.warn("[notepad] update send failed", err);
-      }
-    };
-    this.doc.on("update", this.yObserver);
-
-    this.awarenessObserver = (
-      { added, updated, removed }: { added: number[]; updated: number[]; removed: number[] },
-      origin: unknown,
-    ) => {
-      if (origin === this.isOriginRemote) return;
-      const changed = added.concat(updated, removed);
-      if (changed.length === 0) return;
-      try {
-        const update = encodeAwarenessUpdate(this.awareness, changed);
-        this.ws.send({
-          type: "notepad_awareness",
-          awareness: bytesToBase64(update),
-        });
-      } catch (err) {
-        console.warn("[notepad] awareness send failed", err);
-      }
-    };
-    this.awareness.on("update", this.awarenessObserver);
-
-    this.unsub = this.ws.subscribe((evt) => this.handle(evt));
-
-    // Send initial sync request. The WS may not be open yet — guard.
-    try {
-      this.ws.send({ type: "notepad_sync_request" });
-    } catch {
-      // Will retry on the next open via the page-level reconnect logic.
-    }
-  }
-
-  stop(): void {
-    if (this.yObserver) {
-      this.doc.off("update", this.yObserver);
-      this.yObserver = null;
-    }
-    if (this.awarenessObserver) {
-      this.awareness.off("update", this.awarenessObserver);
-      this.awarenessObserver = null;
-    }
-    // Drop our awareness state cleanly so other clients see us go offline.
-    this.awareness.setLocalState(null);
-    if (this.unsub) {
-      this.unsub();
-      this.unsub = null;
-    }
-  }
-
-  private handle(evt: ServerEvent): void {
-    switch (evt.type) {
-      case "notepad_sync_response": {
-        try {
-          const bytes = base64ToBytes(evt.state);
-          if (bytes.length > 0) {
-            Y.applyUpdate(this.doc, bytes, this.isOriginRemote);
-          }
-        } catch (err) {
-          console.warn("[notepad] sync apply failed", err);
-        }
-        if (evt.locked) this.onLocked();
-        break;
-      }
-      case "notepad_update": {
-        try {
-          Y.applyUpdate(
-            this.doc,
-            base64ToBytes(evt.update),
-            this.isOriginRemote,
-          );
-        } catch (err) {
-          console.warn("[notepad] remote update apply failed", err);
-        }
-        break;
-      }
-      case "notepad_awareness": {
-        try {
-          applyAwarenessUpdate(
-            this.awareness,
-            base64ToBytes(evt.awareness),
-            this.isOriginRemote,
-          );
-        } catch (err) {
-          console.warn("[notepad] awareness apply failed", err);
-        }
-        break;
-      }
-      case "notepad_lock_pending":
-        this.onLockPending(evt.locks_in_seconds);
-        break;
-      case "notepad_locked":
-        this.onLocked();
-        break;
-      case "error":
-        if (evt.scope === "notepad") this.onError(evt.message);
-        break;
-      default:
-        break;
-    }
-  }
-}
-
-function bytesToBase64(b: Uint8Array): string {
-  let out = "";
-  for (let i = 0; i < b.length; i += 0x8000) {
-    out += String.fromCharCode(...b.subarray(i, i + 0x8000));
-  }
-  return btoa(out);
-}
-
-function base64ToBytes(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
 }
 
 function timestampHotkeyExtension(sessionStartedAt: string): Extension {
@@ -331,7 +177,21 @@ export function SharedNotepad({
       ydoc,
       awareness,
       ws,
-      () => setLocked(true),
+      () => {
+        setLocked(true);
+        // Three lock-error races to think about:
+        //   (a) error-then-lock: a "notepad is locked" toast arrived
+        //       before the lock event — clear it so the chip alone
+        //       carries the state.
+        //   (b) lock-then-error: the provider's ``this.locked`` flag
+        //       (set above the React update) suppresses any post-lock
+        //       notepad-scope errors at the source.
+        //   (c) error-during-lock: error is rendering, lock event
+        //       arrives, this clear immediately dismisses it. Fine —
+        //       the chip + sr-only live region cover the state.
+        // (Issue #160; QA review M2.)
+        setErrorMsg(null);
+      },
       (secs) => setLockPendingSecs(secs),
       (msg) => setErrorMsg(msg),
     );
@@ -530,10 +390,10 @@ export function SharedNotepad({
           <StatusChip
             tone="warn"
             label="SHARED"
-            value={locked ? "LOCKED · export available" : "HIDDEN FROM AI"}
+            value={locked ? "LOCKED · session ended" : "HIDDEN FROM AI"}
             title={
               locked
-                ? "Notepad is read-only; the export link still works."
+                ? "Session ended — notepad is read-only. The export link still works."
                 : "Hidden from the AI during play. At end of session, the AI reads the whole notepad to write the final report — including anything you've flagged via 'Mark for AAR'. Plan and debrief freely."
             }
           />
@@ -550,6 +410,18 @@ export function SharedNotepad({
           </a>
         </div>
 
+        {/* Screen-reader-only live region. The visible chip itself is a
+            static ``<div>`` with no ARIA semantics, so AT users would
+            otherwise miss the lock transition. ``aria-live="polite"``
+            announces the state change without interrupting whatever the
+            user is currently focused on. (UI/UX review HIGH for issue
+            #160.) */}
+        <span className="sr-only" aria-live="polite" role="status">
+          {locked
+            ? "Session ended. Notepad is locked and read-only. Export link is still available."
+            : ""}
+        </span>
+
         {lockPendingSecs !== null && !locked ? (
           <div
             role="status"
@@ -558,13 +430,6 @@ export function SharedNotepad({
           >
             Session ending — notepad locks in {lockPendingSecs}s. Notes will
             export regardless.
-          </div>
-        ) : null}
-
-        {locked ? (
-          <div className="rounded-r-1 border border-ink-500 bg-ink-900 px-2 py-1 text-[12px] text-ink-200">
-            NOTEPAD LOCKED — session ended. Export still available via the
-            link above.
           </div>
         ) : null}
 

--- a/frontend/src/lib/notepadProvider.ts
+++ b/frontend/src/lib/notepadProvider.ts
@@ -52,6 +52,13 @@ export class WsYjsProvider {
   // the provider from scratch via the parent useEffect, so a fresh
   // session starts unlocked.
   private locked = false;
+  // Bounded-retry timer for the initial ``notepad_sync_request``. The
+  // page may mount the SharedNotepad before the WS finishes its open
+  // handshake; in that race ``ws.send`` throws "websocket not open" and
+  // the request would otherwise be silently dropped — the client would
+  // be left without the current notepad state until someone edited.
+  // Cleared on ``stop()``. (Copilot review on PR #171, BLOCK.)
+  private syncRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     public readonly doc: Y.Doc,
@@ -65,6 +72,21 @@ export class WsYjsProvider {
   /** Read-only view of the lock flag (test hook + future debuggability). */
   get isLocked(): boolean {
     return this.locked;
+  }
+
+  /** Idempotent lock transition. Sets the flag, logs once, and fires
+   *  ``onLocked`` exactly once across multiple lock signals (replay
+   *  buffer's ``notepad_locked`` plus a follow-up
+   *  ``notepad_sync_response.locked=true`` is the canonical race).
+   *  Without this guard the parent saw duplicate ``setLocked(true)``
+   *  + ``setErrorMsg(null)`` calls — the second clear could wipe a
+   *  fresh non-lock error toast that arrived between the two events.
+   *  (Copilot review on PR #171, HIGH.) */
+  private setLockedOnce(source: "sync_response" | "lock_event"): void {
+    if (this.locked) return;
+    this.locked = true;
+    console.info("[notepad] locked", { source });
+    this.onLocked();
   }
 
   start(): void {
@@ -111,15 +133,45 @@ export class WsYjsProvider {
 
     this.unsub = this.ws.subscribe((evt) => this.handle(evt));
 
-    // Send initial sync request. The WS may not be open yet — guard.
+    // Send initial sync request. The WS may not be open yet — retry
+    // with bounded exponential backoff so a race between
+    // editor-mount and the WS open handshake doesn't leave the
+    // client without the current notepad state. ``WsClient.send``
+    // throws ``"websocket not open"`` when ``socket.readyState !==
+    // OPEN``; we re-arm a setTimeout up to MAX_SYNC_RETRIES times
+    // (~3.1s total wall-clock at 100 / 200 / 400 / 800 / 1600 ms),
+    // then give up loud. Cleared in ``stop()``.
+    this.requestInitialSync(0);
+  }
+
+  private static readonly MAX_SYNC_RETRIES = 5;
+
+  private requestInitialSync(attempt: number): void {
     try {
       this.ws.send({ type: "notepad_sync_request" });
-    } catch {
-      // Will retry on the next open via the page-level reconnect logic.
+      this.syncRetryTimer = null;
+      return;
+    } catch (err) {
+      if (attempt >= WsYjsProvider.MAX_SYNC_RETRIES) {
+        console.warn(
+          "[notepad] initial sync_request gave up after retries",
+          { attempts: attempt + 1, lastError: String(err) },
+        );
+        this.syncRetryTimer = null;
+        return;
+      }
+      const delayMs = 100 * 2 ** attempt;
+      this.syncRetryTimer = setTimeout(() => {
+        this.requestInitialSync(attempt + 1);
+      }, delayMs);
     }
   }
 
   stop(): void {
+    if (this.syncRetryTimer) {
+      clearTimeout(this.syncRetryTimer);
+      this.syncRetryTimer = null;
+    }
     if (this.yObserver) {
       this.doc.off("update", this.yObserver);
       this.yObserver = null;
@@ -148,9 +200,7 @@ export class WsYjsProvider {
           console.warn("[notepad] sync apply failed", err);
         }
         if (evt.locked) {
-          this.locked = true;
-          console.info("[notepad] locked", { source: "sync_response" });
-          this.onLocked();
+          this.setLockedOnce("sync_response");
         }
         break;
       }
@@ -182,9 +232,7 @@ export class WsYjsProvider {
         this.onLockPending(evt.locks_in_seconds);
         break;
       case "notepad_locked":
-        this.locked = true;
-        console.info("[notepad] locked", { source: "lock_event" });
-        this.onLocked();
+        this.setLockedOnce("lock_event");
         break;
       case "error":
         if (evt.scope === "notepad") {

--- a/frontend/src/lib/notepadProvider.ts
+++ b/frontend/src/lib/notepadProvider.ts
@@ -1,0 +1,228 @@
+/**
+ * WsYjsProvider — minimal Yjs <-> WsClient bridge for the shared
+ * notepad. Replaces the standard y-websocket provider so the app
+ * doesn't need a separate Yjs server.
+ *
+ * Lifecycle:
+ *   - On ``start()``: subscribes to local Yjs / awareness updates
+ *     and to the WS event stream. Sends an initial
+ *     ``notepad_sync_request``.
+ *   - On local Yjs / awareness update: forwards the binary payload
+ *     base64-encoded (``notepad_update`` / ``notepad_awareness``).
+ *   - On incoming ``notepad_update`` / ``notepad_awareness``: applies
+ *     to the local doc / awareness state. Yjs is idempotent, so the
+ *     sender's own update is a no-op when echoed back.
+ *   - On ``notepad_locked`` (or ``notepad_sync_response.locked``):
+ *     marks the provider terminally locked; future outbound updates
+ *     are dropped at the source AND any future ``scope:"notepad"``
+ *     error frame is suppressed (the parent UI's chip already shows
+ *     the lock state, and the user can't act on the error).
+ *
+ * Extracted from SharedNotepad.tsx so the lock-suppression logic is
+ * unit-testable without booting React/TipTap (issue #160; QA review H2).
+ */
+import { Awareness, applyAwarenessUpdate, encodeAwarenessUpdate } from "y-protocols/awareness";
+import * as Y from "yjs";
+
+import type { ServerEvent, WsClient } from "./ws";
+
+export class WsYjsProvider {
+  private unsub: (() => void) | null = null;
+  private yObserver: ((u: Uint8Array, origin: unknown) => void) | null = null;
+  private awarenessObserver:
+    | ((args: { added: number[]; updated: number[]; removed: number[] }, origin: unknown) => void)
+    | null = null;
+  private isOriginRemote = Symbol("notepad-remote");
+  // Mirrors the React ``locked`` state on the provider so the WS-side
+  // hot path doesn't have to re-query the parent. Two reasons:
+  //   1. Suppress the round-trip noise — once the server has told us the
+  //      notepad is locked, any in-flight Yjs / awareness updates we
+  //      still try to send come back as ``error: notepad is locked``,
+  //      which used to surface as a redundant orange banner under the
+  //      already-visible "LOCKED · session ended" chip (issue #160).
+  //   2. Silence those server errors at the source: when we know we're
+  //      locked, we drop ANY ``scope:"notepad"`` error toast because
+  //      the chip already conveys the lock state and the user cannot
+  //      act on the error. (Started as an exact-string match on
+  //      ``"notepad is locked"`` — see backend/app/ws/routes.py:345 —
+  //      but per QA review M1 we widened it: keying on the
+  //      server-message string is brittle, and once locked there's
+  //      nothing actionable for any notepad-scope error.)
+  // Lock is terminal — we never reset to false. A reconnect rebuilds
+  // the provider from scratch via the parent useEffect, so a fresh
+  // session starts unlocked.
+  private locked = false;
+
+  constructor(
+    public readonly doc: Y.Doc,
+    public readonly awareness: Awareness,
+    private readonly ws: WsClient,
+    public readonly onLocked: () => void,
+    public readonly onLockPending: (secs: number) => void,
+    public readonly onError: (msg: string) => void,
+  ) {}
+
+  /** Read-only view of the lock flag (test hook + future debuggability). */
+  get isLocked(): boolean {
+    return this.locked;
+  }
+
+  start(): void {
+    this.yObserver = (update: Uint8Array, origin: unknown) => {
+      if (origin === this.isOriginRemote) return;
+      // Server REJECTS local notepad_update once locked (raises
+      // NotepadLockedError → ``error: notepad is locked``) so this
+      // short-circuit eliminates the round-trip + the would-be toast.
+      if (this.locked) return;
+      try {
+        this.ws.send({ type: "notepad_update", update: bytesToBase64(update) });
+      } catch (err) {
+        console.warn("[notepad] update send failed", err);
+      }
+    };
+    this.doc.on("update", this.yObserver);
+
+    this.awarenessObserver = (
+      { added, updated, removed }: { added: number[]; updated: number[]; removed: number[] },
+      origin: unknown,
+    ) => {
+      if (origin === this.isOriginRemote) return;
+      // Server-side awareness handler does NOT raise on lock (it just
+      // broadcasts) — so this short-circuit is purely defensive: once
+      // the session has ended, awareness cursor positions stop being
+      // useful, and dropping them keeps the WS quiet. Don't "fix" this
+      // by adding server-side rejection; that would re-introduce a
+      // race where late awareness frames produce a toast.
+      // (QA review H1 for issue #160.)
+      if (this.locked) return;
+      const changed = added.concat(updated, removed);
+      if (changed.length === 0) return;
+      try {
+        const update = encodeAwarenessUpdate(this.awareness, changed);
+        this.ws.send({
+          type: "notepad_awareness",
+          awareness: bytesToBase64(update),
+        });
+      } catch (err) {
+        console.warn("[notepad] awareness send failed", err);
+      }
+    };
+    this.awareness.on("update", this.awarenessObserver);
+
+    this.unsub = this.ws.subscribe((evt) => this.handle(evt));
+
+    // Send initial sync request. The WS may not be open yet — guard.
+    try {
+      this.ws.send({ type: "notepad_sync_request" });
+    } catch {
+      // Will retry on the next open via the page-level reconnect logic.
+    }
+  }
+
+  stop(): void {
+    if (this.yObserver) {
+      this.doc.off("update", this.yObserver);
+      this.yObserver = null;
+    }
+    if (this.awarenessObserver) {
+      this.awareness.off("update", this.awarenessObserver);
+      this.awarenessObserver = null;
+    }
+    // Drop our awareness state cleanly so other clients see us go offline.
+    this.awareness.setLocalState(null);
+    if (this.unsub) {
+      this.unsub();
+      this.unsub = null;
+    }
+  }
+
+  private handle(evt: ServerEvent): void {
+    switch (evt.type) {
+      case "notepad_sync_response": {
+        try {
+          const bytes = base64ToBytes(evt.state);
+          if (bytes.length > 0) {
+            Y.applyUpdate(this.doc, bytes, this.isOriginRemote);
+          }
+        } catch (err) {
+          console.warn("[notepad] sync apply failed", err);
+        }
+        if (evt.locked) {
+          this.locked = true;
+          console.info("[notepad] locked", { source: "sync_response" });
+          this.onLocked();
+        }
+        break;
+      }
+      case "notepad_update": {
+        try {
+          Y.applyUpdate(
+            this.doc,
+            base64ToBytes(evt.update),
+            this.isOriginRemote,
+          );
+        } catch (err) {
+          console.warn("[notepad] remote update apply failed", err);
+        }
+        break;
+      }
+      case "notepad_awareness": {
+        try {
+          applyAwarenessUpdate(
+            this.awareness,
+            base64ToBytes(evt.awareness),
+            this.isOriginRemote,
+          );
+        } catch (err) {
+          console.warn("[notepad] awareness apply failed", err);
+        }
+        break;
+      }
+      case "notepad_lock_pending":
+        this.onLockPending(evt.locks_in_seconds);
+        break;
+      case "notepad_locked":
+        this.locked = true;
+        console.info("[notepad] locked", { source: "lock_event" });
+        this.onLocked();
+        break;
+      case "error":
+        if (evt.scope === "notepad") {
+          // Drop ANY notepad-scope error once we know we're locked —
+          // the parent already renders the lock chip and the user
+          // cannot act on the error. Keying on the literal message
+          // string (e.g. ``"notepad is locked"``) is brittle: the
+          // backend literal at app/ws/routes.py could be rephrased,
+          // and other late-arriving notepad errors (rate limit,
+          // oversized) post-lock would surface as confusing toasts
+          // under a clearly-locked chip. (Issue #160; QA review M1.)
+          if (this.locked) {
+            console.debug(
+              "[notepad] suppressed post-lock error toast",
+              { message: evt.message },
+            );
+            break;
+          }
+          this.onError(evt.message);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+export function bytesToBase64(b: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < b.length; i += 0x8000) {
+    out += String.fromCharCode(...b.subarray(i, i + 0x8000));
+  }
+  return btoa(out);
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}


### PR DESCRIPTION
Closes #160

## Summary

When a session ended, the team-notepad rail rendered **three** simultaneous indicators of the locked state:

1. Status chip "SHARED  LOCKED · export available"
2. Banner "NOTEPAD LOCKED — session ended. Export still available via the link above."
3. Error toast "notepad is locked" — the WS-error string the server returned for in-flight Yjs / awareness frames that raced the `notepad_locked` event.

This PR collapses all three into a single, more informative status chip, fixes a screen-reader regression along the way, and stops the WS-error pump that fed indicator #3.

## What changed

**`frontend/src/components/SharedNotepad.tsx`**
- Removed the redundant "NOTEPAD LOCKED — session ended..." banner.
- Updated the chip's value to **`LOCKED · session ended`** (was `LOCKED · export available`). The export button is right next to the chip so the affordance is already visible; the "why" is the more useful copy.
- Updated the chip's `title` to `"Session ended — notepad is read-only. The export link still works."`
- Added an `sr-only` `aria-live="polite"` region announcing the lock transition (the chip itself is a static `<div>` with no ARIA semantics — AT users would otherwise miss the change).
- Clear stale `errorMsg` in the React parent on `onLocked` to handle the error-then-lock race.

**`frontend/src/lib/notepadProvider.ts`** (new — extracted from `SharedNotepad.tsx`)
- `WsYjsProvider` now mirrors the lock state internally. Once we know we're locked:
  - Outbound `notepad_update` and `notepad_awareness` sends short-circuit (no more round-trip).
  - **Any** `scope:"notepad"` error frame is suppressed (logged at `console.debug`). Started as an exact-string match on `"notepad is locked"`; widened per QA review to avoid silent breakage if the backend literal at `app/ws/routes.py:345` is ever rephrased, and because no notepad-scope error is user-actionable post-lock.
  - Lock is terminal — never reset; a reconnect rebuilds the provider via the parent effect.
- Added `console.info("[notepad] locked", { source })` at both lock boundaries (sync-response and lock event) per CLAUDE.md debuggability rule.

**`frontend/src/__tests__/notepadProvider.test.ts`** (new — 11 tests)
- Both lock-then-error and error-then-lock orderings.
- Sync-response lock variant.
- Outbound update / awareness suppression post-lock.
- Non-notepad-scope error pass-through.
- Lock-pending forwarding.

## Sub-agent reviews

Per CLAUDE.md, ran all six in parallel before pushing. All BLOCK / CRITICAL / HIGH and the LOW debuggability finding addressed:

| Agent | Findings | Status |
| --- | --- | --- |
| Security | MEDIUM (string-equality brittleness), LOW (no reset by design) | both addressed (M widened to scope-key; L documented) |
| UI/UX | HIGH (aria-live), MEDIUM (tooltip context) | both addressed |
| Product | MINOR only | acknowledged |
| User | HIGH (why-it-locked context), MEDIUM (mobile tooltip), MEDIUM (silent typing) | first two addressed; third deferred (see follow-ups) |
| Prompt Expert | none | clean (no LLM/prompt impact) |
| QA | HIGH H1 (awareness-suppression asymmetry), HIGH H2 (no unit tests), MEDIUM M1 (string-equality), MEDIUM M2 (race comment), LOW L1 (boundary logging) | all addressed |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test -- --run` — 372 passed (361 → 372; 11 new tests added)
- [x] `npm test -- --run notepadProvider` — 11/11 pass
- [ ] Manual smoke: end a session → notepad should show ONE chip ("SHARED LOCKED · session ended") and the Export .md button. No banner. Type into the notepad → no orange "notepad is locked" toast.
- [ ] Manual smoke: VoiceOver / NVDA should announce "Session ended. Notepad is locked and read-only. Export link is still available." when the lock transition happens.

## Out of scope (follow-ups worth filing separately)

- **Silent typing rejection while locked.** ProseMirror's read-only state swallows keystrokes with no in-editor feedback. Pre-existing; the suppression of the toast made it slightly more silent. Worth a follow-up to add inline ghost-text feedback in the editor body.
- **Structured error code on WS error frames.** Sharing a `code: "notepad_locked"` field between server and client would harden the suppression check (currently scope-keyed, which is robust but less explicit).

## Why no live tests

Per CLAUDE.md "always-do checklist" item 6: the diff is purely frontend; no `backend/app/llm/`, `app/sessions/turn_*.py`, `submission_pipeline.py`, prompt, tool description, or recovery-directive copy touched. Live LLM tests not required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKmVwfUFgQJvcKFG3AMkdw)_