### PR TITLE
sessions: surface validator state to creator UI (closes #70)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -164,6 +164,111 @@ class WorkstreamOverrideBody(BaseModel):
         return v
 
 
+def _compute_turn_diagnostics(
+    audit_events: list[Any],
+    turn_id_to_index: dict[str, int],
+    *,
+    max_turns: int | None = None,
+) -> list[dict[str, Any]]:
+    """Roll ``turn_validation`` + ``turn_recovery_directive`` audit
+    rows into a per-turn summary structure for the creator UI.
+
+    Issue #70: pre-fix, validator state lived in stdout-only structlog
+    events that the ``/debug`` and ``/activity`` endpoints couldn't
+    see. Now both audit-row kinds are emitted alongside the structlog
+    line; this helper aggregates them by ``turn_id`` so the panel can
+    render `Turn 6: drive ✗ → recovered via broadcast (attempt 2),
+    yield ✓ (attempt 3)` without log access.
+
+    Parameters
+    ----------
+    audit_events:
+        Ordered list of :class:`AuditEvent` (oldest first).
+    turn_id_to_index:
+        Map of ``turn.id`` -> ``turn.index`` so we can render in
+        index order even though the audit log keys by id.
+    max_turns:
+        Optional cap on the number of *most recent* turns returned
+        (newest-first selection, then re-sorted ascending). The
+        ``/activity`` endpoint passes a small cap (3) to keep its
+        response cheap; ``/debug`` passes ``None`` for the full set.
+
+    Returns a list of dicts shaped:
+
+    .. code-block:: python
+
+        {
+          "turn_index": 5,                     # 0-based; UI adds +1
+          "validations": [
+            {"attempt": 1, "slots": ["yield"], "violations": ["missing_drive"],
+             "warnings": [], "ok": False},
+            {"attempt": 2, "slots": ["drive", "yield"], "violations": [],
+             "warnings": [], "ok": True},
+          ],
+          "recoveries": [
+            {"attempt": 1, "kind": "missing_drive", "tools": ["broadcast"]},
+          ],
+        }
+    """
+
+    by_turn: dict[str, dict[str, Any]] = {}
+    for evt in audit_events:
+        if evt.kind not in {"turn_validation", "turn_recovery_directive"}:
+            continue
+        if not evt.turn_id:
+            continue
+        bucket = by_turn.setdefault(
+            evt.turn_id,
+            {"validations": [], "recoveries": []},
+        )
+        if evt.kind == "turn_validation":
+            bucket["validations"].append(
+                {
+                    "attempt": evt.payload.get("attempt"),
+                    "slots": evt.payload.get("slots", []),
+                    "violations": evt.payload.get("violations", []),
+                    "warnings": evt.payload.get("warnings", []),
+                    "ok": evt.payload.get("ok", False),
+                    "ts": evt.ts.isoformat(),
+                }
+            )
+        else:
+            # ``directive_kind`` is the field name in the audit payload
+            # (the on-the-wire ``kind`` would collide with
+            # ``SessionManager._emit``'s positional ``kind`` param).
+            # The rollup re-publishes it as ``kind`` for the frontend
+            # so the panel doesn't need to know about the workaround.
+            bucket["recoveries"].append(
+                {
+                    "attempt": evt.payload.get("attempt"),
+                    "kind": evt.payload.get("directive_kind"),
+                    "tools": evt.payload.get("tools", []),
+                    "ts": evt.ts.isoformat(),
+                }
+            )
+
+    out: list[dict[str, Any]] = []
+    for turn_id, bucket in by_turn.items():
+        idx = turn_id_to_index.get(turn_id)
+        if idx is None:
+            continue
+        # Sort the per-turn lists by attempt so the UI can render in
+        # natural order regardless of audit-buffer ordering.
+        bucket["validations"].sort(key=lambda v: v.get("attempt") or 0)
+        bucket["recoveries"].sort(key=lambda r: r.get("attempt") or 0)
+        out.append(
+            {
+                "turn_index": idx,
+                "validations": bucket["validations"],
+                "recoveries": bucket["recoveries"],
+            }
+        )
+    out.sort(key=lambda d: d["turn_index"])
+    if max_turns is not None and len(out) > max_turns:
+        out = out[-max_turns:]
+    return out
+
+
 def register_api_routes(app: FastAPI) -> None:
     router = APIRouter(prefix="/api")
 
@@ -1757,8 +1862,31 @@ def register_api_routes(app: FastAPI) -> None:
         import time as _t
 
         now = _t.monotonic()
+        # Issue #70: roll up validator + recovery audit rows so the
+        # activity panel can render per-turn slot/recovery breadcrumbs
+        # without needing the heavier ``/debug`` payload. Cap to the 3
+        # most-recent turns so the polled response stays small even on
+        # 50-turn sessions. Uses the filtered ``for_kinds`` accessor
+        # (security review LOW) — the polled endpoint only cares
+        # about two of ~20 audit-row kinds; calling ``dump`` and
+        # filtering would copy the full O(N=AUDIT_RING_SIZE) ring on
+        # every poll.
+        audit_events = manager.audit().for_kinds(
+            session_id,
+            kinds=("turn_validation", "turn_recovery_directive"),
+        )
+        turn_id_to_index = {t.id: t.index for t in session.turns}
+        recent_turn_diagnostics = _compute_turn_diagnostics(
+            audit_events, turn_id_to_index, max_turns=3
+        )
+        settings = manager.settings()
         return {
             "state": session.state.value,
+            # Issue #70: ``ai_paused`` was previously only on
+            # ``/snapshot``; surfacing here lets the creator activity
+            # panel + LLM chip distinguish "idle (paused)" from "idle
+            # (waiting for players)" without a separate fetch.
+            "ai_paused": session.ai_paused,
             "turn": (
                 {
                     "index": session.current_turn.index,
@@ -1807,6 +1935,20 @@ def register_api_routes(app: FastAPI) -> None:
                 }
                 for evt in manager.audit().recent_diagnostics(session_id)
             ],
+            # Issue #70: per-turn validator + recovery rollup so the
+            # activity panel can render `Turn 6: drive ✗ → recovered
+            # via broadcast (attempt 2), yield ✓ (attempt 3)` for the
+            # most-recent few turns.
+            "recent_turn_diagnostics": recent_turn_diagnostics,
+            # Issue #70: surface the legacy soft-drive carve-out flag
+            # so a misconfigured deployment is visible in the creator
+            # UI rather than only in the boot log. The flag is the
+            # known way to silence the validator's most important
+            # check; if it's enabled in production the operator MUST
+            # see it.
+            "legacy_carve_out_enabled": (
+                settings.llm_recovery_drive_soft_on_open_question
+            ),
         }
 
     @router.get("/sessions/{session_id}/debug")
@@ -1832,9 +1974,14 @@ def register_api_routes(app: FastAPI) -> None:
         registry = _registry(request)
         audit = manager.audit().dump(session_id)
         in_flight = manager.llm().in_flight_for(session_id)
+        settings = manager.settings()
         import time as _t
 
         now = _t.monotonic()
+        # Issue #70: full per-turn rollup for the God Mode / debug
+        # surface — no cap, includes every turn in the buffer.
+        turn_id_to_index = {t.id: t.index for t in session.turns}
+        turn_diagnostics = _compute_turn_diagnostics(audit, turn_id_to_index)
         return {
             "session": {
                 "id": session.id,
@@ -1845,6 +1992,11 @@ def register_api_routes(app: FastAPI) -> None:
                 "cost": session.cost.model_dump(),
                 "aar_status": session.aar_status,
                 "aar_error": session.aar_error,
+                # Issue #70: ``ai_paused`` is part of the operator-
+                # facing view of "what is the engine doing?"; include
+                # it here so debug consumers don't have to fetch the
+                # snapshot endpoint separately.
+                "ai_paused": session.ai_paused,
                 "created_at": session.created_at.isoformat(),
                 "ended_at": session.ended_at.isoformat() if session.ended_at else None,
             },
@@ -1909,6 +2061,18 @@ def register_api_routes(app: FastAPI) -> None:
                     {"name": p.name, "description": p.description, "scope": p.scope}
                     for p in registry.prompts.values()
                 ],
+            },
+            # Issue #70: full per-turn validator + recovery rollup.
+            "turn_diagnostics": turn_diagnostics,
+            # Issue #70: surface engine kill-switches the operator may
+            # have flipped on for emergency rollback. Each one widens
+            # the silent-yield surface; God Mode operators MUST be
+            # able to see them at a glance.
+            "engine_flags": {
+                "legacy_carve_out_enabled": (
+                    settings.llm_recovery_drive_soft_on_open_question
+                ),
+                "drive_required": settings.llm_recovery_drive_required,
             },
         }
 

