### PR TITLE
ci(docker): run Trivy gate on PRs, not just post-merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,25 @@ on:
   push:
     branches: ["main"]
     tags: ["v*"]
+  pull_request:
+    # Validate the build + Trivy gate on every PR that touches the
+    # runtime image, BEFORE merge. PR #135 introduced the Trivy gate
+    # on push-to-main only, which meant a CVE could land on main and
+    # block every subsequent push (the way it did 2026-05-03 →
+    # 2026-05-05). Running the same workflow on PRs catches the
+    # regression in the PR's own CI; the auth + push steps below are
+    # gated on ``github.event_name == 'push'`` so PR runs build and
+    # scan but never publish to GHCR.
+    branches: ["main"]
+    paths:
+      # Anything that ends up in the image, plus the workflow itself.
+      # Pure docs / design / test-only PRs don't need a Trivy scan.
+      - "docker/**"
+      - "backend/pyproject.toml"
+      - "backend/app/**"
+      - "backend/scenarios/**"
+      - "frontend/**"
+      - ".github/workflows/docker.yml"
 
 permissions:
   contents: read
@@ -29,6 +48,11 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        # Only push events publish to GHCR; PR runs build + scan only.
+        # Skipping the login on PRs avoids a noisy auth attempt and is
+        # required for fork PRs (where ``GITHUB_TOKEN`` is read-only and
+        # ``packages: write`` is downgraded).
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -127,7 +151,14 @@ jobs:
         # Always upload, even if the scan failed — findings land in the
         # Security tab and can be triaged from there instead of
         # disappearing with the failed run.
-        if: always()
+        #
+        # Only on push events: the Code Scanning view shows the current
+        # state of ``main``, not pre-merge PR speculation. PR runs still
+        # gate the merge via the Trivy step's exit code; we just don't
+        # let PR-only findings clutter the Security tab. (Also avoids a
+        # silent SARIF upload failure on fork PRs where
+        # ``security-events: write`` is downgraded.)
+        if: always() && github.event_name == 'push'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
@@ -137,8 +168,14 @@ jobs:
         # Re-runs the build with the same inputs to publish to GHCR.
         # The previous build's ``cache-to`` populated the gha cache, so
         # this is a near-instant cache hit — no real rebuild happens.
-        # Skipped automatically if the Trivy step failed because steps
-        # default to ``if: success()``.
+        #
+        # Two gates: ``success()`` so a failed Trivy scan skips the
+        # push (the original guarantee), AND
+        # ``github.event_name == 'push'`` so PR runs never publish.
+        # Both are required because specifying any ``if:`` overrides
+        # the default ``if: success()`` GitHub Actions applies to
+        # subsequent steps.
+        if: success() && github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary

Closes the structural gap that let PR #135 land a broken Trivy gate on `main` without anyone noticing for two days. Until now, `docker.yml` only ran on `push: main` and `tags: v*`, so the gate's first end-to-end execution against any change was the merge commit itself — too late to block, and the only recovery was a follow-up commit on `main`.

After this PR every PR that touches the runtime image runs the build + Trivy scan in its own CI; the same scan that gates publish from `main` now also gates merge into `main`.

## Changes

`.github/workflows/docker.yml`

- **`on:` adds `pull_request: branches: ["main"]`** with a paths filter restricting it to image-affecting changes:
  ```
  docker/**
  backend/pyproject.toml
  backend/app/**
  backend/scenarios/**
  frontend/**
  .github/workflows/docker.yml
  ```
  Pure docs / design / test-only PRs (the bulk of recent merges) still skip the scan, so this doesn't double the average PR's CI time.

- **`Log in to GHCR` step** is gated on `github.event_name == 'push'`. PR runs build + scan only; they never publish, so the auth attempt would be wasted at best and would fail noisily on fork PRs (where `GITHUB_TOKEN` is read-only) at worst.

- **`Push (only if scan passed)` step** now carries explicit `if: success() && github.event_name == 'push'`. The `success()` half preserves the original "skip on Trivy failure" guarantee — required because any explicit `if:` overrides the default `if: success()` GitHub Actions applies. The `event_name` half ensures PR runs never publish.

- **`Upload Trivy SARIF to Code Scanning` step** is also gated to push events (`if: always() && github.event_name == 'push'`). The Code Scanning view continues to reflect the current state of `main`; PR runs gate via Trivy's exit code without polluting the Security tab with pre-merge speculation, and we sidestep the `security-events: write` downgrade that breaks SARIF upload on fork PRs.

## What this catches that the previous setup missed

- A Dependabot PR that bumps the runtime base image (e.g. #142, `python:3.12-slim` → `3.14-slim`; #137, `node:20-slim` → `25-slim`): the scan now runs before merge, and a regression blocks the PR check instead of the next push to `main`.
- Any PR touching `backend/pyproject.toml` that pulls in a vulnerable transitive dep into the image — same logic.
- Future edits to `docker.yml` itself: the workflow validates itself on every PR that changes it, so the "PR #135 introduces a broken gate" failure mode can't recur.

## What this does NOT change

- **Push-to-`main` behavior is identical**: build → scan → SARIF upload → push. Same artifacts, same tags, same Code Scanning entries.
- The Trivy scan parameters (severity / ignore-unfixed / vuln-type / informational table-format step) are unchanged.
- No secrets exposure: PR runs use the same `GITHUB_TOKEN` GitHub already provides; nothing new is referenced.

## Scope carve-out (per `CLAUDE.md`)

CI-only change. No application code, no LLM call sites, no `SessionState` / turn-pump / submission-pipeline / `MessageKind` changes. **The six-agent review pipeline and scenario-replay rule do not apply** ("Phase-1 docs / CI / scaffolding work is exempt").

## Test plan

- [ ] On this PR's own CI: the Docker workflow runs (validating the change validates itself), the build + Trivy steps execute, and the Push step is **skipped** because `event_name == 'pull_request'`.
- [ ] No GHCR login attempt in the PR run logs.
- [ ] No new SARIF entries appear in Code Scanning from this PR run.
- [ ] After merge, the next push to `main` runs the workflow as before: full build → scan → SARIF upload → publish.
- [ ] Confirm a docs-only follow-up PR (e.g. README tweak) does **not** trigger the Docker workflow (paths filter working).
- [ ] Confirm a `backend/app/**` PR does trigger it.

https://claude.ai/code/session_01NJxSp8XAdtGVFqUmTXkQEH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJxSp8XAdtGVFqUmTXkQEH)_