### PR TITLE
docs: complete pass; restructure quick-start, fix tool-palette drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,14 +56,17 @@ load-bearing references; CONTRIBUTING.md is just the index.
 
 | File | Read before… |
 |---|---|
-| [`docs/PLAN.md`](docs/PLAN.md) | Anything architectural. Source of truth for decisions, phase plan, milestones. |
-| [`docs/architecture.md`](docs/architecture.md) | Touching the request/turn flow. Diagrams, retry-feedback loop, phase-policy contract. |
-| [`docs/configuration.md`](docs/configuration.md) | Adding any env var or operator-tunable knob. Hardening checklist for non-toy deploys. |
+| [`docs/architecture.md`](docs/architecture.md) | Touching the request/turn flow. Live diagrams, retry-feedback loop, phase-policy contract, current tool palette, operator runtime controls. |
+| [`docs/configuration.md`](docs/configuration.md) | Adding any env var or operator-tunable knob. Quick-start cheat sheet + hardening checklist. |
 | [`docs/llm_providers.md`](docs/llm_providers.md) | Wiring Bedrock / Vertex / OpenRouter / Ollama via `ANTHROPIC_BASE_URL`. |
 | [`docs/prompts.md`](docs/prompts.md) | Editing system prompts, guardrails, tool-use protocol, AAR rubric. JSON tool-use only — no XML function-call shapes. |
+| [`docs/prompt-writing-rules.md`](docs/prompt-writing-rules.md) | **Style guide for prompt copy.** Shape-not-phrase, deflection patterns, trust-boundary first. Distilled from the 2026-05-04 / 2026-05-05 live-test sweep. |
 | [`docs/tool-design.md`](docs/tool-design.md) | **Adding, renaming, or rewording any play-tier tool.** Five trap patterns documented. |
 | [`docs/turn-lifecycle.md`](docs/turn-lifecycle.md) | **Touching `turn_driver.py`, `turn_validator.py`, `slots.py`, or `dispatch.py`.** Every gate, contract, recovery path, and the 2026-04-30 silent-yield post-mortem. |
 | [`docs/extensions.md`](docs/extensions.md) | Adding a custom tool / resource / prompt. Declarative handlers only (`templated_text`, `static_text`); content flows as `tool_result`, never system content. |
+| [`docs/PLAN.md`](docs/PLAN.md) | Original architecture & implementation plan. Kept as historical reference for the "why"; for current behaviour, prefer `architecture.md` and `configuration.md`. |
+| [`docs/plans/`](docs/plans/) | Cross-cutting design plans (chat-declutter is currently the only one — delivered, kept for rationale). |
+| [`docs/ux-tests/`](docs/ux-tests/) | UX-test protocols (Wave-1 discussion mode is currently the only one). Contributor-facing testing scripts. |
 | [`CLAUDE.md`](CLAUDE.md) | Anything. Coding conventions, logging rules, dependency intake, sub-agent review protocol, model-output trust boundary, communication transport choices, the no-backwards-compat policy. |
 
 Brand work also reads:

--- a/README.md
+++ b/README.md
@@ -50,48 +50,99 @@ itself while the room is still warm.
 
 ## Quickstart
 
