### PR TITLE
sessions: emit per-turn progress_pct for the TURN STATE rail (#111)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -20,6 +20,7 @@ from ..auth.authz import (
 from ..extensions.registry import FrozenRegistry
 from ..sessions.manager import SessionManager
 from ..sessions.models import ParticipantKind, ScenarioPlan, SessionState
+from ..sessions.progress import compute_progress_pct
 from ..sessions.repository import SessionNotFoundError
 from ..sessions.turn_driver import TurnDriver
 from ..sessions.turn_engine import IllegalTransitionError
@@ -333,6 +334,12 @@ def register_api_routes(app: FastAPI) -> None:
                     # contributions that don't yet flip the AI to advance).
                     "ready_role_ids": session.current_turn.ready_role_ids,
                     "status": session.current_turn.status,
+                    # Issue #111: per-turn progress fraction (0.0–1.0)
+                    # for the TURN STATE rail's determinate progress
+                    # bar. ``None`` keeps the indeterminate sweep
+                    # rendering — see ``sessions/progress.py`` for the
+                    # per-state policy.
+                    "progress_pct": compute_progress_pct(session),
                 }
                 if session.current_turn
                 else None

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -29,6 +29,7 @@ from .models import (
     SetupNote,
     Turn,
 )
+from .progress import compute_progress_pct
 from .repository import SessionRepository
 from .submission_pipeline import FACILITATOR_MENTION_TOKEN
 from .turn_engine import (
@@ -223,7 +224,21 @@ class SessionManager:
             },
         )
 
-    async def _broadcast_state(self, session: Session) -> None:
+    async def _broadcast_state(
+        self, session: Session, *, record: bool = True
+    ) -> None:
+        """Broadcast a ``state_changed`` event for the current state.
+
+        ``record`` controls whether the event lands in the connection
+        manager's bounded replay buffer. Default ``True`` (state
+        transitions are durable; reconnecting clients need them in the
+        replay). Issue #111's progress-pulse re-broadcasts pass
+        ``record=False`` — the snapshot regenerates ``progress_pct``
+        at fetch time, so the pulse doesn't need to survive in the
+        replay buffer (and using a slot per pulse would evict
+        legitimate state_changed / message_complete events).
+        """
+
         await self._connections.broadcast(
             session.id,
             {
@@ -235,7 +250,12 @@ class SessionManager:
                 "turn_index": (
                     session.current_turn.index if session.current_turn else None
                 ),
+                # Issue #111: per-turn progress fraction so the TURN
+                # STATE rail can render a determinate bar without
+                # waiting for the next snapshot poll.
+                "progress_pct": compute_progress_pct(session),
             },
+            record=record,
         )
 
     # ----------------------------------------------------- session lifecycle
@@ -756,6 +776,10 @@ class SessionManager:
                 "type": "turn_changed",
                 "turn_index": turn.index,
                 "active_role_ids": turn.active_role_ids,
+                # Issue #111: ride the new-turn fan-out so a freshly-
+                # opened turn (e.g. after force-advance reopens an
+                # active set) carries the reset progress fraction.
+                "progress_pct": compute_progress_pct(session),
             },
         )
         self._emit(
@@ -1100,6 +1124,10 @@ class SessionManager:
                         "type": "turn_changed",
                         "turn_index": new_turn.index,
                         "active_role_ids": new_turn.active_role_ids,
+                        # Issue #111: fresh turn → reset progress
+                        # fraction (computed from active/submitted on
+                        # the new turn).
+                        "progress_pct": compute_progress_pct(session),
                     },
                 )
                 self._emit("force_advance", session, by=by_role_id, recovered_from="errored")

--- a/backend/app/sessions/models.py
+++ b/backend/app/sessions/models.py
@@ -190,6 +190,17 @@ class Turn(BaseModel):
     ended_at: datetime | None = None
     error_reason: str | None = None
     retried_with_strict: bool = False
+    # Issue #111: per-turn AI sub-step progress (0.0–1.0). Written by
+    # ``turn_driver.run_play_turn`` at known sub-step boundaries
+    # (planning → tool dispatch → emit / yield) so the frontend's
+    # TURN STATE rail can render a determinate bar instead of the
+    # indeterminate sweep. ``None`` while the turn has not yet
+    # produced a meaningful sub-step (e.g. waiting on the LLM call to
+    # start) — the rail falls back to the sweep in that case.
+    # Only populated while ``session.state`` is AI_PROCESSING /
+    # BRIEFING; AWAITING_PLAYERS computes its own progress from
+    # ``submitted_role_ids / active_role_ids`` at snapshot time.
+    ai_progress_pct: float | None = None
 
 
 class ScenarioInject(BaseModel):