--- a/backend/app/auth/audit.py
+++ b/backend/app/auth/audit.py
@@ -123,7 +123,12 @@ class AuditLog:
         buf = self._buffers.get(session_id)
         if not buf:
             return []
-        return [evt for evt in buf if evt.kind in kinds]
+        # Promote ``kinds`` to a frozenset for O(1) membership lookup
+        # — the polled-endpoint path runs this filter on every 3 s
+        # tick per active session, and ``in tuple`` is O(k) linear
+        # (Copilot review #173).
+        kinds_set = frozenset(kinds)
+        return [evt for evt in buf if evt.kind in kinds_set]
 
     def drop(self, session_id: str) -> None:
         """Forget a session's audit trail (used after export retention)."""

--- a/backend/app/auth/audit.py
+++ b/backend/app/auth/audit.py
@@ -98,6 +98,33 @@ class AuditLog:
                     break
         return out
 
+    def for_kinds(
+        self,
+        session_id: str,
+        *,
+        kinds: tuple[str, ...],
+    ) -> list[AuditEvent]:
+        """Filtered, oldest-first view of the per-session ring buffer.
+
+        Issue #70 (security review LOW): ``/activity`` polls every 3 s
+        and only needs ``turn_validation`` + ``turn_recovery_directive``
+        rows. Calling :meth:`dump` (a full O(N=AUDIT_RING_SIZE) copy)
+        and then filtering wastes work on long sessions. ``for_kinds``
+        skips uninteresting events at iteration time — same iteration
+        cost as ``recent_diagnostics`` but in chronological order so
+        callers that *aggregate* (rather than show "latest N") avoid
+        a re-sort.
+
+        Distinct from :meth:`recent_diagnostics` because this returns
+        ALL matching events (not a head-N cap) and in oldest-first
+        order (matching :meth:`dump`).
+        """
+
+        buf = self._buffers.get(session_id)
+        if not buf:
+            return []
+        return [evt for evt in buf if evt.kind in kinds]
+
     def drop(self, session_id: str) -> None:
         """Forget a session's audit trail (used after export retention)."""
 

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -590,6 +590,25 @@ class TurnDriver:
                     warnings=validation.warnings,
                     ok=validation.ok,
                 )
+                # Issue #70: also persist as an AuditEvent so the
+                # creator's /activity + /debug endpoints can surface
+                # validator state without log access. Mirrors the
+                # ``phase_policy_dropped_tools`` pattern — emit the
+                # structlog line for stdout scrapers AND the audit row
+                # for the creator UI rollup. The two MUST stay in sync;
+                # if a future change drops the structlog line, drop the
+                # audit emission too (and vice versa) so the contract
+                # stays "one validation pass = one audit row".
+                self._manager._emit(
+                    "turn_validation",
+                    session,
+                    turn_index=turn.index,
+                    attempt=attempt,
+                    slots=sorted(s.value for s in cumulative.slots),
+                    violations=[d.kind for d in validation.violations],
+                    warnings=list(validation.warnings),
+                    ok=validation.ok,
+                )
 
                 # Issue #151 fix B observability — surface inject-grounded
                 # recovery firings so operators can grep for them and
@@ -647,6 +666,27 @@ class TurnDriver:
                     turn_index=turn.index,
                     attempt=attempt,
                     kind=active_directive.kind,
+                    tools=sorted(active_directive.tools_allowlist),
+                )
+                # Issue #70: same audit-row pairing as
+                # ``turn_validation`` above. The creator UI uses these
+                # rows to render ``Turn 6: drive ✗ → recovered via
+                # broadcast (attempt 2)`` without log access. The
+                # ``attempt`` here is the *failing* attempt — the
+                # next-attempt directive gets queued for attempt+1.
+                # Note the keyword is ``directive_kind``: ``_emit``'s
+                # first positional parameter is named ``kind`` so a
+                # ``kind=`` kwarg here would collide with it (the
+                # original review-pass bug). The frontend reads
+                # ``payload.kind`` via the ``_compute_turn_diagnostics``
+                # rollup, which translates ``directive_kind`` →
+                # ``kind`` so the wire shape is unchanged.
+                self._manager._emit(
+                    "turn_recovery_directive",
+                    session,
+                    turn_index=turn.index,
+                    attempt=attempt,
+                    directive_kind=active_directive.kind,
                     tools=sorted(active_directive.tools_allowlist),
                 )
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -84,3 +84,31 @@ def test_audit_isolation_per_session() -> None:
     assert len(log.dump("s1")) == 1
     assert log.dump("s1")[0].kind == "a"
     assert log.dump("nope") == []
+
+
+def test_audit_for_kinds_filters_to_requested_kinds() -> None:
+    """Issue #70 (security review LOW): the polled ``/activity``
+    rollup uses ``for_kinds`` to skip uninteresting events at
+    iteration time instead of materializing the whole ring buffer.
+    """
+
+    log = AuditLog(ring_size=20)
+    log.emit(AuditEvent(kind="tool_use", session_id="s", payload={"i": 1}))
+    log.emit(AuditEvent(kind="turn_validation", session_id="s", payload={"i": 2}))
+    log.emit(AuditEvent(kind="session_event", session_id="s", payload={"i": 3}))
+    log.emit(
+        AuditEvent(kind="turn_recovery_directive", session_id="s", payload={"i": 4})
+    )
+    out = log.for_kinds(
+        "s", kinds=("turn_validation", "turn_recovery_directive")
+    )
+    assert [e.kind for e in out] == [
+        "turn_validation",
+        "turn_recovery_directive",
+    ]
+    # Oldest-first preserves chronological order — same as ``dump``.
+    assert [e.payload["i"] for e in out] == [2, 4]
+    # Empty session returns empty list (no error).
+    assert log.for_kinds("nope", kinds=("turn_validation",)) == []
+    # No matches in the buffer returns empty list.
+    assert log.for_kinds("s", kinds=("nope",)) == []