-### GitHub Codespaces
+> **Minimum viable config:** export `ANTHROPIC_API_KEY` and run one of
+> the recipes below. Everything else has a sensible default.
+> See [Environment variables](#environment-variables) for the
+> shortlist that actually matters and
+> [`docs/configuration.md`](docs/configuration.md) for the full
+> reference.
+
+### GitHub Codespaces (zero-install)
 
 Open the repo in Codespaces. The devcontainer installs both halves.
-Add `ANTHROPIC_API_KEY` to your Codespaces secrets and the env var is
-forwarded into the container.
+Add `ANTHROPIC_API_KEY` to your Codespaces secrets — it's forwarded
+into the container automatically. Then run `docker compose up --build`
+in the terminal and click the forwarded port.
 
 ### Local Docker (single container)
 
 ```bash
+export ANTHROPIC_API_KEY=sk-ant-…
 docker compose up --build
 # visit http://localhost:8000
 ```
 
-Or directly:
+Or pull the published image directly (no clone needed):
 
 ```bash
 docker run --rm -p 8000:8000 \
   -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
   ghcr.io/nebriv/crittable:latest
 ```
-<!--
-The Docker workflow (.github/workflows/docker.yml) publishes to
-``ghcr.io/nebriv/crittable`` — derived from ``github.repository``
-lowercased. The next push to ``main`` (or a tagged release) will be
-the first one published under the new image name; before then, the
-last tag published under the old ``ai-tabletop-facilitator`` name is
-still pullable from GHCR if you have a pinned reference.
--->
 
 ### Local development (no Docker)
 
+Two terminals — backend reload + Vite HMR:
+
 ```bash
-# Backend
+# Terminal 1 — backend (auto-reload on save)
+export ANTHROPIC_API_KEY=sk-ant-…
 cd backend && pip install -e ".[dev]"
 uvicorn app.main:app --reload --app-dir .
 
-# Frontend (separate terminal)
+# Terminal 2 — frontend (Vite dev server)
 cd frontend && npm ci && npm run dev
 ```
 
-The frontend dev server proxies `/api` and `/ws` to `localhost:8000` so
+The Vite dev server proxies `/api` and `/ws` to `localhost:8000`, so
 the two halves co-develop without CORS friction.
+
+## Environment variables
+
+The full reference is [`docs/configuration.md`](docs/configuration.md).
+This section is the **shortlist** — the variables that actually
+matter day-to-day. Everything else has a working default.
+
+### Required to start
+
+| Var | Why |
+|---|---|
+| `ANTHROPIC_API_KEY` | The app refuses to start without it. Also accepts an Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL` (see below). |
+
+### Required before any non-toy deployment
+
+The app boots without these — but **set them before exposing it to
+anyone**. The hardening checklist in
+[`docs/configuration.md`](docs/configuration.md#before-going-public--hardening-checklist)
+is the long form.
+
+| Var | Default | Why |
+|---|---|---|
+| `SESSION_SECRET` | randomly generated, with a startup warning | HMAC key for join tokens. Not setting this means tokens are invalidated on every restart. Use 32+ random bytes. |
+| `CORS_ORIGINS` | `*` | Comma-separated allowlist. Lock to your actual origin(s). |
+| `RATE_LIMIT_ENABLED` | `false` | Flip to `true` and tune `RATE_LIMIT_REQ_PER_MIN` (default 60). |
+
+### Useful day-to-day
+
+| Var | Default | Why |
+|---|---|---|
+| `ANTHROPIC_BASE_URL` | _unset_ | Point at Bedrock / Vertex / OpenRouter / Ollama via litellm. See [`docs/llm_providers.md`](docs/llm_providers.md). |
+| `ANTHROPIC_MODEL_PLAY` / `_SETUP` / `_AAR` / `_GUARDRAIL` | Sonnet 4.6 / Sonnet 4.6 / Opus 4.7 / Haiku 4.5 | Per-tier model overrides. Drop the setup tier to Haiku if you want cheaper setup turns (with a small XML-fallback risk; see configuration.md). |
+| `LOG_LEVEL` / `LOG_FORMAT` | `INFO` / `json` | Lower to `DEBUG` for verbose; switch to `console` for human-readable output during local dev. |
+| `MAX_TURNS_PER_SESSION` | `40` | Soft warning at 80%, hard stop at limit. |
+| `INPUT_GUARDRAIL_ENABLED` | `true` | Cheap Haiku off-topic / prompt-injection pre-classifier. |
+
+### Dev-only — never enable in production
+
+| Var | Default | Why |
+|---|---|---|
+| `DEV_FAST_SETUP` | `false` | Skip AI setup; land in `READY` with a generic plan. Useful for iterating on play UI. |
+| `DEV_TOOLS_ENABLED` | `false` | Exposes `/api/dev/scenarios/*` and the God Mode Scenarios panel. **Allows unauthenticated session creation** — never set in production. The app emits a `dev_tools_enabled_unauth_path_active` warning at boot if it's on. |
+| `AAR_INLINE_ON_END` | `false` | Tests-only: blocks the end-session response on AAR generation. |
+
+For everything else — per-tier sampling, retry budgets, session
+limits, the chat-declutter kill-switch, extension loaders — see
+[`docs/configuration.md`](docs/configuration.md).
 
 ## Session lifecycle (the phase machine)
 
@@ -120,25 +171,37 @@ boundaries are enforced in code:
 
 ## Documentation
 
-- [`docs/PLAN.md`](docs/PLAN.md) — architecture and phase plan (source of
-  truth).
-- [`docs/architecture.md`](docs/architecture.md) — diagrams, request flows,
-  phase policy, retry-feedback loop.
+**Operate / deploy:**
 - [`docs/configuration.md`](docs/configuration.md) — every env var,
   defaults, "before going public" hardening checklist.
 - [`docs/llm_providers.md`](docs/llm_providers.md) — swap to Bedrock /
   Vertex / OpenRouter / local Ollama via `ANTHROPIC_BASE_URL`.
 - [`docs/extensions.md`](docs/extensions.md) — Skills-style custom tools /
   resources / prompts.
-- [`docs/prompts.md`](docs/prompts.md) — system-prompt blocks, guardrails,
-  tool-use protocol, AAR rubric.
+
+**Architecture / engine internals (read before touching the matching code):**
+- [`docs/architecture.md`](docs/architecture.md) — live diagrams,
+  request flows, phase policy, retry-feedback loop.
 - [`docs/turn-lifecycle.md`](docs/turn-lifecycle.md) — **load-bearing
   reference for the play-turn engine.** Read before touching
   `app/sessions/turn_*` or `app/llm/dispatch.py`.
-- [`docs/tool-design.md`](docs/tool-design.md) — **tool authoring
-  guidelines.** Read before adding, renaming, or rewording any tool.
-- [`CLAUDE.md`](CLAUDE.md) — guidance for Claude Code sessions on this
-  repo (six-agent review protocol, logging rules, dependency intake).
+- [`docs/tool-design.md`](docs/tool-design.md) — tool authoring
+  guidelines. Read before adding, renaming, or rewording any tool.
+- [`docs/prompts.md`](docs/prompts.md) — system-prompt blocks,
+  guardrails, tool-use protocol, AAR rubric.
+- [`docs/prompt-writing-rules.md`](docs/prompt-writing-rules.md) —
+  prompt style guide (shape-not-phrase rule, deflection patterns,
+  trust-boundary first). Read before editing any prompt block.
+- [`docs/PLAN.md`](docs/PLAN.md) — original architecture & phase plan.
+  Historical reference; for the current state, prefer
+  `architecture.md` and `configuration.md`.
+
+**Working in the repo:**
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — local setup, conventions,
+  the six-agent review protocol.
+- [`CLAUDE.md`](CLAUDE.md) — guidance for Claude Code sessions on
+  this repo (logging rules, dependency intake, model-output trust
+  boundary, communication transport choices).
 
 ## Development
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,4 +1,32 @@
-# AI Cybersecurity Tabletop Facilitator — Architecture & Implementation Plan
+# Crittable — Original Architecture & Implementation Plan
+
+> ## ⏳ This is the historical blueprint
+>
+> This document captures the **original Phase-1 / Phase-2 design plan**
+> for what shipped as Crittable. It's preserved for context — naming
+> decisions, the "why" behind locked choices, the original phase
+> structure — but it is not the live reference for how the app behaves
+> today.
+>
+> **For current behaviour, prefer:**
+> - [`docs/architecture.md`](architecture.md) — live diagrams,
+>   tool palette, phase-policy contract, slot taxonomy, recovery
+>   cascade. Updated as the engine evolves.
+> - [`docs/configuration.md`](configuration.md) — current env vars
+>   and defaults.
+> - [`docs/turn-lifecycle.md`](turn-lifecycle.md) — load-bearing
+>   reference for the play-turn engine.
+>
+> Where this doc and the live references conflict, the live references
+> win. Concrete drift to be aware of in the body below: the repo was
+> renamed from `ai-tabletop-facilitator` to `Crittable`; the play tool
+> palette was redesigned 2026-04-30 (added `share_data` / `pose_choice`,
+> removed `inject_event` / `mark_timeline_point`); `end_session` was
+> removed from the AI palette in 2026-05-02 (issue #104); per-tier
+> defaults moved (`ANTHROPIC_MODEL_SETUP` shifted from Haiku to Sonnet;
+> `MAX_ROLES_PER_SESSION` default is now 24, not 8); the AAR pipeline
+> grew structured-output validation; multiple Wave-1/2/3 features
+> shipped that aren't reflected below.
 
 > # ⚠️ NO BACKWARDS COMPATIBILITY
 >
@@ -12,7 +40,7 @@
 
 A multi-user, browser-based chat application that runs cybersecurity tabletop exercises facilitated by Claude. A creator opens "New session," provides a scenario prompt, defines participant roles (e.g., CISO, IR Lead, Legal, Comms, Engineering), and shares a unique join link per role. The creator also plays a role. Claude holds the scenario brief and full roster, drives a turn-based loop (narrates events, decides which role(s) act next, ingests responses over WebSocket, advances the exercise), and at the end produces a downloadable markdown after-action report with scores.
 
-The repo (`nebriv/ai-tabletop-facilitator`) is currently empty. Bootstrap from scratch on branch `claude/ai-cybersecurity-chat-app-fEYFi`. Primary development environment is GitHub Codespaces, so devcontainer + CI + Docker image build are first-class Phase-1 deliverables. `ANTHROPIC_API_KEY` is provided via env var.
+The repo (originally `nebriv/ai-tabletop-facilitator`, now `nebriv/Crittable`) was empty at plan time. Bootstrap from scratch on branch `claude/ai-cybersecurity-chat-app-fEYFi`. Primary development environment is GitHub Codespaces, so devcontainer + CI + Docker image build are first-class Phase-1 deliverables. `ANTHROPIC_API_KEY` is provided via env var.
 
 Long-term intent: this may become a subscription SaaS. **Build with the right seams now, not the heavy machinery.** Async-first, per-session (not global) locks, repository/registry interfaces, pluggable AAA, tenancy-shaped data model — but no DB, no auth backends, no horizontal-scale infra in MVP.
 
@@ -49,7 +77,7 @@ Long-term intent: this may become a subscription SaaS. **Build with the right se
 ## Repo Layout
 
 ```
-ai-tabletop-facilitator/
+Crittable/  (originally `ai-tabletop-facilitator`)
 ├── .devcontainer/devcontainer.json
 ├── .github/workflows/{ci.yml, docker.yml}
 ├── backend/
@@ -296,7 +324,7 @@ Client → server events: `submit_response`, `request_force_advance`, `request_e
 
 All via env, documented in `docs/configuration.md`. Names:
 
-`ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`), `ANTHROPIC_MAX_RETRIES`, `LOG_LEVEL`, `LOG_FORMAT` (`json`|`console`), `SESSION_SECRET` (HMAC key), `MAX_SESSIONS`, `MAX_ROLES_PER_SESSION` (default 8), `MAX_TURNS_PER_SESSION` (default 40), `AI_TURN_SOFT_WARN_PCT` (default 80), `WS_HEARTBEAT_S`, `CORS_ORIGINS`, `EXTENSIONS_*_JSON`, `EXTENSIONS_*_PATH`.
+`ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`), `ANTHROPIC_MAX_RETRIES`, `LOG_LEVEL`, `LOG_FORMAT` (`json`|`console`), `SESSION_SECRET` (HMAC key), `MAX_SESSIONS`, `MAX_ROLES_PER_SESSION` (default 24 — was 8 in the original plan), `MAX_TURNS_PER_SESSION` (default 40), `AI_TURN_SOFT_WARN_PCT` (default 80), `WS_HEARTBEAT_S`, `CORS_ORIGINS`, `EXTENSIONS_*_JSON`, `EXTENSIONS_*_PATH`. The current full list is in [`docs/configuration.md`](configuration.md).
 
 ### Logging
 
@@ -405,7 +433,7 @@ OAuth/SSO authentication, persistent repository (SQLite then Postgres), tenant/o
 2. **Run / dev commands** — Codespace, local Docker, backend-only, frontend-only.
 3. **Configuration reference** — every env var, default, and effect (linked to `docs/configuration.md`).
 4. **Milestones** — exact MCP commands to list current scope, e.g.
-   `mcp__github__search_issues` with `repo:nebriv/ai-tabletop-facilitator is:issue is:open milestone:"Phase 1"` (and equivalents for `Phase 2` / `Phase 3`). Phase grouping is tracked via GitHub **milestones**, not labels. **Always read this before starting work.**
+   `mcp__github__search_issues` with `repo:nebriv/Crittable is:issue is:open milestone:"Phase 1"` (and equivalents for `Phase 2` / `Phase 3`). Phase grouping is tracked via GitHub **milestones**, not labels. **Always read this before starting work.**
 5. **Sub-agent review protocol** — every major task (= any closed Phase-2 issue, every Phase-3 epic) requires three reviews before merge:
    - **QA Agent** — verifies tests cover golden path + edge cases, regression risk, validates the issue's acceptance criteria.
    - **Security Engineer Agent** — input validation, secret handling, AuthN/AuthZ correctness, WebSocket origin/token checks, rate limits, prompt-injection surface (with extra attention to the extensions pipeline), dependency CVEs.
@@ -475,7 +503,7 @@ OAuth/SSO authentication, persistent repository (SQLite then Postgres), tenant/o
   Free for any non-competing use; converts to Apache-2.0 two years after each
   release. Chosen to preserve the option of running a hosted SaaS without
   closing the source.
-- GHCR image name (`ghcr.io/nebriv/ai-tabletop-facilitator`?).
+- GHCR image name. *Resolved: published as `ghcr.io/nebriv/crittable` after the rename.*
 - Whether to file the Phase 1/2/3 issue stubs immediately on plan approval, or as the first commit on the development branch.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,13 +139,13 @@ Two ad-hoc paths the validator replaced:
 
 | Slot | Tools | What it represents |
 |---|---|---|
-| `DRIVE` | `broadcast`, `address_role` | A player-facing question / addressable narrative beat |
-| `YIELD` | `set_active_roles` | Advances the turn |
-| `NARRATE` | `inject_event` | Stage-direction system note |
-| `PIN` | `mark_timeline_point` | Sidebar timeline pin (no chat bubble) |
-| `ESCALATE` | `inject_critical_event` | Headline-grade banner — must chain to DRIVE+YIELD |
-| `TERMINATE` | ~~`end_session`~~ | Removed from the AI palette in 2026-05-02 (issue #104). Slot retained as defensive dead code; only the creator can end the exercise (REST + WS). |
+| `DRIVE` | `broadcast`, `address_role`, `share_data`, `pose_choice` | Player-facing message — answer, brief, data dump, or A/B fork |
+| `YIELD` | `set_active_roles` | Advances the turn to the next active roles |
+| `ESCALATE` | `inject_critical_event` | Headline-grade banner — must chain to DRIVE + YIELD on the same turn |
 | `BOOKKEEPING` | `track_role_followup` / `resolve_role_followup` / `request_artifact` / `lookup_resource` / `use_extension_tool` / extension tools | Side effects that neither drive nor yield |
+| ~~`NARRATE`~~ | ~~`inject_event`~~ | Removed from the active play palette in the 2026-04-30 redesign. Slot retained as defensive dead code in [`slots.py`](../backend/app/sessions/slots.py). |
+| ~~`PIN`~~ | ~~`mark_timeline_point`~~ | Same — removed in the 2026-04-30 redesign; dead-code slot only. |
+| ~~`TERMINATE`~~ | ~~`end_session`~~ | Removed in 2026-05-02 (issue #104). The AI cannot end the exercise; only the creator can, via `POST /api/sessions/{id}/end` or the WS `request_end_session` event. |
 
 ### Contracts (play tier)
 
@@ -261,33 +261,68 @@ egress). See [`llm_providers.md`](llm_providers.md).
 
 ## Tools surfaced to Claude
 
-Built-ins (play tier):
+Built-ins (play tier — every play turn must end with a yield):
 
-- `address_role`, `broadcast`, `inject_event`,
-  `inject_critical_event` — narration tools.
-- `set_active_roles` — yield (the only "advance the turn" tool).
-- `request_artifact` — ask a role for a structured deliverable.
-- `mark_timeline_point` — pin a beat to the right-sidebar timeline
-  (sidebar-only; produces no chat bubble).
+- `broadcast` / `address_role` — narrate to all roles or speak
+  directly to one (player-facing DRIVE).
+- `share_data` — player-facing data dump (logs, IOCs, IR runbook
+  excerpts) addressed to one or more roles. Counts as DRIVE.
+- `pose_choice` — multi-option decision prompt. Counts as DRIVE.
+- `set_active_roles` — yield. The only tool that advances the turn.
+  Every play turn must end with a `set_active_roles` call.
+- `inject_critical_event` — escalation banner. **Must chain to
+  DRIVE + YIELD on the same turn**; standalone calls are rejected
+  by the validator and trigger the recovery cascade.
+- `request_artifact` — ask a role for a structured deliverable
+  (IR plan, comms draft).
 - `track_role_followup` / `resolve_role_followup` — per-role todo
   list the AI maintains across turns; surfaced back to the model as
   Block 11 of the system prompt.
-- `use_extension_tool`, `lookup_resource` — operator extensions.
+- `use_extension_tool` / `lookup_resource` — operator extensions.
 
-(`end_session` was removed in 2026-05-02 / issue #104; only the creator
-can wrap the exercise, via `POST /api/sessions/{id}/end` or the WS
-`request_end_session` event.)
+Removed from the play palette:
 
-Setup-only:
+- `end_session` — removed 2026-05-02 (issue #104). Only the creator
+  can end the exercise, via `POST /api/sessions/{id}/end` or the WS
+  `request_end_session` event.
+- `inject_event` / `mark_timeline_point` — removed in the 2026-04-30
+  redesign (the four DRIVE tools subsume their use cases). Slot
+  enums kept in [`slots.py`](../backend/app/sessions/slots.py) as
+  defensive dead code.
+
+Setup-only (state == `SETUP`, `tool_choice = {"type":"any"}` always):
 
 - `ask_setup_question`, `propose_scenario_plan`, `finalize_setup`.
+- `declare_workstreams` — added when `WORKSTREAMS_ENABLED=true`
+  (default). See [`docs/plans/chat-decluttering.md`](plans/chat-decluttering.md).
 
-AAR-only: `finalize_report`.
+AAR-only (state == `ENDED`, `tool_choice = {"type":"tool","name":"finalize_report"}`):
+
+- `finalize_report`.
 
 Tool descriptions in
 [`backend/app/llm/tools.py`](../backend/app/llm/tools.py) carry the
 detail; the tool-use protocol in
-[`prompts.md`](prompts.md) covers the chaining patterns.
+[`prompts.md`](prompts.md) covers the chaining patterns; the
+authoring rules live in [`tool-design.md`](tool-design.md).
+
+## Operator runtime controls
+
+Beyond the engine-side guardrails, the creator has a handful of
+runtime escape hatches surfaced in the UI ("God Mode" panel) and via
+REST:
+
+| Action | Endpoint | Purpose |
+|---|---|---|
+| **Force-advance** | `POST /api/sessions/{id}/force-advance` | Skip a stalled turn (any participant). Bypasses the ready-quorum gate. |
+| **Pause / Resume AI** | `POST /api/sessions/{id}/pause` & `/resume` | Wave 3 / issue #69. Halts the play-turn pump so the room can have an out-of-band discussion without the AI advancing. |
+| **End session** | `POST /api/sessions/{id}/end` | Creator-only as of issue #104. Kicks AAR generation. |
+| **Proxy respond** / **Proxy submit pending** | `POST /api/sessions/{id}/admin/proxy-respond` & `/admin/proxy-submit-pending` | Submit on behalf of an absent role (solo testing, missing-player escape). Subject to the same per-role-per-turn cap as a real submission. |
+| **Abort turn** | `POST /api/sessions/{id}/admin/abort-turn` | Drop the in-flight AI turn and roll back to `AWAITING_PLAYERS`. Recovery for stuck retries. |
+| **Retry AAR** | `POST /api/sessions/{id}/admin/retry-aar` | Re-run AAR generation if the first attempt failed (the export endpoint returns `500` when this happens). |
+| **Edit plan fields** | `POST /api/sessions/{id}/plan` | Inline edit of `key_objectives` / `guardrails` / `injects` / `out_of_scope` / `success_criteria` mid-exercise. Title and `narrative_arc` are immutable post-finalize. |
+| **Reissue / revoke join token** | `POST /api/sessions/{id}/roles/{role_id}/reissue` & `/revoke` | Kick a participant and mint a fresh signed link. |
+| **Shared notepad** | `GET /api/sessions/{id}/notepad/templates` & `/notepad/export.md` | Read the player-facing markdown notepad (locked at session end; reachable for `EXPORT_RETENTION_MIN`). |
 
 ## Extensions (Skills-style)
 
@@ -326,17 +361,36 @@ to see the trace.
   scaffolding, docs. **Complete** (milestone #1, all 10 issues
   closed).
 - **Phase 2** — full MVP. **Complete** (milestone #2, all 9 epics
-  closed: #11–#19). Bow-tying additions in PR #29:
-  - Per-tier sampling + timeout knobs, `ANTHROPIC_BASE_URL`,
+  closed: #11–#19). Layered on top of Phase 2 since:
+  - **Phase-policy engine guardrails** (state assertions, tool
+    filter, tool-choice posture, dispatcher rejection of forbidden
+    calls). PR #29.
+  - **Slot-based turn validator + recovery cascade** with the
+    retry-feedback loop. The model sees its own prior `tool_use` +
+    dispatcher `tool_result` blocks on retry and self-corrects.
+    See [`turn-lifecycle.md`](turn-lifecycle.md).
+  - **Per-tier sampling + timeout knobs**, `ANTHROPIC_BASE_URL`,
     `LLM_STRICT_RETRY_MAX`, `MAX_SETUP_TURNS`,
-    `MAX_PARTICIPANT_SUBMISSION_CHARS`.
-  - `phase_policy.py` engine-side guardrails (state assertions,
-    tool filter, tool-choice posture).
-  - Retry-feedback loop (model sees its own prior tool_use +
-    dispatcher rejections on strict retry).
-  - HTTP access log middleware with token scrubber.
-  - AI auto-interject on direct questions.
-  - Multi-section setup intro + dev-mode auto-start.
+    `MAX_PARTICIPANT_SUBMISSION_CHARS`,
+    `MAX_SUBMISSIONS_PER_ROLE_PER_TURN`.
+  - **Wave 1 — per-submission intent + ready-quorum gate** (issue
+    #134, PR #148). `submit_response` carries
+    `intent: "ready" | "discuss"`; the AI advances when
+    `set(active) ⊆ set(ready_role_ids)`. Force-advance bypasses.
+  - **Wave 2 — composer mentions + AI auto-interject on
+    `@facilitator`** (PR #152). Replaces the trailing-`?` heuristic.
+  - **Wave 3 — pause / resume AI toggle** (issue #69, PR #157).
+  - **Chat-declutter** — workstream metadata, transcript filter
+    pills, manual override, AAR isolation, creator markdown
+    exports (`/exports/timeline.md`, `/exports/full-record.md`).
+    PRs #119, #150, #152, #156, #158. Master kill-switch:
+    `WORKSTREAMS_ENABLED` (default true).
+  - **Mark-for-AAR** via the highlight registry (issue #117, PR #169).
+  - **Shared notepad** (issue #98, PR #115).
+  - **Live-tests workflow** with per-run dollar cap (issue #74).
+  - **Setup-wizard chrome** through SETUP + READY; creator role
+    moved to step 3 (PR #167).
+  - **Validator state surfaced to creator UI** (issue #70, PR #173).
 - **Phase 3** — value-add (persistence, OAuth/SSO, scenario library,
   voice, observability, scale-out, native non-Anthropic LLM
   adapters). Tracked under epics labelled `phase-3` (#20–#25).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -310,19 +310,23 @@ authoring rules live in [`tool-design.md`](tool-design.md).
 
 Beyond the engine-side guardrails, the creator has a handful of
 runtime escape hatches surfaced in the UI ("God Mode" panel) and via
-REST:
+REST. Unless noted otherwise the endpoint is **creator-only**
+(`require_creator`); the notepad endpoints accept any seated
+participant.
 
 | Action | Endpoint | Purpose |
 |---|---|---|
-| **Force-advance** | `POST /api/sessions/{id}/force-advance` | Skip a stalled turn (any participant). Bypasses the ready-quorum gate. |
-| **Pause / Resume AI** | `POST /api/sessions/{id}/pause` & `/resume` | Wave 3 / issue #69. Halts the play-turn pump so the room can have an out-of-band discussion without the AI advancing. |
+| **Force-advance** | `POST /api/sessions/{id}/force-advance` | Skip a stalled turn (any participant). Bypasses the ready-quorum gate. Also the recovery follow-up after `abort-turn`. |
+| **Pause / Resume `@facilitator` interjects** | `POST /api/sessions/{id}/pause` & `/resume` | Wave 3 / issue #69. **Limited scope** — only silences the side-channel `run_interject` reply when a player `@facilitator`'s the AI. Normal play turns still advance on the ready quorum; this is not a full engine pause. |
 | **End session** | `POST /api/sessions/{id}/end` | Creator-only as of issue #104. Kicks AAR generation. |
 | **Proxy respond** / **Proxy submit pending** | `POST /api/sessions/{id}/admin/proxy-respond` & `/admin/proxy-submit-pending` | Submit on behalf of an absent role (solo testing, missing-player escape). Subject to the same per-role-per-turn cap as a real submission. |
-| **Abort turn** | `POST /api/sessions/{id}/admin/abort-turn` | Drop the in-flight AI turn and roll back to `AWAITING_PLAYERS`. Recovery for stuck retries. |
+| **Abort turn** | `POST /api/sessions/{id}/admin/abort-turn` | Marks the in-flight AI turn `errored`. Does NOT itself reopen the turn — the operator follows up with `/force-advance` to open a fresh `AWAITING_PLAYERS` turn for the humans. Two-step recovery for stuck retries. |
 | **Retry AAR** | `POST /api/sessions/{id}/admin/retry-aar` | Re-run AAR generation if the first attempt failed (the export endpoint returns `500` when this happens). |
 | **Edit plan fields** | `POST /api/sessions/{id}/plan` | Inline edit of `key_objectives` / `guardrails` / `injects` / `out_of_scope` / `success_criteria` mid-exercise. Title and `narrative_arc` are immutable post-finalize. |
-| **Reissue / revoke join token** | `POST /api/sessions/{id}/roles/{role_id}/reissue` & `/revoke` | Kick a participant and mint a fresh signed link. |
-| **Shared notepad** | `GET /api/sessions/{id}/notepad/templates` & `/notepad/export.md` | Read the player-facing markdown notepad (locked at session end; reachable for `EXPORT_RETENTION_MIN`). |
+| **Reissue join token** | `POST /api/sessions/{id}/roles/{role_id}/reissue` | Re-mint the role's join URL **without invalidating the existing token**. Use when the creator lost the link and just needs to recover it; anyone already holding the old URL keeps working. |
+| **Revoke join token** | `POST /api/sessions/{id}/roles/{role_id}/revoke` | Bumps `role.token_version` so any old token starts failing with 401 on the next request, then mints a fresh one. Use this — not `reissue` — to actually kick whoever is holding the old link. |
+| **Notepad starter templates** | `GET /api/sessions/{id}/notepad/templates` | Participant-readable catalog of empty-state templates the editor can apply locally. Only the creator can record the chosen template id on the session. |
+| **Notepad markdown export** | `GET /api/sessions/{id}/notepad/export.md` | Participant-readable snapshot of the current shared notepad with a contributor header. Available before AND after the session ends, for `EXPORT_RETENTION_MIN` minutes after end. |
 
 ## Extensions (Skills-style)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,42 @@
 # Configuration
 
-All configuration is via environment variables, parsed by `pydantic-settings` in `backend/app/config.py` (lands in Phase 2). Phase 1 uses none of these directly; this page is the contract that Phase 2 implements.
+All configuration is via environment variables, parsed by
+`pydantic-settings` in [`backend/app/config.py`](../backend/app/config.py).
+This page is the authoritative contract; the module is the
+implementation.
+
+## Quick start — the env you actually need
+
+The vast majority of operators only set one variable.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-…
+docker compose up --build
+```
+
+That's the entire required surface. Everything else has a working
+default. Three small layers above that:
+
+| Layer | Vars | When |
+|---|---|---|
+| **Required** | `ANTHROPIC_API_KEY` | Always — the app refuses to start without it. |
+| **Before going public** | `SESSION_SECRET`, `CORS_ORIGINS`, `RATE_LIMIT_ENABLED` | Before anyone outside your machine touches the app. The app boots without these but warns loudly. See [the hardening checklist](#before-going-public--hardening-checklist). |
+| **Tweaks worth knowing** | `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL_<TIER>`, `LOG_LEVEL`, `MAX_TURNS_PER_SESSION`, `INPUT_GUARDRAIL_ENABLED` | When you want to point at a non-Anthropic backend, change models, see more logs, change cost caps, or disable the off-topic guardrail. |
+| **Dev-only — never set in production** | `DEV_FAST_SETUP`, `DEV_TOOLS_ENABLED`, `AAR_INLINE_ON_END` | Iterating on the play UI / running scenario replays / running tests. Each one degrades security or correctness if left on. |
+
+The rest of this page is the long form: every var, its default, and
+why you'd touch it.
+
+> **Heads-up: don't shadow `ANTHROPIC_*` in agent harnesses.** The
+> Anthropic SDK auto-discovers `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`,
+> `ANTHROPIC_AUTH_TOKEN`. Setting any of them as a session-wide env var
+> in a Claude Code harness shadows the harness's own credentials. For
+> the live-test workflow we wrap the variable as
+> `LIVE_TEST_ANTHROPIC_API_KEY` and bridge it inline (see
+> [`backend/scripts/run-live-tests.sh`](../backend/scripts/run-live-tests.sh)
+> and the corresponding section in [`CLAUDE.md`](../CLAUDE.md)).
+> This restriction does NOT apply to GitHub Actions, Docker, or local
+> shells — name the variable `ANTHROPIC_API_KEY` directly there.
 
 ## Required
 
@@ -64,7 +100,9 @@ rationale for each default lives in `backend/app/config.py`
 | `MAX_CRITICAL_INJECTS_PER_5_TURNS` | `1` | Rate limit on `inject_critical_event` |
 | `EXPORT_RETENTION_MIN` | `60` | Minutes to keep an ENDED session's export available (covers AAR markdown, structured AAR JSON, **and the shared notepad** — `notepad/export.md` is reachable for the same window). |
 | `WS_HEARTBEAT_S` | `20` | WebSocket heartbeat interval |
-| `INPUT_GUARDRAIL_ENABLED` | `true` | Toggle the Haiku off-topic pre-classifier |
+| `INPUT_GUARDRAIL_ENABLED` | `true` | Toggle the Haiku off-topic / prompt-injection pre-classifier (single-word verdict). |
+| `DUPLICATE_SUBMISSION_WINDOW_SECONDS` | `30` | Reject a participant submission if it matches the role's previous body (whitespace-stripped) within this window. Backstop for the no-feedback retype loop on issue #63. Set `0` to disable. |
+| `AUDIT_RING_SIZE` | `2000` | Capacity of the in-memory audit ring buffer surfaced to the AAR appendix and `/debug` endpoint. |
 | `DEV_FAST_SETUP` | `false` | Dev/testing only: skip the AI setup dialogue at session creation, drop a generic default plan, and land in `READY`. **Never enable in production.** A creator can also trigger this mid-flow via `POST /api/sessions/{id}/setup/skip`. |
 | `DEV_TOOLS_ENABLED` | `false` | Dev/testing only: expose the `/api/dev/scenarios/...` endpoints (scenario list / play / record). Required for the "Scenarios" panel inside God Mode to load — without this flag the panel renders a "Scenarios — disabled" empty state. **Never enable in production**: `/play` accepts UNAUTHENTICATED callers in this mode — an attacker can mint sessions and harvest the creator token from the response body without any prior credential. `main.py` emits a `dev_tools_enabled_unauth_path_active` startup WARNING when the flag is on so the misconfiguration shows up in operator log scans. See `backend/scenarios/README.md` and the "Scenario replay" section in `CLAUDE.md`. |
 | `AAR_INLINE_ON_END` | `false` | Tests-only knob: run AAR generation inline (rather than as a background task) when `end_session` is called. Required by the unit-test suite because Starlette's sync `TestClient` doesn't reliably progress cross-request `asyncio.create_task` work and the polling client would otherwise see `aar_status="pending"` forever. The parent `backend/tests/conftest.py` sets this on every test run. **Never enable in production**: blocks the `POST /end` request handler on the AAR pipeline (5–60 s). |
@@ -124,6 +162,7 @@ Defaults preserve historical behaviour so unset = no change.
 | `EXTENSIONS_TOOLS_JSON` / `EXTENSIONS_TOOLS_PATH` | JSON list of `ExtensionTool` definitions, inline or from a file path |
 | `EXTENSIONS_RESOURCES_JSON` / `EXTENSIONS_RESOURCES_PATH` | Same for `ExtensionResource` |
 | `EXTENSIONS_PROMPTS_JSON` / `EXTENSIONS_PROMPTS_PATH` | Same for `ExtensionPrompt` |
+| `EXTENSION_TEMPLATE_MAX_BYTES` | `8192` (default; minimum 64) | Hard byte ceiling on a rendered `templated_text` extension result. The Jinja sandbox already bans dangerous filters / loaders; this cap is the runaway-output backstop. |
 
 ## Before going public — hardening checklist
 

--- a/docs/plans/chat-decluttering.md
+++ b/docs/plans/chat-decluttering.md
@@ -1,7 +1,10 @@
 # Chat-declutter — design plan
 
-**Status:** Draft · 2026-05-02 · feeds Phase 3 (milestone #3)
+**Status:** **Delivered** (Phase A → iter-4 polish, 2026-05-03 → 2026-05-04). Kept as the design rationale; the live behaviour is reflected in `WORKSTREAMS_ENABLED` ([`configuration.md`](../configuration.md)), the `declare_workstreams` setup tool ([`backend/app/llm/tools.py`](../../backend/app/llm/tools.py)), and the transcript/composer chrome in [`frontend/src/`](../../frontend/src/).
+
+**Original status:** Draft · 2026-05-02 · feeds Phase 3 (milestone #3)
 **Owner:** unassigned
+**Shipped via:** PR #119 (plan) · PR #150 (Phase A — workstream metadata + AAR isolation) · PR #152 (Phase C + Wave 2 — composer mentions + facilitator routing) · PR #156 (Phase B — visible filter chrome) · PR #158 (iter-4 polish — rail tabs, manual override, exports, flag flip to default-on)
 **Cross-refs:** PR #116 (closed, mockups archived on `claude/threaded-replies-investigation-1eekS`) · PR #115 (merged, highlight-to-notepad) · issue #117 (Mark-for-AAR affordance, implemented as a sibling action in the highlight registry — pins under the notepad's `## AAR Review` section, surfaced to the AAR via a dedicated `<player_aar_marked_verbatim>` priority block)
 
 ## TL;DR

--- a/docs/turn-lifecycle.md
+++ b/docs/turn-lifecycle.md
@@ -36,10 +36,17 @@ contract. Four exist:
 
 | Tier | When | Tools | Validator runs? |
 |---|---|---|---|
-| `setup` | Creator setup loop | `ask_setup_question`, `propose_scenario_plan`, `finalize_setup` | No — own loop. |
-| `play` | Driving the exercise (this doc) | `broadcast`, `address_role`, `share_data`, `pose_choice`, `set_active_roles`, `inject_critical_event`, `end_session`, `request_artifact`, `track/resolve_role_followup`, `lookup_resource`, `use_extension_tool` | **Yes** — the focus of this doc. |
+| `setup` | Creator setup loop | `ask_setup_question`, `propose_scenario_plan`, `finalize_setup` (+ `declare_workstreams` when `WORKSTREAMS_ENABLED=true`) | No — own loop. |
+| `play` | Driving the exercise (this doc) | `broadcast`, `address_role`, `share_data`, `pose_choice`, `set_active_roles`, `inject_critical_event`, `request_artifact`, `track_role_followup` / `resolve_role_followup`, `lookup_resource`, `use_extension_tool` (+ operator extension tools) | **Yes** — the focus of this doc. |
 | `aar` | After-action report generation | `finalize_report` only | No — `tool_choice` pinned. |
-| `guardrail` | Pre-flight off-topic / harmful classifier | classifier tool only | No. |
+| `guardrail` | Pre-flight off-topic / harmful classifier | none — single-word text verdict | No. |
+
+> `end_session` was removed from the play palette in 2026-05-02 (issue
+> #104) — only the creator can end the exercise. `inject_event` and
+> `mark_timeline_point` were removed in the 2026-04-30 redesign. The
+> `Slot` enum still carries `TERMINATE` / `NARRATE` / `PIN` as defensive
+> dead code so a stale prompt cache that emits one of these names still
+> classifies cleanly.
 
 ### Slot
 


### PR DESCRIPTION
## Summary

Documentation pass against the last 20 PRs (#84 through #173). Goal: make the repo easy to pick up, deploy, and modify; surface what actually matters in the env-var jungle; align the design docs with the code that shipped.

## What changed

**README.md — quick-start clarity**
- Quick-start leads with a one-line "minimum viable config" callout, then three tiered recipes (Codespaces / Docker / local dev).
- New `Environment variables` shortlist split into four tiers: *required to start*, *required before going public*, *useful day-to-day*, *dev-only — never enable in production*. Full table stays in `docs/configuration.md`.
- Documentation index regrouped by use case (operate / architecture / contribute) and now references `prompt-writing-rules.md` and `CONTRIBUTING.md` (both previously orphaned).

**docs/configuration.md — quick-start at the top**
- New "Quick start — the env you actually need" section so first-time operators don't have to scan 130 lines.
- Anthropic-env-shadow callout (the one that lives in CLAUDE.md) lifted up so contributors using Claude Code as a harness see it before breaking their session.
- Three missing rows filled: `DUPLICATE_SUBMISSION_WINDOW_SECONDS`, `AUDIT_RING_SIZE`, `EXTENSION_TEMPLATE_MAX_BYTES`.

**docs/architecture.md — palette & ops controls aligned with code**
- Slot taxonomy fixed: DRIVE now lists `share_data` + `pose_choice` (added 2026-04-30); `inject_event` / `mark_timeline_point` / `end_session` marked as removed dead-code slots.
- "Tools surfaced to Claude" section rewritten to match the live `PLAY_TOOLS` array.
- New "Operator runtime controls" table covering force-advance, pause/resume AI (Wave 3), end-session, proxy-respond, abort-turn, retry-AAR, plan-edit, reissue/revoke token, notepad — all real endpoints not previously surfaced.
- Phase-scope updated to include Wave 1/2/3, chat-declutter, Mark-for-AAR, shared notepad, live-tests workflow, setup-wizard rework, validator-state UI surfacing.

**docs/PLAN.md — labelled as historical**
- New banner at the top making clear it's the original Phase-1/2 design plan, not the live reference. Concrete drift called out by name.
- Repo name fixed (`ai-tabletop-facilitator` → `Crittable`) in context, repo-layout, milestone-search example, and the GHCR-image open item.
- `MAX_ROLES_PER_SESSION` default corrected (8 → 24).

**docs/turn-lifecycle.md — vocabulary tier table**
- Tier table now matches the live tool palette. Removed `end_session` / `inject_event` / `mark_timeline_point` from play; added `WORKSTREAMS_ENABLED` note for setup; corrected the guardrail row (no tools, just a one-word verdict).

**docs/plans/chat-decluttering.md — status flipped**
- Status changed from Draft to **Delivered** with a list of shipping PRs (#119 / #150 / #152 / #156 / #158). Original status preserved underneath for the historical record.

**CONTRIBUTING.md — docs map completeness**
- Map now references `prompt-writing-rules.md`, `docs/plans/`, `docs/ux-tests/` — all previously unlinked. PLAN.md re-described as historical reference (matching the new banner).

## Out of scope (intentionally not touched)

- Prompt copy itself (`prompts.md`, `prompt-writing-rules.md`) — no drift found against `app/llm/prompts.py`.
- `tool-design.md`, `extensions.md`, `llm_providers.md` — current.
- The 879-line `turn-lifecycle.md` body past the vocabulary fix — the decision tree, recovery cascade, and 2026-04-30 post-mortem are still load-bearing accurate; rewriting would risk introducing regressions in the next debugging session.

## Test plan

- [ ] Read `README.md` top-to-bottom as a first-time operator. Quick-start should land you on a working `docker compose up --build` after exporting `ANTHROPIC_API_KEY`.
- [ ] Read `docs/configuration.md` top section. The four-tier cheat sheet should make the "what do I actually need to set" question answerable in 30 seconds.
- [ ] Spot-check `docs/architecture.md` "Tools surfaced to Claude" against `backend/app/llm/tools.py` `PLAY_TOOLS` — should match name-for-name.
- [ ] Spot-check `docs/architecture.md` "Operator runtime controls" against `grep '@router' backend/app/api/routes.py` — every endpoint listed should exist.
- [ ] `docs/PLAN.md` opening banner should make clear it's a historical artifact and direct readers to `architecture.md` / `configuration.md`.
- [ ] No remaining unintentional `ai-tabletop-facilitator` references: `grep -rn ai-tabletop-facilitator docs/ README.md CONTRIBUTING.md` — only the three intentional rename callouts in `PLAN.md` should remain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjzGpaqnDRjTB5dE41pBe1)_