--- a/backend/app/sessions/progress.py
+++ b/backend/app/sessions/progress.py
@@ -1,0 +1,101 @@
+"""Per-turn progress percentage for the TURN STATE rail (issue #111).
+
+Single source of truth for "what fraction of the active step is done?"
+Three call sites consume this:
+
+1. The snapshot serializer in ``app/api/routes.py`` — surfaces
+   ``current_turn.progress_pct`` so a reconnecting tab gets the value
+   at fetch time.
+2. The ``state_changed`` / ``turn_changed`` WS broadcasts in
+   ``app/sessions/manager.py`` and ``app/sessions/turn_driver.py`` —
+   pushes interim updates without forcing a snapshot poll.
+3. The play-turn driver itself, which writes ``Turn.ai_progress_pct``
+   at sub-step boundaries (planning → tool dispatch → emit / yield)
+   and re-broadcasts state so the bar advances as the AI works.
+
+Coarse buckets are by design — the issue explicitly asks for "anything
+better than the constant sweep." A precise estimator is a follow-up.
+"""
+
+from __future__ import annotations
+
+from ..logging_setup import get_logger
+from .models import Session, SessionState
+
+_logger = get_logger("session.progress")
+
+
+def compute_progress_pct(session: Session) -> float | None:
+    """Return the active step's progress fraction in [0.0, 1.0], or
+    ``None`` to keep the sweep (indeterminate) bar.
+
+    Per-state policy:
+
+    - ``ENDED`` — terminal state, bar fills (1.0).
+    - ``AWAITING_PLAYERS`` — submitted / active. ``None`` when the
+      turn has no active roles (e.g. the very first frame after a
+      yield, before the engine has populated the next active set).
+    - ``AI_PROCESSING`` / ``BRIEFING`` — driver-written
+      ``Turn.ai_progress_pct``. May be ``None`` early in the turn
+      before the LLM call returns; callers fall back to the sweep.
+    - ``CREATED`` / ``SETUP`` / ``READY`` — sweep (None). The setup
+      tier has no natural sub-step pulse and a stuck-at-zero bar
+      would read as broken.
+
+    Each ``None`` return logs a debug breadcrumb so an operator
+    debugging "why is the bar stuck in sweep" can grep for the
+    reason without reproducing the live session (logging-and-
+    debuggability rule, CLAUDE.md).
+    """
+
+    state = session.state
+    if state == SessionState.ENDED:
+        return 1.0
+    if state == SessionState.AWAITING_PLAYERS:
+        turn = session.current_turn
+        if turn is None:
+            _logger.debug(
+                "progress_pct_indeterminate",
+                session_id=session.id,
+                state=state.value,
+                reason="no_current_turn",
+            )
+            return None
+        active_count = len(turn.active_role_ids)
+        if active_count == 0:
+            _logger.debug(
+                "progress_pct_indeterminate",
+                session_id=session.id,
+                state=state.value,
+                reason="empty_active_role_ids",
+                turn_index=turn.index,
+            )
+            return None
+        submitted_count = len(turn.submitted_role_ids)
+        return min(1.0, submitted_count / active_count)
+    if state in (SessionState.AI_PROCESSING, SessionState.BRIEFING):
+        turn = session.current_turn
+        if turn is None:
+            _logger.debug(
+                "progress_pct_indeterminate",
+                session_id=session.id,
+                state=state.value,
+                reason="no_current_turn",
+            )
+            return None
+        if turn.ai_progress_pct is None:
+            _logger.debug(
+                "progress_pct_indeterminate",
+                session_id=session.id,
+                state=state.value,
+                reason="ai_progress_pct_unset",
+                turn_index=turn.index,
+            )
+        return turn.ai_progress_pct
+    # CREATED / SETUP / READY: deliberate sweep — no log line because
+    # the volume would be high (every snapshot fetch during setup) and
+    # the cause is not a bug, it's policy.
+    return None
+
+
+__all__ = ["compute_progress_pct"]

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -47,6 +47,7 @@ from .models import (
     Turn,
 )
 from .phase_policy import assert_state, tool_choice_for
+from .progress import compute_progress_pct
 from .slots import Slot
 from .turn_engine import critical_inject_allowed
 from .turn_validator import (
@@ -62,6 +63,58 @@ _logger = get_logger("session.turn_driver")
 class TurnDriver:
     def __init__(self, *, manager: SessionManager) -> None:
         self._manager = manager
+
+    async def _set_progress(
+        self,
+        session: Session,
+        turn: Turn,
+        value: float,
+    ) -> None:
+        """Write ``turn.ai_progress_pct`` and re-broadcast ``state_changed``.
+
+        Issue #111: the TURN STATE rail's bar binds to
+        ``current_turn.progress_pct``. Each AI sub-step boundary
+        (planning → tool dispatch → emit / yield) calls this so the
+        bar advances from the indeterminate sweep into a determinate
+        fraction.
+
+        **Monotonic** (review-pass): the bar never goes backwards
+        within a single turn. A recovery pass whose bucket value
+        falls below the prior attempt's high-water mark stays at the
+        high-water mark until the next sub-step actually advances
+        past it. Without this, a visible bar drop on recovery reads
+        as "the system rewound" — flagged HIGH by the user-persona
+        review. The ``ai_status`` event already labels recovery
+        passes (``recovery: missing_yield`` etc.); the bar is the
+        ambient signal, ai_status is the explicit one.
+
+        Callers pass ``1.0`` only at the validation-success boundary;
+        sub-step buckets stay below it so the bar reaches 100% only
+        when the AI step is genuinely done, not while still thinking.
+
+        ``record=False`` on the underlying broadcast: progress pulses
+        are stale on reconnect (the snapshot fetch regenerates the
+        value from session state) and would otherwise consume slots
+        in the bounded 256-event replay buffer, evicting legitimate
+        ``state_changed`` / ``message_complete`` events that a
+        reconnecting client needs (security review MEDIUM).
+        """
+
+        clamped = max(0.0, min(1.0, value))
+        current = turn.ai_progress_pct or 0.0
+        if clamped <= current:
+            return
+        turn.ai_progress_pct = clamped
+        try:
+            await self._manager._broadcast_state(session, record=False)
+        except Exception as exc:
+            _logger.warning(
+                "progress_broadcast_failed",
+                session_id=session.id,
+                turn_id=turn.id,
+                progress_pct=clamped,
+                error=str(exc),
+            )
 
     async def _emit_ai_status(
         self,
@@ -363,6 +416,17 @@ class TurnDriver:
                     turn_index=turn.index,
                 )
 
+                # Issue #111: bar pulse — "starting" the (re)attempt.
+                # Coarse buckets per the issue's "anything is better
+                # than the constant sweep" criterion. The monotonic
+                # clamp inside ``_set_progress`` absorbs recovery-pass
+                # values that fall below the prior attempt's high-water
+                # mark (the bar stalls until the next sub-step
+                # genuinely advances past it).
+                await self._set_progress(
+                    session, turn, 0.10 + 0.20 * (attempt - 1)
+                )
+
                 # Build messages. On a recovery pass replace the trailing
                 # kickoff/strict nudge with the directive's user_nudge,
                 # then splice the prior assistant tool_use blocks +
@@ -430,6 +494,12 @@ class TurnDriver:
                     session_id=session.id, tier="play", result=result, turn_id=turn.id
                 )
 