--- a/backend/tests/test_turn_diagnostics.py
+++ b/backend/tests/test_turn_diagnostics.py
@@ -1,0 +1,293 @@
+"""Tests for the per-turn validator/recovery rollup surfaced to the
+creator UI (issue #70).
+
+The rollup turns ``turn_validation`` and ``turn_recovery_directive``
+audit rows into a per-turn summary structure rendered by
+``SessionActivityPanel`` + the ``/debug`` God Mode panel. Pre-fix
+these events were stdout-only structlog lines and a 5-hour log dive
+was required to diagnose the 2026-04-30 silent-yield regression.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.api.routes import _compute_turn_diagnostics
+from app.auth.audit import AuditEvent
+
+
+def _evt(
+    kind: str,
+    *,
+    turn_id: str,
+    payload: dict,
+    offset_s: int = 0,
+) -> AuditEvent:
+    """Build an ``AuditEvent`` with a deterministic timestamp."""
+
+    ts = datetime(2026, 5, 5, tzinfo=UTC) + timedelta(seconds=offset_s)
+    return AuditEvent(
+        ts=ts,
+        kind=kind,
+        session_id="sess-1",
+        turn_id=turn_id,
+        payload=payload,
+    )
+
+
+def test_compute_turn_diagnostics_groups_by_turn() -> None:
+    events = [
+        _evt(
+            "turn_validation",
+            turn_id="t-aaa",
+            payload={
+                "attempt": 1,
+                "slots": ["yield"],
+                "violations": ["missing_drive"],
+                "warnings": [],
+                "ok": False,
+            },
+        ),
+        _evt(
+            "turn_recovery_directive",
+            turn_id="t-aaa",
+            payload={
+                "attempt": 1,
+                # Stored as ``directive_kind`` to avoid colliding with
+                # ``SessionManager._emit``'s positional ``kind`` param;
+                # the rollup re-publishes it as ``kind`` for the UI.
+                "directive_kind": "missing_drive",
+                "tools": ["broadcast"],
+            },
+            offset_s=1,
+        ),
+        _evt(
+            "turn_validation",
+            turn_id="t-aaa",
+            payload={
+                "attempt": 2,
+                "slots": ["drive", "yield"],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+            offset_s=2,
+        ),
+        _evt(
+            "turn_validation",
+            turn_id="t-bbb",
+            payload={
+                "attempt": 1,
+                "slots": ["drive", "yield"],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+            offset_s=10,
+        ),
+    ]
+    diag = _compute_turn_diagnostics(
+        events,
+        {"t-aaa": 0, "t-bbb": 1},
+    )
+    # Two turns, sorted by turn_index ascending.
+    assert [t["turn_index"] for t in diag] == [0, 1]
+
+    # Turn 0 had two validation passes and one recovery between.
+    t0 = diag[0]
+    assert len(t0["validations"]) == 2
+    assert len(t0["recoveries"]) == 1
+    assert t0["validations"][0]["attempt"] == 1
+    assert t0["validations"][0]["ok"] is False
+    assert t0["validations"][1]["attempt"] == 2
+    assert t0["validations"][1]["ok"] is True
+    assert t0["recoveries"][0]["kind"] == "missing_drive"
+    assert t0["recoveries"][0]["tools"] == ["broadcast"]
+
+    # Turn 1 had a single clean pass.
+    t1 = diag[1]
+    assert len(t1["validations"]) == 1
+    assert t1["recoveries"] == []
+    assert t1["validations"][0]["ok"] is True
+
+
+def test_compute_turn_diagnostics_drops_unknown_turn_id() -> None:
+    events = [
+        _evt(
+            "turn_validation",
+            turn_id="t-orphan",
+            payload={
+                "attempt": 1,
+                "slots": [],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+        ),
+    ]
+    # Turn id is not in the index map (e.g. ring buffer rotated).
+    diag = _compute_turn_diagnostics(events, {})
+    assert diag == []
+
+
+def test_compute_turn_diagnostics_ignores_unrelated_events() -> None:
+    events = [
+        _evt(
+            "session_created",
+            turn_id="t-x",
+            payload={"scenario_prompt": "x"},
+        ),
+        _evt(
+            "tool_use",
+            turn_id="t-x",
+            payload={"name": "broadcast"},
+        ),
+        _evt(
+            "turn_validation",
+            turn_id="t-x",
+            payload={
+                "attempt": 1,
+                "slots": ["drive", "yield"],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+        ),
+    ]
+    diag = _compute_turn_diagnostics(events, {"t-x": 0})
+    assert len(diag) == 1
+    # Only the validator pass survived — session_created / tool_use are
+    # not part of the validator rollup.
+    assert len(diag[0]["validations"]) == 1
+    assert diag[0]["recoveries"] == []
+
+
+def test_compute_turn_diagnostics_caps_to_max_turns() -> None:
+    events = []
+    turn_index = {}
+    for i in range(5):
+        tid = f"t-{i}"
+        turn_index[tid] = i
+        events.append(
+            _evt(
+                "turn_validation",
+                turn_id=tid,
+                payload={
+                    "attempt": 1,
+                    "slots": ["drive", "yield"],
+                    "violations": [],
+                    "warnings": [],
+                    "ok": True,
+                },
+                offset_s=i * 10,
+            ),
+        )
+    diag = _compute_turn_diagnostics(events, turn_index, max_turns=3)
+    # Newest 3 by turn_index, ascending.
+    assert [t["turn_index"] for t in diag] == [2, 3, 4]
+
+
+def test_compute_turn_diagnostics_carries_warnings() -> None:
+    events = [
+        _evt(
+            "turn_validation",
+            turn_id="t-w",
+            payload={
+                "attempt": 1,
+                "slots": ["yield"],
+                "violations": [],
+                "warnings": [
+                    "drive missing but downgraded — legacy carve-out fired"
+                ],
+                "ok": True,
+            },
+        ),
+    ]
+    diag = _compute_turn_diagnostics(events, {"t-w": 0})
+    [warning] = diag[0]["validations"][0]["warnings"]
+    assert "legacy carve-out" in warning
+
+
+def test_compute_turn_diagnostics_sorts_attempts_within_turn() -> None:
+    """Attempts arrive in chronological order, but the helper must be
+    robust against an out-of-order audit buffer (e.g. a future
+    persistent backend that re-fetches by turn_id)."""
+
+    events = [
+        _evt(
+            "turn_validation",
+            turn_id="t-x",
+            payload={
+                "attempt": 3,
+                "slots": ["drive", "yield"],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+            offset_s=10,
+        ),
+        _evt(
+            "turn_validation",
+            turn_id="t-x",
+            payload={
+                "attempt": 1,
+                "slots": [],
+                "violations": ["missing_drive", "missing_yield"],
+                "warnings": [],
+                "ok": False,
+            },
+            offset_s=0,
+        ),
+        _evt(
+            "turn_validation",
+            turn_id="t-x",
+            payload={
+                "attempt": 2,
+                "slots": ["drive"],
+                "violations": ["missing_yield"],
+                "warnings": [],
+                "ok": False,
+            },
+            offset_s=5,
+        ),
+    ]
+    diag = _compute_turn_diagnostics(events, {"t-x": 0})
+    attempts = [v["attempt"] for v in diag[0]["validations"]]
+    assert attempts == [1, 2, 3]
+
+
+def test_compute_turn_diagnostics_survives_missing_attempt_field() -> None:
+    """QA review LOW: a corrupt audit row missing the ``attempt`` key
+    must not crash the rollup. The sort key falls back to ``0`` so
+    the entry lands first in the list rather than raising
+    ``TypeError`` on ``None`` ordering."""
+
+    events = [
+        _evt(
+            "turn_validation",
+            turn_id="t-x",
+            payload={
+                # No ``attempt`` field at all.
+                "slots": ["drive", "yield"],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+        ),
+        _evt(
+            "turn_validation",
+            turn_id="t-x",
+            payload={
+                "attempt": 2,
+                "slots": ["drive", "yield"],
+                "violations": [],
+                "warnings": [],
+                "ok": True,
+            },
+            offset_s=5,
+        ),
+    ]
+    # Must not raise; missing-attempt entry sorts first (None → 0).
+    diag = _compute_turn_diagnostics(events, {"t-x": 0})
+    attempts = [v["attempt"] for v in diag[0]["validations"]]
+    assert attempts == [None, 2]

--- a/backend/tests/test_turn_driver.py
+++ b/backend/tests/test_turn_driver.py
@@ -189,3 +189,86 @@ def test_ai_status_events_are_not_recorded_in_replay_buffer(client: TestClient) 
     thinkings = [e for e in rec.events if e.get("type") == "ai_thinking"]
     for evt in thinkings:
         assert evt["_record"] is False, evt
+
+
+def test_run_play_turn_emits_turn_validation_audit_event(
+    client: TestClient,
+) -> None:
+    """Issue #70: every validator pass MUST land in the audit ring
+    buffer (not just stdout) so the creator's ``/debug`` and
+    ``/activity`` endpoints can render a per-turn slot/recovery
+    summary without log access. A clean play turn produces at least
+    one ``turn_validation`` row with ``ok=True``.
+    """
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    audit_events = client.app.state.manager.audit().dump(seats["sid"])
+    validations = [evt for evt in audit_events if evt.kind == "turn_validation"]
+    assert validations, (
+        "expected at least one turn_validation audit row during play turn"
+    )
+    # Each row carries enough info to drive the panel: attempt, slots,
+    # violations, warnings, ok. The first attempt of a clean turn is ok.
+    first = validations[0]
+    assert first.turn_id is not None
+    payload = first.payload
+    assert "attempt" in payload
+    assert "slots" in payload
+    assert "violations" in payload
+    assert "warnings" in payload
+    assert "ok" in payload
+
+
+def test_debug_endpoint_includes_turn_diagnostics(client: TestClient) -> None:
+    """Issue #70: the rolled-up per-turn diagnostics MUST be on the
+    ``/debug`` payload. Without this the creator panel has no way to
+    render `Turn 6: drive ✓ yield ✓` without scraping audit events
+    client-side. Also verifies ``ai_paused`` and ``engine_flags``
+    surface so a misconfigured deploy is visible at a glance.
+    """
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    sid = seats["sid"]
+    cr = seats["creator_token"]
+    body = client.get(f"/api/sessions/{sid}/debug?token={cr}").json()
+
+    assert "turn_diagnostics" in body
+    assert isinstance(body["turn_diagnostics"], list)
+    # ai_paused on the session block lets a debug consumer see the
+    # pause state without a separate snapshot fetch.
+    assert "ai_paused" in body["session"]
+    # engine_flags expose the kill-switches an operator may have
+    # flipped on for emergency rollback. Both keys must be present
+    # so a missing key isn't silently treated as "off" by the UI.
+    flags = body["engine_flags"]
+    assert "legacy_carve_out_enabled" in flags
+    assert "drive_required" in flags
+
+
+def test_activity_endpoint_includes_recent_turn_diagnostics(
+    client: TestClient,
+) -> None:
+    """Issue #70: ``/activity`` is the polled (3 s) creator panel so
+    its rollup is bounded — at most the most-recent 3 turns —
+    keeping the response cheap on long sessions. ``ai_paused`` and
+    ``legacy_carve_out_enabled`` must also surface here so the
+    BottomActionBar's LLM chip + the panel's red banner have the
+    data they need without a second fetch.
+    """
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+
+    sid = seats["sid"]
+    cr = seats["creator_token"]
+    body = client.get(f"/api/sessions/{sid}/activity?token={cr}").json()
+
+    assert "recent_turn_diagnostics" in body
+    assert isinstance(body["recent_turn_diagnostics"], list)
+    assert len(body["recent_turn_diagnostics"]) <= 3
+    assert "ai_paused" in body
+    assert "legacy_carve_out_enabled" in body

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -156,6 +156,10 @@ const baseProps = {
   cost: null,
   messageCount: 0,
   activeTiers: [] as string[],
+  // Issue #70: multi-state LLM chip needs ai_paused + recoveryStatus + turnErrored.
+  aiPaused: false,
+  recoveryStatus: null as { kind: string; attempt?: number; budget?: number } | null,
+  turnErrored: false,
   buildSha: "abcdef0",
   buildTs: "2026-05-01T00:00:00Z",
 };
@@ -341,6 +345,141 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
       />,
     );
     expect(screen.getByText("LLM: guardrail+play")).toBeInTheDocument();
+  });
+
+  // Issue #70: multi-state LLM chip — distinguish recovering / paused
+  // / waiting-for-players / recovery-failed from the legacy binary
+  // "thinking-or-idle" chip. Each branch is the cure for an
+  // operationally-distinct state that used to read as "LLM: idle"
+  // and was the diagnostic gap behind the silent-yield 5-hour log
+  // dive.
+  it("renders 'LLM: idle (paused)' when the AI is paused with no calls in flight", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        aiPaused={true}
+      />,
+    );
+    expect(screen.getByText("LLM: idle (paused)")).toBeInTheDocument();
+  });
+
+  it("renders 'LLM: waiting for players' on AWAITING_PLAYERS with no calls in flight", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        backendState="AWAITING_PLAYERS"
+      />,
+    );
+    expect(
+      screen.getByText("LLM: waiting for players"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'LLM: recovering N/M (kind)' during a recovery cascade", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        recoveryStatus={{
+          kind: "missing_drive",
+          attempt: 2,
+          budget: 3,
+        }}
+      />,
+    );
+    // Check substring rather than full string so "last attempt" cue
+    // is verified separately in its own case.
+    expect(
+      screen.getByText(/LLM: recovering 2\/3.*missing drive/),
+    ).toBeInTheDocument();
+  });
+
+  it("appends 'last attempt' when recovery hits the budget (UI/UX HIGH #2)", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        recoveryStatus={{
+          kind: "missing_yield",
+          attempt: 3,
+          budget: 3,
+        }}
+      />,
+    );
+    expect(
+      screen.getByText(/LLM: recovering 3\/3 — last attempt/),
+    ).toBeInTheDocument();
+  });
+
+  it("appends '· paused' to the in-flight chip when paused mid-recovery (User Agent MEDIUM #6)", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        aiPaused={true}
+        recoveryStatus={{
+          kind: "missing_drive",
+          attempt: 2,
+          budget: 3,
+        }}
+      />,
+    );
+    expect(
+      screen.getByText(/LLM: recovering 2\/3.*missing drive.*· paused/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders crit 'LLM: recovery FAILED' when the current turn errored (User Agent HIGH #3)", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        turnErrored={true}
+      />,
+    );
+    expect(screen.getByText("LLM: recovery FAILED")).toBeInTheDocument();
+    // Even with concurrent recovery + active tiers, the errored
+    // signal wins the chip because it's the operator's call to act
+    // on. Without this, the silent-yield class of bug stays hidden
+    // the moment the strict-retry loop exits.
+  });
+
+  it("turnErrored wins over recoveryStatus + activeTiers (priority order)", () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={2}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        turnErrored={true}
+        recoveryStatus={{ kind: "missing_yield", attempt: 3, budget: 3 }}
+        activeTiers={["play"]}
+      />,
+    );
+    expect(screen.getByText("LLM: recovery FAILED")).toBeInTheDocument();
+    expect(screen.queryByText(/recovering/)).not.toBeInTheDocument();
+    expect(screen.queryByText("LLM: play")).not.toBeInTheDocument();
   });
 
   it("expands the cost chip to show the token breakdown", () => {

--- a/frontend/src/components/SessionActivityPanel.tsx
+++ b/frontend/src/components/SessionActivityPanel.tsx
@@ -10,8 +10,38 @@ interface ActivityDiagnostic {
   hint?: string | null;
 }
 
+/**
+ * Issue #70: per-attempt validator pass landed in the audit log by
+ * ``turn_driver.run_play_turn``. The panel renders one row per
+ * attempt so the operator sees `Turn 6: drive ✗ → recovered via
+ * broadcast (attempt 2), yield ✓ (attempt 3)` without needing log
+ * access.
+ */
+interface ValidationAttempt {
+  attempt: number | null;
+  slots: string[];
+  violations: string[];
+  warnings: string[];
+  ok: boolean;
+  ts?: string;
+}
+
+interface RecoveryAttempt {
+  attempt: number | null;
+  kind: string | null;
+  tools: string[];
+  ts?: string;
+}
+
+interface TurnDiagnostics {
+  turn_index: number;
+  validations: ValidationAttempt[];
+  recoveries: RecoveryAttempt[];
+}
+
 interface ActivitySnapshot {
   state: string;
+  ai_paused?: boolean;
   turn: {
     index: number;
     status: string;
@@ -28,6 +58,8 @@ interface ActivitySnapshot {
   message_count: number;
   setup_note_count: number;
   recent_diagnostics?: ActivityDiagnostic[];
+  recent_turn_diagnostics?: TurnDiagnostics[];
+  legacy_carve_out_enabled?: boolean;
 }
 
 interface Props {
@@ -152,6 +184,46 @@ export function SessionActivityPanel({
         <p className="text-xs text-ink-400">Loading…</p>
       ) : (
         <>
+          {/* Issue #70: surface the legacy soft-drive carve-out
+              kill-switch in red so a misconfigured deployment is
+              visible without log access. The flag default is false;
+              if it's true, an operator flipped it on for emergency
+              rollback and forgot to flip it back. The validator
+              treats this as a downgrade ("warning, not violation")
+              for the AI's "missing DRIVE on a player @facilitator"
+              case — exactly the kind of silent-yield window the
+              issue exists to make visible. */}
+          {data.legacy_carve_out_enabled ? (
+            <div
+              role="alert"
+              className="rounded border border-warn bg-warn/30 p-2 text-[11px] text-warn"
+            >
+              <p className="font-semibold uppercase tracking-wider">
+                Legacy carve-out enabled
+              </p>
+              <p className="mt-0.5 text-ink-200">
+                <span className="mono">
+                  LLM_RECOVERY_DRIVE_SOFT_ON_OPEN_QUESTION=True
+                </span>{" "}
+                is set on the backend. The validator will downgrade the
+                missing-DRIVE check to a warning when a player @-mentions
+                the facilitator, which can let the AI silently yield.
+              </p>
+              <p className="mt-1 text-ink-200">
+                Safe for testing; <strong>disable for production</strong>.
+                To turn off, set{" "}
+                <span className="mono">
+                  LLM_RECOVERY_DRIVE_SOFT_ON_OPEN_QUESTION=False
+                </span>{" "}
+                in the backend environment and restart.
+              </p>
+            </div>
+          ) : null}
+          {data.ai_paused ? (
+            <p className="rounded border border-info bg-info-bg px-2 py-1 text-[11px] text-info">
+              AI is paused — facilitator-mention replies queue until resumed.
+            </p>
+          ) : null}
           <p className="text-xs text-ink-300">
             Turn{" "}
             <span className="font-semibold text-ink-100">
@@ -276,10 +348,212 @@ export function SessionActivityPanel({
               </ul>
             </details>
           ) : null}
+
+          {/* Issue #70: per-turn validator + recovery rollup. Pre-fix
+              this lived only in stdout-only structlog events; a
+              silent-yield regression took 5 hours to diagnose because
+              the creator panel couldn't tell apart "AI is thinking"
+              from "AI yielded silently". Now each attempt of each
+              turn shows up here as `drive ✓ yield ✓` (success) or
+              `drive ✗ yield ✓ — missing_drive recovered via broadcast`
+              (recovered) or `drive ✗ yield ✗` (warnings highlighted in
+              red). The rollup is creator-only and capped to the most
+              recent 3 turns server-side to keep the polled response
+              cheap on long sessions. */}
+          {data.recent_turn_diagnostics &&
+          data.recent_turn_diagnostics.length > 0 ? (
+            <details
+              open
+              className="rounded border border-ink-600 bg-ink-900 p-1.5 text-xs"
+            >
+              <summary
+                className="cursor-pointer text-ink-300"
+                aria-label={`Validator rollup, last ${data.recent_turn_diagnostics.length} turns`}
+              >
+                Validator rollup · last{" "}
+                {data.recent_turn_diagnostics.length} turn
+                {data.recent_turn_diagnostics.length === 1 ? "" : "s"}
+              </summary>
+              <ul className="mt-1 flex flex-col gap-1">
+                {data.recent_turn_diagnostics.map((td) => (
+                  <TurnDiagnosticsRow key={td.turn_index} diagnostics={td} />
+                ))}
+              </ul>
+              {/* Issue #70 review (User Agent MEDIUM #5): point the
+                  operator at God Mode for the full history rather
+                  than leaving them stuck at the most-recent-3-turns
+                  cap. Plain text — God Mode is the same window so a
+                  link would just be "scroll up to that pill". */}
+              <p className="mt-1 text-[10px] text-ink-500">
+                For older turns, open <strong>God Mode</strong> →
+                turn_diagnostics.
+              </p>
+            </details>
+          ) : null}
         </>
       )}
 
       {error ? <p className="text-[10px] text-crit">poll: {error}</p> : null}
     </section>
+  );
+}
+
+/**
+ * Per-turn validator-attempt + recovery breadcrumb row.
+ *
+ * Each turn can produce 1..N validation attempts (one per LLM call
+ * inside ``run_play_turn``'s strict-retry loop). Between attempts the
+ * validator may queue a recovery directive — a narrowed follow-up LLM
+ * call pinned to a specific tool. The row shows attempts in order,
+ * each with the slots that fired (DRIVE / YIELD / etc.) and a
+ * green ✓ / red ✗ tick per slot. A recovery directive that fired
+ * between attempts renders as a "↪ recovered via <tool> (kind:
+ * missing_drive)" hint underneath. Warnings (e.g. "drive missing but
+ * downgraded — legacy carve-out fired") render in red with no ✓ to
+ * make the silent-yield class of bug visually obvious.
+ */
+function TurnDiagnosticsRow({
+  diagnostics,
+}: {
+  diagnostics: TurnDiagnostics;
+}) {
+  // Build a quick lookup: which directive ran AFTER each attempt.
+  // Recovery directives are queued at the end of an attempt and
+  // executed on attempt+1; we pair recovery.attempt with that
+  // failing-attempt number so the UI groups them with the attempt
+  // that triggered them.
+  const recoveriesByAttempt = new Map<number, RecoveryAttempt>();
+  for (const r of diagnostics.recoveries) {
+    if (r.attempt !== null) recoveriesByAttempt.set(r.attempt, r);
+  }
+  const finalAttempt =
+    diagnostics.validations.length > 0
+      ? diagnostics.validations[diagnostics.validations.length - 1]
+      : null;
+  // Three outcomes drive the top-of-row badge (User Agent HIGH #2):
+  //  - ``ok``        — first attempt passed cleanly. Green.
+  //  - ``recovered`` — final attempt passed AFTER >= 1 retries. Warn —
+  //                    it WORKED but a regression in the underlying
+  //                    behavior is worth tracking.
+  //  - ``violations``— final attempt failed. Crit — turn errored or
+  //                    will need force-advance.
+  const overallOk = finalAttempt?.ok === true;
+  const attemptCount = diagnostics.validations.length;
+  const recovered = overallOk && attemptCount > 1;
+  return (
+    <li className="rounded bg-ink-900 px-2 py-1 text-[11px] text-ink-200">
+      <p className="flex items-center gap-1.5">
+        <span className="font-semibold text-ink-100">
+          Turn {diagnostics.turn_index + 1}
+        </span>
+        {finalAttempt ? (
+          recovered ? (
+            <span
+              className="rounded bg-warn-bg px-1 text-warn"
+              title={`Final attempt validation passed after ${attemptCount} attempts. The first attempt(s) needed recovery — fine, but worth tracking.`}
+            >
+              recovered ({attemptCount} attempts)
+            </span>
+          ) : overallOk ? (
+            <span
+              className="rounded bg-signal/30 px-1 text-signal"
+              title="First-attempt validation passed cleanly."
+            >
+              ok
+            </span>
+          ) : (
+            <span
+              className="rounded bg-crit/30 px-1 text-crit"
+              title="Final attempt did NOT pass — turn errored or was force-advanced."
+            >
+              violations
+            </span>
+          )
+        ) : (
+          <span className="text-ink-500">no validator pass yet</span>
+        )}
+      </p>
+      <ul className="mt-0.5 flex flex-col gap-0.5 pl-3">
+        {diagnostics.validations.map((v, idx) => {
+          const recovery =
+            v.attempt !== null ? recoveriesByAttempt.get(v.attempt) : null;
+          // Final attempt = "current state of the turn". Prior
+          // attempts = "history that the recovery loop already
+          // resolved" (User Agent MEDIUM #7). Prior-attempt
+          // violations rendered in warn (medium severity) instead of
+          // crit (high severity) so the row doesn't read as multiple
+          // active bugs.
+          const isFinal = idx === diagnostics.validations.length - 1;
+          const violationTone =
+            isFinal && !v.ok ? "text-crit" : "text-warn";
+          return (
+            <li
+              key={`v-${v.attempt}-${v.ts ?? "na"}`}
+              className="border-l border-ink-700 pl-2"
+            >
+              <span className="text-ink-300">
+                attempt {v.attempt}: {renderSlotTicks(v, isFinal)}
+              </span>
+              {v.violations.length > 0 ? (
+                <span className={`ml-1 ${violationTone}`}>
+                  · violations: {v.violations.join(", ")}
+                </span>
+              ) : null}
+              {v.warnings.length > 0 ? (
+                <span
+                  className="ml-1 text-warn"
+                  title={v.warnings.join(" · ")}
+                >
+                  ⚠ warnings: {v.warnings.length}
+                </span>
+              ) : null}
+              {recovery ? (
+                <p className="text-warn">
+                  ↪ recovered via {recovery.tools.join(", ") || "—"} (kind:{" "}
+                  <span className="mono">{recovery.kind ?? "?"}</span>)
+                </p>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </li>
+  );
+}
+
+const SLOT_LABELS = {
+  drive: "drive",
+  yield: "yield",
+} as const;
+
+function renderSlotTicks(v: ValidationAttempt, isFinal: boolean) {
+  // Show only the contract-relevant slots — drive + yield — since the
+  // bookkeeping / pin / narrate / escalate slots aren't required for
+  // turn validity and would clutter the row.
+  // ``isFinal`` mutes prior-attempt ✗ marks so the row reads as one
+  // resolved history (User Agent MEDIUM #7).
+  // ``aria-hidden`` on the glyph itself prevents SR from reading
+  // "check mark drive" awkwardly — the textual label below is what
+  // SR users hear (UI/UX LOW #8).
+  const fired = new Set(v.slots);
+  const missing = new Set(v.violations);
+  return (Object.keys(SLOT_LABELS) as Array<keyof typeof SLOT_LABELS>).map(
+    (slot) => {
+      const has = fired.has(slot);
+      const isMissing = missing.has(`missing_${slot}`);
+      const tone = has
+        ? "text-signal"
+        : isMissing
+          ? isFinal
+            ? "text-crit"
+            : "text-warn"
+          : "text-ink-500";
+      return (
+        <span key={slot} className={`ml-1 ${tone}`}>
+          <span aria-hidden="true">{has ? "✓" : "✗"}</span>{" "}
+          {SLOT_LABELS[slot]}
+        </span>
+      );
+    },
   );
 }

--- a/frontend/src/components/SessionActivityPanel.tsx
+++ b/frontend/src/components/SessionActivityPanel.tsx
@@ -41,7 +41,11 @@ interface TurnDiagnostics {
 
 interface ActivitySnapshot {
   state: string;
-  ai_paused?: boolean;
+  // Issue #70: ``/activity`` always returns these — the backend
+  // populates them unconditionally on every poll. Per CLAUDE.md
+  // "NO BACKWARDS COMPATIBILITY" they're typed as required so a
+  // future field drop is caught at typecheck time, not at runtime.
+  ai_paused: boolean;
   turn: {
     index: number;
     status: string;
@@ -57,9 +61,9 @@ interface ActivitySnapshot {
   turn_count: number;
   message_count: number;
   setup_note_count: number;
-  recent_diagnostics?: ActivityDiagnostic[];
-  recent_turn_diagnostics?: TurnDiagnostics[];
-  legacy_carve_out_enabled?: boolean;
+  recent_diagnostics: ActivityDiagnostic[];
+  recent_turn_diagnostics: TurnDiagnostics[];
+  legacy_carve_out_enabled: boolean;
 }
 
 interface Props {

--- a/frontend/src/components/brand/BottomActionBar.tsx
+++ b/frontend/src/components/brand/BottomActionBar.tsx
@@ -48,6 +48,29 @@ interface Props {
   cost: CostSnapshot | null;
   messageCount: number;
   activeTiers: string[];
+  /** Issue #70: AI paused via the Pause-AI toggle. Surfaces as
+   *  "LLM: idle (paused)" so the operator can tell the engine apart
+   *  from "the AI is just waiting on players". */
+  aiPaused: boolean;
+  /** Issue #70: validator-recovery breadcrumb. ``recovery`` is the
+   *  directive kind (``missing_drive`` / ``missing_yield``);
+   *  ``attempt`` / ``budget`` come from the strict-retry loop in
+   *  ``turn_driver.run_play_turn``. When set, the chip renders
+   *  ``LLM: recovering N/M (kind)`` so a stuck recovery is visible
+   *  without scanning the activity panel. */
+  recoveryStatus: {
+    kind: string;
+    attempt?: number;
+    budget?: number;
+  } | null;
+  /** Issue #70 (review): when the current turn errored after the
+   *  recovery budget was exhausted, the chip needs to sticky-stay on
+   *  a crit-tinted "recovery FAILED" until the operator
+   *  force-advances or starts a new turn. Without this, the chip
+   *  cleared to "LLM: idle (waiting for players)" the moment the
+   *  recovery loop exited — exactly the silent-yield-style
+   *  ambiguity the issue exists to kill (User Agent HIGH #3). */
+  turnErrored: boolean;
   buildSha: string;
   buildTs: string;
 }
@@ -172,20 +195,14 @@ export function BottomActionBar(props: Props) {
       >
         Last: {lastEventLabel}
       </span>
-      {props.activeTiers.length > 0 ? (
-        <span
-          role="status"
-          aria-live="polite"
-          className="mono rounded-r-1 border border-warn bg-warn-bg px-2 py-0.5 text-[10px] font-semibold uppercase text-warn"
-          title={`Active LLM tier(s): ${props.activeTiers.join(", ")}`}
-        >
-          LLM: {props.activeTiers.join("+")}
-        </span>
-      ) : (
-        <span className="mono rounded-r-1 bg-ink-800 px-2 py-0.5 text-[10px] uppercase text-ink-500">
-          LLM: idle
-        </span>
-      )}
+      <LlmStateChip
+        activeTiers={props.activeTiers}
+        recoveryStatus={props.recoveryStatus}
+        aiPaused={props.aiPaused}
+        backendState={props.backendState}
+        turnErrored={props.turnErrored}
+      />
+
 
       <CostChipMini cost={props.cost} />
 
@@ -236,6 +253,143 @@ export function BottomActionBar(props: Props) {
         ● {props.wsStatus.toUpperCase()}
       </span>
     </footer>
+  );
+}
+
+/**
+ * Multi-state LLM status chip (issue #70 + first-pass review fixes).
+ * The original chip was binary: either ``LLM: <tiers>`` (something in
+ * flight) or ``LLM: idle``. That collapsed four operationally-distinct
+ * cases into one ambiguous "idle" label and was the diagnostic gap
+ * behind the 2026-04-30 silent-yield 5-hour log dive — the operator
+ * couldn't tell apart "AI is thinking", "AI is waiting on players",
+ * "AI is paused", and "AI yielded silently".
+ *
+ * Priority order (top wins):
+ *   1. ``turnErrored`` true       → ``LLM: recovery FAILED`` (crit) —
+ *      sticky-stays after recovery exhausted so the bar reflects the
+ *      real engine state (User Agent HIGH #3). Cleared by
+ *      force-advance / starting a new turn.
+ *   2. ``recoveryStatus`` set     → ``LLM: recovering N/M (kind)`` (warn).
+ *      When ``attempt === budget`` the label adds "last attempt" so
+ *      colorblind operators get a non-color cue (UI/UX HIGH #2).
+ *      When ``aiPaused`` is also true, suffix "· paused" so the
+ *      operator can confirm pause took effect (User Agent MEDIUM #6).
+ *   3. ``activeTiers`` non-empty  → ``LLM: <tiers>`` (warn — "thinking").
+ *      Same paused-suffix rule applies.
+ *   4. ``aiPaused`` true          → ``LLM: idle (paused)`` (info-tinted).
+ *   5. ``AWAITING_PLAYERS``       → ``LLM: waiting for players`` (default).
+ *   6. fallback                   → ``LLM: idle`` (default).
+ *
+ * `aria-live="polite"` is set ONLY on the recovery + crit branches —
+ * the bug class the chip exists to surface. The generic in-flight
+ * chip lights for every play turn so announcing it would be
+ * announce-fatigue (UI/UX MEDIUM #5).
+ */
+function LlmStateChip({
+  activeTiers,
+  recoveryStatus,
+  aiPaused,
+  backendState,
+  turnErrored,
+}: {
+  activeTiers: string[];
+  recoveryStatus: { kind: string; attempt?: number; budget?: number } | null;
+  aiPaused: boolean;
+  backendState: string;
+  turnErrored: boolean;
+}) {
+  const pausedSuffix = aiPaused ? " · paused" : "";
+  // 1) Recovery exhausted — turn errored after strict-retry budget.
+  //    Crit-tinted, sticky-stays until next state transition. This
+  //    is the case the issue exists to make obvious; without it, the
+  //    chip would clear to "waiting for players" the moment the
+  //    recovery loop exited.
+  if (turnErrored) {
+    return (
+      <span
+        role="status"
+        aria-live="polite"
+        className="mono rounded-r-1 border border-crit bg-crit/30 px-2 py-0.5 text-[10px] font-semibold uppercase text-crit"
+        title="The current turn errored after the recovery budget was exhausted. Use Force-advance or End session to recover."
+      >
+        LLM: recovery FAILED
+      </span>
+    );
+  }
+  // 2) Recovery cascade is the loudest in-flight signal — "the AI is
+  //    mid-recovery" is the precise state the original silent-yield
+  //    bug was invisible in. Render even when ``activeTiers`` is
+  //    empty (between the failing attempt and the next LLM call).
+  if (recoveryStatus) {
+    const a = recoveryStatus.attempt;
+    const b = recoveryStatus.budget;
+    const aLabel = a ?? "?";
+    const bLabel = b ?? "?";
+    const kind = recoveryStatus.kind.replace(/_/g, " ");
+    const lastAttempt =
+      typeof a === "number" && typeof b === "number" && a >= b;
+    return (
+      <span
+        role="status"
+        aria-live="polite"
+        className="mono rounded-r-1 border border-warn bg-warn-bg px-2 py-0.5 text-[10px] font-semibold uppercase text-warn"
+        title={`Validator recovery in flight — kind=${recoveryStatus.kind}, attempt ${aLabel}/${bLabel}.${lastAttempt ? " This is the last attempt — turn will error if it fails." : ""}${aiPaused ? " AI pause is queued for next call." : ""}`}
+      >
+        LLM: recovering {aLabel}/{bLabel}
+        {lastAttempt ? " — last attempt" : ""} ({kind}){pausedSuffix}
+      </span>
+    );
+  }
+  // 3) Anything in flight — the legacy "thinking" signal. Tooltip
+  //    lists every tier so guardrail+play stacks are inspectable.
+  //    No aria-live — this fires every play turn and would be
+  //    announce-fatigue.
+  if (activeTiers.length > 0) {
+    return (
+      <span
+        className="mono rounded-r-1 border border-warn bg-warn-bg px-2 py-0.5 text-[10px] font-semibold uppercase text-warn"
+        title={`Active LLM tier(s): ${activeTiers.join(", ")}.${aiPaused ? " AI pause is queued for next call." : ""}`}
+      >
+        LLM: {activeTiers.join("+")}
+        {pausedSuffix}
+      </span>
+    );
+  }
+  // 4) Operator has paused the AI's facilitator-reply path. No
+  //    in-flight call is expected; this is *not* a regression.
+  if (aiPaused) {
+    return (
+      <span
+        className="mono rounded-r-1 border border-info bg-info-bg px-2 py-0.5 text-[10px] uppercase text-info"
+        title="AI is paused — facilitator-mention replies will queue until resumed."
+      >
+        LLM: idle (paused)
+      </span>
+    );
+  }
+  // 5) Engine waiting on players — "idle by design". Distinguishes
+  //    healthy AWAITING_PLAYERS from "AI yielded silently and the
+  //    engine doesn't know it" (which now would surface in the
+  //    SessionActivityPanel's per-turn validator rollup).
+  if (backendState === "AWAITING_PLAYERS") {
+    return (
+      <span
+        className="mono rounded-r-1 bg-ink-800 px-2 py-0.5 text-[10px] uppercase text-ink-300"
+        title="No LLM call in flight — the engine is waiting for player submissions / ready signals."
+      >
+        LLM: waiting for players
+      </span>
+    );
+  }
+  // 6) Catch-all — pre-session, between-turns, post-end.
+  return (
+    <span
+      className="mono rounded-r-1 bg-ink-800 px-2 py-0.5 text-[10px] uppercase text-ink-500"
+      title="No LLM call in flight."
+    >
+      LLM: idle
+    </span>
   );
 }
 

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1722,6 +1722,26 @@ export function Facilitator() {
           for (const tier of aiCalls.values()) seen.add(tier);
           return Array.from(seen).sort();
         })()}
+        // Issue #70: extra inputs for the multi-state LLM chip.
+        // ``aiPaused`` from the snapshot covers reload after the
+        // ``ai_pause_state_changed`` event has rolled out of the
+        // replay buffer; ``recoveryStatus`` from the live ``aiStatus``
+        // (set by the WS ``ai_status`` event the turn-driver emits at
+        // each strict-retry attempt) drives the
+        // ``LLM: recovering N/M (kind)`` label; ``turnErrored`` is
+        // the sticky crit signal once the recovery budget is
+        // exhausted (review pass: User Agent HIGH #3).
+        aiPaused={Boolean(snapshot.ai_paused)}
+        recoveryStatus={
+          aiStatus && aiStatus.phase === "play" && aiStatus.recovery
+            ? {
+                kind: aiStatus.recovery,
+                attempt: aiStatus.attempt,
+                budget: aiStatus.budget,
+              }
+            : null
+        }
+        turnErrored={snapshot.current_turn?.status === "errored"}
         buildSha={__ATF_GIT_SHA__}
         buildTs={__ATF_BUILD_TS__}
       />


### PR DESCRIPTION
## Summary

The 2026-04-30 silent-yield regression took 5 hours of log spelunking to diagnose because the creator panel collapsed four operationally-distinct states ("AI is thinking", "AI is paused", "AI is waiting on players", "AI yielded silently") into one ambiguous `LLM: idle` chip. This change makes the next regression a 5-second visual diagnosis.

Closes #70.

## Backend

- `turn_driver.run_play_turn` now emits `audit_kind=turn_validation` and `audit_kind=turn_recovery_directive` audit rows alongside the existing structlog lines. Pre-fix these were stdout-only and unreachable from `/debug` / `/activity`.
- `/api/sessions/{id}/debug` adds `ai_paused`, an `engine_flags` block (`legacy_carve_out_enabled` + `drive_required`), and a full `turn_diagnostics` rollup.
- `/api/sessions/{id}/activity` adds `ai_paused`, `legacy_carve_out_enabled`, and a `recent_turn_diagnostics` rollup capped to 3 turns. Uses a new `audit().for_kinds()` accessor so the 3-second poll doesn't copy the full `AUDIT_RING_SIZE=2000` ring on every request.
- `_compute_turn_diagnostics` rolls audit rows into a per-turn shape the panel renders directly. Audit-payload field is `directive_kind` to dodge `SessionManager._emit`'s positional `kind` collision; the rollup re-publishes it as `kind` for the wire.

## Frontend

- `BottomActionBar` LLM chip now has six explicit states with a documented priority order:
  1. **turn-errored** (crit, sticky) → "LLM: recovery FAILED"
  2. **recovering N/M** (warn) → "LLM: recovering 2/3 (missing drive)"; at `attempt === budget` adds "— last attempt"; with `aiPaused` adds "· paused"
  3. **active tier(s)** (warn) → "LLM: play"
  4. **paused** (info) → "LLM: idle (paused)"
  5. **AWAITING_PLAYERS** (default) → "LLM: waiting for players"
  6. **fallback** (default) → "LLM: idle"
  
  `aria-live="polite"` on recovery + recovery-failed branches only (UI/UX MEDIUM #5).
- `SessionActivityPanel` renders the per-turn validator rollup with three top-of-row badges:
  - `ok` (first-attempt clean — green)
  - `recovered (N attempts)` (passed after retries — warn)
  - `violations` (final attempt failed — crit)
  
  Prior-attempt violations render in warn (not crit) so a recovered turn doesn't read as multiple active bugs (User Agent MEDIUM #7).
- Carve-out banner is actionable ("set `LLM_RECOVERY_DRIVE_SOFT_ON_OPEN_QUESTION=False` and restart"); uses warn (medium severity) tokens, not crit. `aria-hidden` on ✓/✗ glyphs, `aria-label` on the `<details>` summary, and a "Full history in God Mode" hint at the bottom of the rollup.

## Tests

- `backend/tests/test_turn_diagnostics.py` (new) — 7 unit tests for the rollup helper covering grouping, orphan turn_id, max_turns cap, attempt-sort, warnings carry-through, and missing-attempt resilience.
- `backend/tests/test_auth.py` — 1 test for `audit().for_kinds`.
- `backend/tests/test_turn_driver.py` — 3 integration tests verifying audit row lands on a clean play turn, `/debug` carries the new keys, and `/activity` carries the new keys with the 3-turn cap.
- `frontend/src/__tests__/Facilitator.intro.test.tsx` — 6 new cases pinning the chip's multi-state rendering (paused, waiting for players, recovering N/M, last-attempt label, paused suffix, recovery-failed crit, priority order).

## Sub-agent reviews (six, in parallel — all addressed)

- **Prompt Expert**: PASS — observability-only diff, no model-facing strings.
- **Security**: PASS. One LOW addressed (`audit().for_kinds()` instead of full dump on `/activity`).
- **Product / App-Owner**: APPROVE. Per-turn `llm_call_start/complete/failed` history accepted as scope reduction per the issue comment's explicit recommendation; remains an optional follow-up.
- **QA**: addressed all flagged items — added missing-attempt edge-case test, `for_kinds` test, and frontend chip-state tests for each priority branch.
- **UI/UX**: addressed all 3 HIGH (warn-vs-crit token alignment + warning glyph, last-attempt non-color cue, banner typo + actionable copy) plus MEDIUM #5/6 and LOW #8.
- **User (CISO persona)**: addressed all 3 HIGH (actionable carve-out banner, recovered-vs-broken row badge, sticky crit chip on turn-errored) plus MEDIUM #6 (paused suffix) and #7 (faded prior-attempt violations).

## Live tests

Skipped: `turn_driver.py` diff is provably LLM-blind. The new `_emit` calls run AFTER the LLM call's outcome is known (post-validate, post-dispatch); they cannot affect model routing or tool selection. No prompts, tool descriptions, or recovery directives changed.

## Test plan

- [x] `cd backend && pytest -q --ignore=tests/live` — 702 passed, 1 skipped
- [x] `cd backend && ruff check app tests` — clean
- [x] `cd backend && mypy app` — clean
- [x] `cd frontend && npm test -- --run` — 391 passed
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [ ] Manual smoke: drive a play turn that recovers (assert chip flips through "recovering 1/3 missing drive" → "recovering 2/3 missing drive" → "ok"); drive a turn that exhausts (assert chip sticky-stays on "recovery FAILED"); pause AI mid-turn (assert "· paused" suffix appears).
- [ ] Manual smoke: enable `LLM_RECOVERY_DRIVE_SOFT_ON_OPEN_QUESTION=True`, restart, confirm carve-out banner renders with the disable instructions.

https://claude.ai/code/session_013BbiKT48wuckWHUTMzepnU

---
_Generated by [Claude Code](https://claude.ai/code/session_013BbiKT48wuckWHUTMzepnU)_