### PR TITLE
ci(live-tests): address Copilot review on PR #174

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -164,13 +164,21 @@ jobs:
         # parsing -- a non-numeric override falls back to the default.
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          PYTEST_ARGS: ${{ inputs.pytest_args || '' }}
-          LIVE_TEST_COST_CAP_USD: ${{ inputs.cost_cap_usd != '' && inputs.cost_cap_usd || '2.00' }}
+          # ``github.event.inputs.<name>`` is the long-stable context that
+          # works across every trigger — the modern ``inputs`` context is
+          # only documented for ``workflow_dispatch`` / ``workflow_call``
+          # / ``workflow_run`` events and has historically thrown
+          # "Unrecognized named-value: 'inputs'" on ``pull_request``
+          # triggers in some Actions runtime versions. The
+          # ``github.event.inputs`` form returns null on non-dispatch
+          # events; the ``||`` operator collapses null to the default.
+          PYTEST_ARGS: ${{ github.event.inputs.pytest_args || '' }}
+          LIVE_TEST_COST_CAP_USD: ${{ github.event.inputs.cost_cap_usd != '' && github.event.inputs.cost_cap_usd || '2.00' }}
           # Override the play-tier model only when the dispatch input
           # is non-empty; blank lets the backend's documented default
           # (``claude-sonnet-4-6``) apply. Reaches the backend via
           # the standard ``Settings.model_for("play")`` resolution.
-          ANTHROPIC_MODEL_PLAY: ${{ inputs.anthropic_model_play || '' }}
+          ANTHROPIC_MODEL_PLAY: ${{ github.event.inputs.anthropic_model_play || '' }}
         run: |
           set -euo pipefail
           if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -143,8 +143,8 @@ The live conftest installs a session-scoped wrapper around
 `AsyncAnthropic.messages.create` that records `response.usage` and
 multiplies by the per-million-token rate from `app/llm/cost.py`. When
 the cumulative spend crosses `LIVE_TEST_COST_CAP_USD` (default
-**$1.50**; standing suite ~$1.40), the in-flight test finishes and
-the next teardown sets `session.shouldstop` to halt cleanly.
+**$2.00**; standing suite ~$1.40, ~40% headroom), the in-flight test
+finishes and the next teardown sets `session.shouldstop` to halt cleanly.
 
 * Override per-run: `LIVE_TEST_COST_CAP_USD=2.50 pytest tests/live/`.
 * Disable (intentional stress run): `LIVE_TEST_COST_CAP_USD=0 ...`.

--- a/backend/tests/live/conftest.py
+++ b/backend/tests/live/conftest.py
@@ -546,9 +546,17 @@ def _live_cost_cap() -> Any:
          ``AARGenerator`` and the setup driver), which constructs
          ``AsyncAnthropic`` lazily on first call.
 
-    The patch is reverted at session teardown so unit tests run
-    afterward (in a single ``pytest`` invocation that includes both
-    suites, e.g. CI's full pass) see an unwrapped class.
+    Lifetime: this is a session-scoped autouse fixture, so once any
+    live test triggers it the patch stays active for the *entire*
+    pytest session and is only reverted at session teardown. Unit
+    tests that run BEFORE the live suite in the same invocation see
+    an unwrapped class; unit tests that run AFTER the live suite has
+    activated the fixture (and before the session ends) would see
+    the patched ``__init__``. In practice this only matters in a
+    single ``pytest`` invocation that mixes ``tests/`` and
+    ``tests/live/`` — CI runs them in separate jobs, and the wrapper
+    is benign for non-live AsyncAnthropic instances anyway (it just
+    counts usage that no test asserts on).
     """
 
     try:
@@ -565,10 +573,16 @@ def _live_cost_cap() -> Any:
         original_init(self, *args, **kwargs)
         _wrap_messages_create(self)
 
+    # Test-only monkeypatch of the SDK's __init__ so every
+    # AsyncAnthropic constructed during the live session gets the
+    # cost-cap wrapper. mypy flags re-assigning a method on a class
+    # (method-assign); intentional here.
     AsyncAnthropic.__init__ = init_wrapper  # type: ignore[method-assign]
     try:
         yield get_tracker()
     finally:
+        # Restore the original at session end so a later non-live
+        # test invocation in the same shell sees an unwrapped class.
         AsyncAnthropic.__init__ = original_init  # type: ignore[method-assign]
 
 

--- a/backend/tests/live/cost_cap.py
+++ b/backend/tests/live/cost_cap.py
@@ -9,7 +9,8 @@ Why we need this even with low per-test cost
 --------------------------------------------
 
 The standing suite is ~$1.40 / full run. CI runs it on a path filter
-plus a nightly schedule; a misconfigured workflow that fan-outs into
+plus ``workflow_dispatch`` (no scheduled cron — see
+``docs/tool-design.md``); a misconfigured workflow that fan-outs into
 N parallel jobs (or a contributor who pushes 30 times in an hour while
 iterating) can multiply that bill by 10x in minutes. Anthropic's TPM
 and RPM rate limits gate request volume but **not dollars** — at 100


### PR DESCRIPTION
## Summary

Follow-up to PR #174 (issue #74). Addresses the four real findings from Copilot's review of #174 plus minor polish:

| # | Copilot finding | Real? | Fix |
|---|---|---|---|
| 3 | `backend/scripts/README.md` says default `$1.50` but code is `$2.00` | **Yes** — stale doc | Updated to `$2.00` matching `DEFAULT_CAP_USD`. |
| 6 | `cost_cap.py` module docstring says "nightly schedule" | **Yes** — stale doc | Updated to "path filter plus workflow_dispatch (no scheduled cron)". |
| 1 | `inputs.X` context may error on non-dispatch triggers | **Defensive** | Switched to `github.event.inputs.X` (long-stable context that works across every trigger, returns null on non-dispatch, `||` collapses to default). |
| 4 | `_live_cost_cap` docstring claim about patch lifetime is misleading | **Yes** — wording bug | Clarified that the session-scoped patch stays active for the entire pytest session, not just the live subtree, and explained why the practical impact is benign. |
| 5 | `# type: ignore[method-assign]` lacks inline justification | Style nit | Added inline reasons. |
| 2 | "No schedule" but PR body claimed schedule | N/A — stale PR body | #174 is merged; PR body can't be edited. Codebase is consistent (no cron). |

The two stale docs were both byproducts of mid-PR pivots — bumping the cap default from $1.50 → $2.00 (security MEDIUM about headroom) and dropping the cron after the "$2/day for a side project" pushback. Both surfaces missed the update.

The `inputs` → `github.event.inputs` switch is defensive: the workflow ran successfully on PR #174's own runs, but `inputs.X` is only formally documented for `workflow_dispatch` / `workflow_call` / `workflow_run` and has historically produced "Unrecognized named-value: 'inputs'" on `pull_request` triggers in some runtime versions. The `github.event.inputs` form is documented to return null cleanly on non-dispatch events.

## Test plan

- [x] `pytest -q tests/test_live_cost_cap.py tests/test_live_fixtures.py` → 23 passed.
- [x] `ruff check backend/` → clean.
- [x] `mypy backend/app backend/tests/live/cost_cap.py backend/tests/live/conftest.py backend/tests/test_live_cost_cap.py` → 52 source files, no issues.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/live-tests.yml'))"` → valid.
- [ ] Confirm via Actions tab that the next routing-relevant PR triggers the live-tests workflow without the "Unrecognized named-value" failure mode (this PR itself doesn't touch a relevant path so won't fire it; merge-then-watch the next backend/app/llm/** PR).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiVCeyq5XZjntRfr4YWm66)_