+                # Issue #111: bar pulse — LLM call returned, about to
+                # dispatch tools.
+                await self._set_progress(
+                    session, turn, 0.40 + 0.20 * (attempt - 1)
+                )
+
                 tool_uses = _tool_uses(result)
                 outcome = await dispatcher.dispatch(
                     session=session,
@@ -439,6 +509,12 @@ class TurnDriver:
                         session,
                         max_per_5_turns=settings.max_critical_injects_per_5_turns,
                     ),
+                )
+
+                # Issue #111: bar pulse — tools dispatched, about to
+                # validate / apply outcome.
+                await self._set_progress(
+                    session, turn, 0.70 + 0.10 * (attempt - 1)
                 )
 
                 # Harvest the model's natural text content as the
@@ -536,6 +612,15 @@ class TurnDriver:
                     )
 
                 if validation.ok:
+                    # Issue #111: bar pulse — validation passed, about
+                    # to apply the outcome. 1.0 is the only place a
+                    # sub-step pulse hits 100%; the next state
+                    # transition resets the bar to the new state's
+                    # natural fraction (0 / N for AWAITING_PLAYERS,
+                    # 1.0 again for ENDED). The CSS ``transition: width
+                    # 300ms`` makes the brief 1.0 frame visible to the
+                    # operator before the snap (user-persona H2).
+                    await self._set_progress(session, turn, 1.0)
                     # Persist + advance state.
                     await self._apply_play_outcome(
                         session,
@@ -983,6 +1068,8 @@ class TurnDriver:
                     "state": session.state.value,
                     "active_role_ids": [],
                     "turn_index": turn.index,
+                    # Issue #111: ENDED → 1.0 (terminal state, bar fills).
+                    "progress_pct": compute_progress_pct(session),
                 },
             )
             # AI-initiated end — kick the AAR generator. Mirrors what the
@@ -1101,6 +1188,9 @@ class TurnDriver:
                     "type": "turn_changed",
                     "turn_index": new_turn.index,
                     "active_role_ids": new_turn.active_role_ids,
+                    # Issue #111: fresh AWAITING_PLAYERS turn — bar
+                    # resets to 0 / N (no submissions yet).
+                    "progress_pct": compute_progress_pct(session),
                 },
             )
             await self._manager.connections().broadcast(
@@ -1110,6 +1200,7 @@ class TurnDriver:
                     "state": session.state.value,
                     "active_role_ids": new_turn.active_role_ids,
                     "turn_index": new_turn.index,
+                    "progress_pct": compute_progress_pct(session),
                 },
             )
         else:

--- a/backend/tests/test_turn_progress.py
+++ b/backend/tests/test_turn_progress.py
@@ -1,0 +1,372 @@
+"""Per-turn progress percentage for the TURN STATE rail (issue #111).
+
+Covers the policy in ``app/sessions/progress.py`` plus the integration
+points: the snapshot serializer, the ``state_changed`` /
+``turn_changed`` WS broadcasts, and the play-turn driver's sub-step
+writes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.main import create_app
+from app.sessions.models import Session, SessionState, Turn
+from app.sessions.progress import compute_progress_pct
+from tests.mock_anthropic import MockAnthropic, setup_then_play_script
+
+# ---------------------------------------------------------------- unit tests
+
+
+def _session_at(state: SessionState, *, turn: Turn | None = None) -> Session:
+    sess = Session(scenario_prompt="ransomware via vendor portal")
+    sess.state = state
+    if turn is not None:
+        sess.turns = [turn]
+    return sess
+
+
+def test_progress_none_for_setup_states() -> None:
+    """SETUP / CREATED / READY have no natural sub-step pulse — keep
+    the indeterminate sweep so a stuck-at-zero bar doesn't read as
+    broken."""
+
+    for state in (SessionState.CREATED, SessionState.SETUP, SessionState.READY):
+        assert compute_progress_pct(_session_at(state)) is None
+
+
+def test_progress_full_for_ended() -> None:
+    assert compute_progress_pct(_session_at(SessionState.ENDED)) == 1.0
+
+
+def test_progress_awaiting_players_submitted_over_active() -> None:
+    """``AWAITING_PLAYERS`` → submitted / active. The natural ratio is
+    documented in the issue body."""
+
+    turn = Turn(
+        index=0,
+        active_role_ids=["a", "b", "c", "d"],
+        submitted_role_ids=["a", "b"],
+        ready_role_ids=["a"],
+    )
+    sess = _session_at(SessionState.AWAITING_PLAYERS, turn=turn)
+    assert compute_progress_pct(sess) == 0.5
+
+
+def test_progress_awaiting_players_zero_active_returns_none() -> None:
+    """A turn with no active roles is degenerate (the engine resets
+    the active set on yield) — surface as ``None`` rather than divide
+    by zero."""
+
+    turn = Turn(index=0, active_role_ids=[], submitted_role_ids=[])
+    sess = _session_at(SessionState.AWAITING_PLAYERS, turn=turn)
+    assert compute_progress_pct(sess) is None
+
+
+def test_progress_awaiting_players_clamped_to_one() -> None:
+    """Force-advance can produce ``submitted > active`` if the engine
+    later trimmed the active set; clamp so the bar never overflows."""
+
+    turn = Turn(
+        index=0,
+        active_role_ids=["a"],
+        submitted_role_ids=["a", "b"],
+    )
+    sess = _session_at(SessionState.AWAITING_PLAYERS, turn=turn)
+    assert compute_progress_pct(sess) == 1.0
+
+
+def test_progress_ai_processing_reads_turn_field() -> None:
+    """``AI_PROCESSING`` / ``BRIEFING`` mirror the driver-written
+    sub-step value. ``None`` early in the turn falls back to the
+    sweep."""
+
+    turn_with_progress = Turn(
+        index=0, active_role_ids=["a"], ai_progress_pct=0.66
+    )
+    sess = _session_at(SessionState.AI_PROCESSING, turn=turn_with_progress)
+    assert compute_progress_pct(sess) == 0.66
+
+    sess_briefing = _session_at(SessionState.BRIEFING, turn=turn_with_progress)
+    assert compute_progress_pct(sess_briefing) == 0.66
+
+    turn_unset = Turn(index=0, active_role_ids=["a"])
+    assert compute_progress_pct(_session_at(SessionState.AI_PROCESSING, turn=turn_unset)) is None
+
+
+# ----------------------------------------------------- integration via REST
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("ANTHROPIC_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("ANTHROPIC_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("ANTHROPIC_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    reset_settings_cache()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as c:
+        c.app.state.llm.set_transport(MockAnthropic({}).messages)
+        yield c
+
+
+def _seat_two(client: TestClient) -> dict[str, Any]:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Ransomware via vendor portal",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+        },
+    )
+    created = resp.json()
+    sid = created["session_id"]
+    creator_token = created["creator_token"]
+    creator_role_id = created["creator_role_id"]
+    r = client.post(
+        f"/api/sessions/{sid}/roles?token={creator_token}",
+        json={"label": "Player_1", "display_name": "P1"},
+    )
+    other = r.json()
+    return {
+        "sid": sid,
+        "creator_token": creator_token,
+        "creator_role_id": creator_role_id,
+        "other_token": other["token"],
+        "other_role_id": other["role_id"],
+    }
+
+
+def _drive_to_play(client: TestClient, seats: dict[str, Any]) -> None:
+    role_ids = [seats["creator_role_id"], seats["other_role_id"]]
+    scripts = setup_then_play_script(role_ids=role_ids, extension_tool="")
+    client.app.state.llm.set_transport(MockAnthropic(scripts).messages)
+    client.post(f"/api/sessions/{seats['sid']}/setup/skip?token={seats['creator_token']}")
+    client.post(f"/api/sessions/{seats['sid']}/start?token={seats['creator_token']}")
+
+
+def test_snapshot_includes_progress_pct(client: TestClient) -> None:
+    """The snapshot's ``current_turn`` block surfaces the new
+    ``progress_pct`` field after a session reaches AWAITING_PLAYERS."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    snap = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['creator_token']}"
+    ).json()
+    assert snap["state"] == "AWAITING_PLAYERS"
+    assert snap["current_turn"] is not None
+    assert "progress_pct" in snap["current_turn"]
+    # Fresh turn, no submissions yet — 0 / N.
+    active_count = len(snap["current_turn"]["active_role_ids"])
+    submitted_count = len(snap["current_turn"].get("submitted_role_ids", []))
+    expected = submitted_count / active_count if active_count else None
+    assert snap["current_turn"]["progress_pct"] == expected
+
+
+# --------------------------------------- integration via direct manager api
+
+
+class _RecordingConnections:
+    def __init__(self, real: Any) -> None:
+        self._real = real
+        self.events: list[dict[str, Any]] = []
+
+    async def broadcast(
+        self, session_id: str, event: dict[str, Any], *, record: bool = True
+    ) -> None:
+        self.events.append({**event, "_session_id": session_id, "_record": record})
+        await self._real.broadcast(session_id, event, record=record)
+
+    async def send_to_role(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.send_to_role(*args, **kwargs)
+
+    async def shutdown(self) -> Any:
+        return await self._real.shutdown()
+
+    async def connected_role_ids(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.connected_role_ids(*args, **kwargs)
+
+    async def role_has_other_connections(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.role_has_other_connections(*args, **kwargs)
+
+    async def register(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.register(*args, **kwargs)
+
+    async def unregister(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._real.unregister(*args, **kwargs)
+
+    async def stream(self, *args: Any, **kwargs: Any) -> Any:
+        return self._real.stream(*args, **kwargs)
+
+
+def _wrap_connections(client: TestClient) -> _RecordingConnections:
+    real = client.app.state.connections
+    rec = _RecordingConnections(real)
+    client.app.state.connections = rec
+    client.app.state.manager._connections = rec
+    client.app.state.llm.set_connections(rec)
+    return rec
+
+
+def test_state_changed_and_turn_changed_carry_progress_pct(
+    client: TestClient,
+) -> None:
+    """Every ``state_changed`` / ``turn_changed`` broadcast must
+    include ``progress_pct`` so a connected client can update the bar
+    without a snapshot fetch (the field rides as part of the snapshot
+    delta — issue #111 'piggy-back' contract)."""
+
+    rec = _wrap_connections(client)
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    relevant = [
+        e for e in rec.events if e.get("type") in ("state_changed", "turn_changed")
+    ]
+    # Must have observed at least one of each kind (start_session →
+    # state_changed BRIEFING; the play turn yield → turn_changed +
+    # state_changed AWAITING_PLAYERS).
+    assert any(e["type"] == "state_changed" for e in relevant), relevant
+    assert any(e["type"] == "turn_changed" for e in relevant), relevant
+    for evt in relevant:
+        assert "progress_pct" in evt, evt
+
+
+def test_play_turn_writes_ai_progress_pct_at_sub_step_boundaries(
+    client: TestClient,
+) -> None:
+    """The driver pulses the progress fraction at known sub-steps:
+    planning → tool dispatch → emit / yield. The series of
+    ``state_changed`` broadcasts during AI_PROCESSING / BRIEFING must
+    show monotonically advancing fractions for a happy-path turn,
+    capped at 1.0 only at the validation-success boundary."""
+
+    rec = _wrap_connections(client)
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    # Filter to state_changed broadcasts emitted during AI_PROCESSING
+    # / BRIEFING (the driver's pulses fire there). Use the broadcast's
+    # ``state`` field rather than session-state-at-broadcast because
+    # the recording isn't time-ordered against session mutation.
+    in_play = [
+        e
+        for e in rec.events
+        if e.get("type") == "state_changed"
+        and e.get("state") in ("AI_PROCESSING", "BRIEFING")
+    ]
+    assert in_play, "expected at least one AI_PROCESSING / BRIEFING state_changed"
+    fractions = [e.get("progress_pct") for e in in_play if e.get("progress_pct") is not None]
+    # At least one pulse must carry a non-null fraction (the driver
+    # writes 0.10 → 0.40 → 0.70 → 1.0 for a happy-path attempt).
+    assert fractions, [e.get("progress_pct") for e in in_play]
+    # Monotonic non-decreasing: the bar never goes backwards within a
+    # single turn. Recovery passes that compute lower bucket values
+    # are absorbed by the clamp inside ``_set_progress``.
+    for i in range(1, len(fractions)):
+        assert fractions[i] >= fractions[i - 1], fractions
+
+
+def test_set_progress_monotonic_clamp() -> None:
+    """``_set_progress`` enforces a monotonic-non-decreasing contract
+    and a [0, 1] clamp. Tested directly on the helper because the
+    recovery-pass code path is hard to script reliably (the validator
+    contract evolves) and the contract is critical for the user-
+    persona review's "bar must not appear to rewind" requirement."""
+
+    import asyncio
+
+    from app.sessions.turn_driver import TurnDriver
+
+    class _StubBroadcast:
+        def __init__(self) -> None:
+            self.calls: list[float | None] = []
+
+        async def broadcast(self, *args: Any, **kwargs: Any) -> None:
+            event = args[1] if len(args) > 1 else kwargs.get("event")
+            self.calls.append(event["progress_pct"] if event else None)
+
+    class _StubManager:
+        def __init__(self) -> None:
+            self._connections = _StubBroadcast()
+
+        def connections(self) -> Any:
+            return self._connections
+
+        async def _broadcast_state(
+            self, session: Session, *, record: bool = True
+        ) -> None:
+            from app.sessions.progress import compute_progress_pct
+
+            await self._connections.broadcast(
+                session.id,
+                {"type": "state_changed", "progress_pct": compute_progress_pct(session)},
+                record=record,
+            )
+
+    mgr = _StubManager()
+    driver = TurnDriver(manager=mgr)  # type: ignore[arg-type]
+    turn = Turn(index=0, active_role_ids=["a"])
+    sess = _session_at(SessionState.AI_PROCESSING, turn=turn)
+
+    async def run() -> None:
+        # Ascending: each pulse advances the bar.
+        await driver._set_progress(sess, turn, 0.10)
+        await driver._set_progress(sess, turn, 0.40)
+        await driver._set_progress(sess, turn, 0.70)
+        # Equal value (dedupe) — no new broadcast.
+        await driver._set_progress(sess, turn, 0.70)
+        # Lower value (recovery bucket regression) — monotonic clamp
+        # rejects the write so the bar doesn't visibly rewind.
+        await driver._set_progress(sess, turn, 0.30)
+        # Ascending again past the prior high-water mark.
+        await driver._set_progress(sess, turn, 0.85)
+        # Success snaps to 1.0.
+        await driver._set_progress(sess, turn, 1.0)
+        # Out-of-range values are clamped to [0, 1].
+        await driver._set_progress(sess, turn, 99.0)  # >1 → no change (already at 1.0)
+        await driver._set_progress(sess, turn, -1.0)  # <0 → no change
+
+    asyncio.run(run())
+
+    # Expected broadcast sequence: 0.10, 0.40, 0.70, 0.85, 1.0
+    assert mgr._connections.calls == [0.10, 0.40, 0.70, 0.85, 1.0]
+    # Final state on the turn: 1.0.
+    assert turn.ai_progress_pct == 1.0
+
+
+def test_non_creator_snapshot_carries_progress_pct(client: TestClient) -> None:
+    """The ``progress_pct`` field is unconditional on the snapshot —
+    a non-creator (player) role sees it too. Confirms no creator-
+    only data accidentally rides on the new field (security review
+    LOW: positive test for cross-role visibility)."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    # Player snapshot via the non-creator token.
+    snap = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['other_token']}"
+    ).json()
+    assert snap["state"] == "AWAITING_PLAYERS"
+    assert snap["current_turn"] is not None
+    assert "progress_pct" in snap["current_turn"]
+    # Non-creator must still get a valid value (or null), not a 403.
+    assert snap["current_turn"]["progress_pct"] is None or (
+        0.0 <= snap["current_turn"]["progress_pct"] <= 1.0
+    )
+
+

--- a/frontend/src/__tests__/TurnStateRail.test.tsx
+++ b/frontend/src/__tests__/TurnStateRail.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Component tests for the TURN STATE rail (issue #111).
+ *
+ * Pins the determinate-vs-sweep contract that the brand mock and the
+ * backend's ``progress_pct`` field cooperate to produce:
+ *
+ *   - Without ``progressPct`` (or ``null`` / ``undefined``): the
+ *     active row renders the indeterminate ``tt-stream`` sweep
+ *     (decorative; ``aria-hidden``).
+ *   - With a numeric ``progressPct``: the active row renders a
+ *     determinate width-driven bar with ``role="progressbar"`` +
+ *     ``aria-valuemin/max/now``.
+ *
+ * Both behaviors are acceptance criteria from the issue.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TurnStateRail } from "../components/brand/TurnStateRail";
+
+describe("TurnStateRail", () => {
+  it("renders the indeterminate sweep when progressPct is omitted", () => {
+    const { container, queryByRole } = render(
+      <TurnStateRail state="AI_PROCESSING" />,
+    );
+    // No determinate progressbar.
+    expect(queryByRole("progressbar")).toBeNull();
+    // Sweep child is present and uses the ``animate-tt-stream`` class
+    // hook so the global ``prefers-reduced-motion`` rule disables it.
+    const sweep = container.querySelector(".animate-tt-stream");
+    expect(sweep).not.toBeNull();
+  });
+
+  it("renders the indeterminate sweep when progressPct is null", () => {
+    const { queryByRole } = render(
+      <TurnStateRail state="AI_PROCESSING" progressPct={null} />,
+    );
+    expect(queryByRole("progressbar")).toBeNull();
+  });
+
+  it("renders a determinate bar with aria-valuenow when progressPct is set", () => {
+    const { getByRole } = render(
+      <TurnStateRail state="AI_PROCESSING" progressPct={0.42} />,
+    );
+    const bar = getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuemin")).toBe("0");
+    expect(bar.getAttribute("aria-valuemax")).toBe("100");
+    expect(bar.getAttribute("aria-valuenow")).toBe("42");
+  });
+
+  it("treats progressPct=0 as a real value (not nullish)", () => {
+    const { getByRole } = render(
+      <TurnStateRail state="AWAITING_PLAYERS" progressPct={0} />,
+    );
+    const bar = getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+  });
+
+  it("clamps progressPct to [0, 1]", () => {
+    const high = render(
+      <TurnStateRail state="AI_PROCESSING" progressPct={1.5} />,
+    );
+    expect(high.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
+    high.unmount();
+
+    const low = render(
+      <TurnStateRail state="AI_PROCESSING" progressPct={-0.2} />,
+    );
+    expect(low.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("0");
+  });
+
+  it("does not render a progressbar when no step is active", () => {
+    // ``state=null`` collapses to no active row → no bar of any kind.
+    const { queryByRole, container } = render(
+      <TurnStateRail state={null} progressPct={0.5} />,
+    );
+    expect(queryByRole("progressbar")).toBeNull();
+    expect(container.querySelector(".animate-tt-stream")).toBeNull();
+  });
+
+  it("only renders the bar on the active row, not on done/pending rows", () => {
+    // ``AI_PROCESSING`` is mid-flight: SETUP and BRIEFING are done,
+    // AWAITING_PLAYERS and ENDED are pending. Only AI_PROCESSING's
+    // row hosts the determinate bar.
+    const { getAllByRole } = render(
+      <TurnStateRail state="AI_PROCESSING" progressPct={0.7} />,
+    );
+    const bars = getAllByRole("progressbar");
+    expect(bars).toHaveLength(1);
+  });
+});

--- a/frontend/src/__tests__/TurnStateRail.test.tsx
+++ b/frontend/src/__tests__/TurnStateRail.test.tsx
@@ -46,6 +46,11 @@ describe("TurnStateRail", () => {
     expect(bar.getAttribute("aria-valuemin")).toBe("0");
     expect(bar.getAttribute("aria-valuemax")).toBe("100");
     expect(bar.getAttribute("aria-valuenow")).toBe("42");
+    // ARIA requires an accessible name for ``role="progressbar"``;
+    // we reference the active row's label so screen readers announce
+    // e.g. "AI PROCESSING progress, 42 percent" rather than an
+    // unnamed progressbar.
+    expect(bar.getAttribute("aria-label")).toBe("AI PROCESSING progress");
   });
 
   it("treats progressPct=0 as a real value (not nullish)", () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -93,6 +93,17 @@ export interface TurnView {
    */
   ready_role_ids?: string[];
   status: string;
+  /**
+   * Issue #111: per-turn progress fraction (0.0–1.0) for the TURN
+   * STATE rail. Backend single-source-of-truth — see
+   * ``backend/app/sessions/progress.py`` for the per-state policy:
+   * AWAITING_PLAYERS = submitted / active, AI_PROCESSING /
+   * BRIEFING = driver-written sub-step (planning → tool dispatch →
+   * emit / yield), ENDED = 1.0, others = ``null`` (sweep).
+   * ``null`` / undefined means the rail keeps the indeterminate
+   * sweep rather than rendering a determinate bar.
+   */
+  progress_pct?: number | null;
 }
 
 export interface MessageView {

--- a/frontend/src/components/brand/TurnStateRail.tsx
+++ b/frontend/src/components/brand/TurnStateRail.tsx
@@ -50,9 +50,14 @@ interface RowProps {
   step: StepId;
   done?: boolean;
   active?: boolean;
+  /** Issue #111: per-turn progress fraction in [0.0, 1.0] for the
+   *  active row's bar. ``null`` / undefined → keep the indeterminate
+   *  sweep; a number → render a determinate width-driven bar. Only
+   *  the active row consumes this; non-active rows ignore it. */
+  progressPct?: number | null;
 }
 
-function TurnStateRow({ step, done, active }: RowProps) {
+function TurnStateRow({ step, done, active, progressPct }: RowProps) {
   const labels: Record<StepId, string> = {
     setup: "SETUP",
     briefing: "BRIEFING",
@@ -66,6 +71,19 @@ function TurnStateRow({ step, done, active }: RowProps) {
       ? "var(--signal)"
       : "var(--ink-500)";
   const dot = done ? "●" : active ? "◉" : "○";
+  // Issue #111: when the backend supplied a real progress fraction,
+  // render a determinate bar (width = pct * 100%) instead of the
+  // indeterminate ``tt-stream`` sweep. ``null`` / undefined falls
+  // back to the sweep so the rail still reads as "the system is
+  // doing something" before the engine has a meaningful sub-step
+  // (e.g. very early in a play turn before the LLM call returns).
+  // The width transition is short and ease-out so a step from 0.40
+  // → 0.70 reads as a smooth fill rather than a jump.
+  const hasDeterminate =
+    typeof progressPct === "number" && Number.isFinite(progressPct);
+  const clampedPct = hasDeterminate
+    ? Math.max(0, Math.min(1, progressPct as number))
+    : 0;
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
       <span className="mono" style={{ fontSize: 12, color, width: 14 }}>
@@ -83,12 +101,6 @@ function TurnStateRow({ step, done, active }: RowProps) {
         {labels[step]}
       </span>
       {active ? (
-        // Indeterminate progress sweep — the engine doesn't yet expose
-        // a real "% of turn complete" signal (tracked in #TBD-issue),
-        // so we render a left-to-right gradient stream so the active
-        // step still reads as "the system is doing something" rather
-        // than a static stub. When the backend ships per-turn progress,
-        // swap this for a width-driven bar bound to that percentage.
         <div
           style={{
             position: "relative",
@@ -98,19 +110,48 @@ function TurnStateRow({ step, done, active }: RowProps) {
             borderRadius: 1,
             overflow: "hidden",
           }}
-          aria-hidden="true"
+          // Determinate bar advertises its value; sweep is decorative.
+          role={hasDeterminate ? "progressbar" : undefined}
+          aria-valuemin={hasDeterminate ? 0 : undefined}
+          aria-valuemax={hasDeterminate ? 100 : undefined}
+          aria-valuenow={
+            hasDeterminate ? Math.round(clampedPct * 100) : undefined
+          }
+          aria-hidden={hasDeterminate ? undefined : "true"}
         >
-          <div
-            style={{
-              position: "absolute",
-              top: 0,
-              bottom: 0,
-              width: "40%",
-              background:
-                "linear-gradient(90deg, transparent, var(--signal) 35%, var(--signal) 65%, transparent)",
-              animation: "tt-stream 1.8s ease-in-out infinite",
-            }}
-          />
+          {hasDeterminate ? (
+            <div
+              style={{
+                position: "absolute",
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: `${clampedPct * 100}%`,
+                background: "var(--signal)",
+                transition: "width 300ms ease-out",
+              }}
+            />
+          ) : (
+            // Both ``className="animate-tt-stream"`` AND inline
+            // ``animation`` are needed: the inline style fires the
+            // sweep at runtime, and the class is the hook that the
+            // ``prefers-reduced-motion`` rule in ``index.css`` uses
+            // to disable it (``animation: none !important`` beats the
+            // inline declaration). Pre-PR the inline-only sweep
+            // slipped past the reduced-motion override.
+            <div
+              className="animate-tt-stream"
+              style={{
+                position: "absolute",
+                top: 0,
+                bottom: 0,
+                width: "40%",
+                background:
+                  "linear-gradient(90deg, transparent, var(--signal) 35%, var(--signal) 65%, transparent)",
+                animation: "tt-stream 1.8s ease-in-out infinite",
+              }}
+            />
+          )}
         </div>
       ) : null}
     </div>
@@ -121,9 +162,13 @@ interface Props {
   state: string | null | undefined;
   /** Optional subtitle for the section header (e.g. "awaiting 1 of 3"). */
   subtitle?: string;
+  /** Issue #111: backend-supplied per-turn progress fraction. See
+   *  ``backend/app/sessions/progress.py`` for the per-state policy.
+   *  ``null`` / undefined → indeterminate sweep. */
+  progressPct?: number | null;
 }
 
-export function TurnStateRail({ state, subtitle }: Props) {
+export function TurnStateRail({ state, subtitle, progressPct }: Props) {
   const active = activeStep(state);
   const activeIdx = STEPS.findIndex((s) => s.id === active);
   return (
@@ -147,6 +192,7 @@ export function TurnStateRail({ state, subtitle }: Props) {
             step={s.id}
             done={activeIdx >= 0 ? i < activeIdx : false}
             active={s.id === active}
+            progressPct={s.id === active ? progressPct : null}
           />
         ))}
       </div>

--- a/frontend/src/components/brand/TurnStateRail.tsx
+++ b/frontend/src/components/brand/TurnStateRail.tsx
@@ -111,7 +111,13 @@ function TurnStateRow({ step, done, active, progressPct }: RowProps) {
             overflow: "hidden",
           }}
           // Determinate bar advertises its value; sweep is decorative.
+          // ``aria-label`` is required when ``role="progressbar"`` is
+          // set — without it screen readers announce an unnamed
+          // progressbar. Referencing the active row's label
+          // (e.g. "AI PROCESSING progress") gives blind operators
+          // the same context sighted users get from the adjacent text.
           role={hasDeterminate ? "progressbar" : undefined}
+          aria-label={hasDeterminate ? `${labels[step]} progress` : undefined}
           aria-valuemin={hasDeterminate ? 0 : undefined}
           aria-valuemax={hasDeterminate ? 100 : undefined}
           aria-valuenow={

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -3,7 +3,21 @@
  */
 
 export type ServerEvent =
-  | { type: "state_changed"; state: string; active_role_ids: string[]; turn_index: number | null }
+  | {
+      type: "state_changed";
+      state: string;
+      active_role_ids: string[];
+      turn_index: number | null;
+      /**
+       * Issue #111: per-turn progress fraction (0.0–1.0) for the
+       * TURN STATE rail's determinate bar. ``null`` keeps the
+       * indeterminate sweep. Re-broadcast at AI sub-step boundaries
+       * (planning → tool dispatch → emit / yield) with the same
+       * ``state`` value but a fresh fraction; the page handler
+       * picks the new value up via ``refreshSnapshot``.
+       */
+      progress_pct?: number | null;
+    }
   | { type: "message_chunk"; turn_id: string; text: string }
   | {
       type: "message_complete";
@@ -32,7 +46,17 @@ export type ServerEvent =
        *  reply" indicator without the client having to track timing. */
       ai_paused_at_submit?: boolean;
     }
-  | { type: "turn_changed"; turn_index: number; active_role_ids: string[] }
+  | {
+      type: "turn_changed";
+      turn_index: number;
+      active_role_ids: string[];
+      /**
+       * Issue #111: per-turn progress fraction (0.0–1.0) — see the
+       * ``state_changed`` doc above. Fresh turn → fraction resets
+       * (e.g. 0 / N for AWAITING_PLAYERS).
+       */
+      progress_pct?: number | null;
+    }
   | { type: "tool_invocation"; tool: string; args: Record<string, unknown> }
   | { type: "participant_joined"; role_id: string; label: string; display_name: string | null; kind: string }
   | { type: "participant_left"; role_id: string }
@@ -355,10 +379,12 @@ export class WsClient {
             safe.state = parsed.state;
             safe.turn_index = parsed.turn_index;
             safe.active_role_count = parsed.active_role_ids?.length ?? 0;
+            safe.progress_pct = parsed.progress_pct ?? null;
             break;
           case "turn_changed":
             safe.turn_index = parsed.turn_index;
             safe.active_role_count = parsed.active_role_ids?.length ?? 0;
+            safe.progress_pct = parsed.progress_pct ?? null;
             break;
           case "message_chunk":
             safe.turn_id = parsed.turn_id;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1308,7 +1308,10 @@ export function Facilitator() {
             />
           ) : null}
           <div className="rounded-r-3 border border-ink-600 bg-ink-850">
-            <TurnStateRail state={snapshot.state} />
+            <TurnStateRail
+              state={snapshot.state}
+              progressPct={snapshot.current_turn?.progress_pct ?? null}
+            />
           </div>
           <SessionActivityPanel
             sessionId={state.sessionId}


### PR DESCRIPTION
## Summary

Closes #111.

Adds `current_turn.progress_pct` (0.0–1.0) on the snapshot and on the `state_changed` / `turn_changed` WS broadcasts so the frontend's TURN STATE rail can render a determinate width-driven bar instead of the indeterminate `tt-stream` sweep.

### Per-state policy (`backend/app/sessions/progress.py`)

| State | Value |
|---|---|
| `ENDED` | `1.0` (terminal, bar fills) |
| `AWAITING_PLAYERS` | `submitted / active`, clamped to `[0,1]`; `None` if no active set |
| `AI_PROCESSING` / `BRIEFING` | driver-written `Turn.ai_progress_pct` |
| `CREATED` / `SETUP` / `READY` | `None` (sweep) |

### Driver pulses (`turn_driver.py`)

`run_play_turn` calls `_set_progress` at four sub-step boundaries per attempt:

- attempt-start → `0.10 + 0.20·(N-1)`
- after-LLM → `0.40 + 0.20·(N-1)`
- after-dispatch → `0.70 + 0.10·(N-1)`
- success → `1.0`

`_set_progress` is **monotonic non-decreasing** within a turn — recovery passes whose bucket value falls below the prior attempt's high-water mark are absorbed by the clamp. This addresses user-persona HIGH H1: a visibly *backward*-moving bar reads as "the system rewound" or "crashed", much worse signal than the original sweep. The `ai_status` event still broadcasts the recovery directive for the explicit "what's happening" signal.

Pulses use `record=False` on the underlying broadcast so they don't consume slots in the bounded 256-event replay buffer (security MEDIUM).

### Frontend (`<TurnStateRail>`)

- Accepts `progressPct?: number | null`.
- Determinate path: `role="progressbar"` + `aria-valuenow`, `transition: width 300ms ease-out`.
- Indeterminate fallback: existing sweep, now with `className="animate-tt-stream"` so the global `prefers-reduced-motion` rule disables it (UI/UX MEDIUM — inline-only sweep slipped past pre-PR).
- `Facilitator.tsx` passes `snapshot.current_turn?.progress_pct ?? null`.

### Logging (CLAUDE.md must-fix)

Every `None` return from `compute_progress_pct` logs `progress_pct_indeterminate` at debug level with `reason` + `state` so an operator debugging "why is the bar stuck in sweep" has signal in the audit log.

### Sub-agent reviews

All six ran: QA, Security, UI/UX, Product, User-persona, Prompt-Expert. All BLOCK / HIGH findings addressed in this commit. Deferred (tracked in commit body):

- Sweep→determinate **initial mount** has no fade-in (UI/UX MEDIUM): acceptable for a 2 px ambient indicator; subsequent updates smooth.
- `submitted_role_ids` vs `ready_role_ids` for AWAITING_PLAYERS (User-persona M1): on-spec per the issue body; switch to "ready" semantics is a follow-up.
- `Play.tsx` (player view) doesn't render the rail at all (Product MEDIUM): pre-existing, not a regression.

### LLM-blind carve-out

No edits to `app/llm/`, prompts, tool descriptions, or recovery-directive copy. `_set_progress` sits between LLM/dispatch boundaries; never alters messages / system_blocks / tools / tool_choice. Confirmed by the prompt-expert sub-agent. Skipping `run-live-tests.sh`.

### Scenario carve-out

`Turn.ai_progress_pct` is a new field but it's purely cosmetic UI state with no engine-behavior implication. Recorder/runner don't need to capture/replay it; replays remain deterministic.

## Test plan

- [x] `pytest backend/tests/test_turn_progress.py` — 11 new (per-state policy, edge cases, monotonic-clamp helper contract, snapshot integration, WS broadcast contract, non-creator visibility)
- [x] `pytest backend/tests/` full suite — 691 pass / 49 skip
- [x] `ruff check` + `mypy` — clean
- [x] `vitest run frontend/src/__tests__/TurnStateRail.test.tsx` — 7 new (sweep vs determinate, ARIA wiring, [0,1] clamp, active-row-only, `progressPct=0` is not nullish)
- [x] `npm test` full suite — 368 pass
- [x] `npm run lint` + `npm run typecheck` — clean
- [ ] Manual smoke: open the creator UI, drive a session through SETUP → BRIEFING → AI_PROCESSING → AWAITING_PLAYERS → ENDED; verify the bar advances during AI_PROCESSING, fills as players submit during AWAITING_PLAYERS, and reaches 100% at ENDED. (Cannot run in this sandbox; flagged for human verification.)


---
_Generated by [Claude Code](https://claude.ai/code/session_013E3fVU4kM2eLHcw32pK3SK)_