### PR TITLE
ci/docker: print Trivy CVE table to log; bump bundled pip to >=25.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Trivy image scan (table, informational) — prints CVEs to log
+        # Same scan parameters as the SARIF gate below, but ``exit-code:
+        # "0"`` so this step never fails the build. Its only purpose is
+        # to surface the human-readable CVE table inside the Actions log
+        # — the SARIF gate that follows writes findings to a file and
+        # does not echo to stdout, which historically forced operators
+        # to dig through the Code Scanning tab to learn *which* CVE
+        # tripped the gate. With this step running first, the next
+        # failed run is self-documenting in the log itself.
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ steps.scan-target.outputs.ref }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "0"
+          vuln-type: os,library
+
       - name: Trivy image scan (HIGH,CRITICAL) — gates the push
         # Scans the locally-loaded image for OS-package and language-dep
         # CVEs BEFORE it reaches the registry. HIGH/CRITICAL findings

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,13 @@ COPY backend/app ./backend/app
 # inside the container ends up missing and the picker silently
 # returns an empty list.
 COPY backend/scenarios ./backend/scenarios
+# Upgrade pip before any install: the bundled pip in python:3.12-slim
+# (25.0.1 at time of writing) ships CVE-2025-8869 (symlink-extraction
+# check missing) and a related path-traversal info-disclosure CVE,
+# both fixed in pip 25.3. The Trivy gate in docker.yml flags these
+# on every push; rather than .trivyignore them, just take the patched
+# pip — it's a five-second image-size-neutral fix.
+RUN pip install --upgrade "pip>=25.3"
 RUN pip install -e ./backend
 
 # Copy built frontend into the location the backend serves static files from


### PR DESCRIPTION
## Summary

The Trivy gate in `.github/workflows/docker.yml` (added in #135) has been failing every push to `main` since 2026-05-03. Two reasons it's been hard to diagnose:

1. The gate uses `format: sarif` + `output: trivy-results.sarif`, which writes to a file and **never echoes the CVE table to stdout**. The Actions log shows only `exit code 1` with no list of which CVE tripped it.
2. The Code Scanning tab is currently showing **"Trivy is reporting errors"** — at least one SARIF upload partially failed, so even that fallback isn't authoritative.

This PR is a diagnostic + low-risk-fix follow-up. **It is not expected to fully unblock the gate on its own** — see "What this does NOT fix" below.

## What this changes

### 1. `.github/workflows/docker.yml` — add a table-format Trivy step before the SARIF gate

A second `aquasecurity/trivy-action@0.35.0` invocation, identical scan parameters (`severity: HIGH,CRITICAL`, `ignore-unfixed: true`, `vuln-type: os,library`), but `format: table` and `exit-code: "0"`. Strictly informational — it can never fail the build. Runs before the SARIF gate so the CVE table prints to the Actions log first; the gate then runs unchanged.

Cost: ~10s per push (one extra Trivy DB hit; image already in the local Docker daemon).

After this lands, the next failed push to `main` is **self-documenting**: CVE id, package name, installed version, and fixed version all show up in the Actions log itself.

### 2. `docker/Dockerfile` — upgrade bundled pip to `>=25.3` before any other install

`python:3.12-slim` ships `pip 25.0.1`, which Trivy flags for:
- **CVE-2025-8869** — pip missing checks on symbolic link extraction (MEDIUM, fixed in 25.3)
- A related path-traversal info-disclosure CVE (LOW, fixed in 25.3)

Both are visible in the Code Scanning tab today. Even though MEDIUM/LOW don't trip the HIGH+CRITICAL gate by themselves, shipping with a known-vulnerable package extractor when the fix is one line is silly. Image-size-neutral.

## What this does NOT fix

The `exit code 1` is from a **HIGH or CRITICAL** finding, and the two visible alerts are MEDIUM/LOW — so there's still a HIGH/CRITICAL CVE we can't see (hidden behind the "Trivy is reporting errors" banner in Code Scanning, or in the "1 Closed" alert tab).

The plan after this PR merges:

1. Watch the next push-to-`main` log; the table-format step will dump the full CVE list.
2. Open a follow-up PR with the actual fix (one of: bump base image — #142 already proposes `python:3.14-slim` —, pin a fixed version in the apt-get block, or add a justified `.trivyignore` entry per CVE).

## Scope carve-out (per `CLAUDE.md`)

CI / Dockerfile-only change. No application code, no LLM call sites, no `SessionState` / turn-pump / submission-pipeline / `MessageKind` changes. **The six-agent review pipeline and scenario-replay rule do not apply** ("Phase-1 docs / CI / scaffolding work is exempt").

## Test plan

- [ ] Merge to `main`; the next Docker workflow run prints a Trivy vulnerability table to the Actions log.
- [ ] The new informational step has `exit-code: 0`; confirm it never short-circuits the SARIF gate even if it lists findings.
- [ ] The image still builds (`docker compose up --build` locally) and the runtime stage's pip is `>=25.3`.
- [ ] Code Scanning's two visible pip alerts (CVE-2025-8869 + the LOW path-traversal one) close on the next push as fixed.

https://claude.ai/code/session_01NJxSp8XAdtGVFqUmTXkQEH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJxSp8XAdtGVFqUmTXkQEH)_