### PR TITLE
frontend(deps-dev): bump eslint-plugin-react-refresh to 0.5.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "autoprefixer": "^10.4.19",
         "eslint": "^9.8.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-        "eslint-plugin-react-refresh": "^0.4.9",
+        "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^15.9.0",
         "jsdom": "^25.0.0",
         "postcss": "^8.4.40",
@@ -3061,13 +3061,13 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
-      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "eslint": ">=8.40"
+        "eslint": "^9 || ^10"
       }
     },
     "node_modules/eslint-scope": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,10 +39,11 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "autoprefixer": "^10.4.19",
     "eslint": "^9.8.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-    "eslint-plugin-react-refresh": "^0.4.9",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^15.9.0",
     "jsdom": "^25.0.0",
     "postcss": "^8.4.40",
@@ -50,8 +51,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.0.0",
     "vite": "^8.0.10",
-    "vitest": "^4.1.5",
-    "@vitest/coverage-v8": "^4.1.5"
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -2,7 +2,8 @@ import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
 import { api, type SessionSnapshot } from "../../api/client";
 import { Eyebrow } from "../brand/Eyebrow";
 import { StatusChip } from "../brand/StatusChip";
-import { WizardRail, type WizardStepId } from "./WizardRail";
+import { WizardRail } from "./WizardRail";
+import type { WizardStepId } from "./wizardSteps";
 
 /**
  * Pre-creation form state. Owned by ``Facilitator``; the wizard is a

--- a/frontend/src/components/setup/WizardRail.tsx
+++ b/frontend/src/components/setup/WizardRail.tsx
@@ -1,5 +1,6 @@
 import { confirmLeaveSession } from "../../lib/leaveGuard";
 import { Eyebrow } from "../brand/Eyebrow";
+import { WIZARD_STEPS, type WizardStepId } from "./wizardSteps";
 
 /**
  * Setup-wizard left rail. Six steps mapped to the brand mock:
@@ -27,17 +28,6 @@ import { Eyebrow } from "../brand/Eyebrow";
  * own children stay in column flow). At ``lg`` and up the rail
  * sits on the left as designed in the brand mock.
  */
-export const WIZARD_STEPS = [
-  { id: 1, name: "Scenario" },
-  { id: 2, name: "Environment" },
-  { id: 3, name: "Roles" },
-  { id: 4, name: "Injects & schedule" },
-  { id: 5, name: "Invite players" },
-  { id: 6, name: "Review & launch" },
-] as const;
-
-export type WizardStepId = (typeof WIZARD_STEPS)[number]["id"];
-
 interface Props {
   current: WizardStepId;
   /** Set of step ids the user has completed (rendered with a ✓). */

--- a/frontend/src/components/setup/wizardSteps.ts
+++ b/frontend/src/components/setup/wizardSteps.ts
@@ -1,0 +1,10 @@
+export const WIZARD_STEPS = [
+  { id: 1, name: "Scenario" },
+  { id: 2, name: "Environment" },
+  { id: 3, name: "Roles" },
+  { id: 4, name: "Injects & schedule" },
+  { id: 5, name: "Invite players" },
+  { id: 6, name: "Review & launch" },
+] as const;
+
+export type WizardStepId = (typeof WIZARD_STEPS)[number]["id"];


### PR DESCRIPTION
## Summary

- Bump `eslint-plugin-react-refresh` from 0.4.26 → 0.5.2 (subsumes dependabot PR #143).
- Extract `WIZARD_STEPS` / `WizardStepId` from `WizardRail.tsx` into a new sibling `wizardSteps.ts` so the file no longer mixes a component export with a non-primitive constant. The new react-refresh 0.5 rule flags that mix; `allowConstantExport` only exempts primitives, so the lift is required for `--max-warnings 0` to stay green.

## Why a hand-written PR

Dependabot's #143 only touches `package.json` + `package-lock.json`; the source-side fix has to land in the same commit so CI is green on the bump. Easier to author one PR than to hand-edit dependabot's branch.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 391/391 passing
- [x] `npm run build` — succeeds (chunk-size warning is pre-existing)

## Cleanup of the rest of the dependabot backlog

This session also merged the green dependabot PRs and closed the ones that need more work than a one-line rebase:

| PR | What | Disposition |
|---|---|---|
| #136 | devcontainer feature node 1 → 2 | merged |
| #137 | docker node 20 → 25 | merged |
| #141 | devcontainer python 3.12 → 3.14 | merged |
| #142 | docker python 3.12 → 3.14 | merged (pycrdt + pydantic-core both publish cp314 wheels) |
| #144 | typescript 5.9 → 6.0 | merged (CI green) |
| #146 | @vitejs/plugin-react 5 → 6 | merged (CI green; vite 8 peer satisfied) |
| #143 | eslint-plugin-react-refresh 0.4 → 0.5 | superseded by this PR; will close once this lands |
| #145 | react 18 → 19 + @types/react | closed — bump is incomplete (peer-dep ERESOLVE on `@types/react-dom`/`react-dom`); needs a coordinated React-19 migration, not a transitive auto-bump |
| #147 | eslint 9 → 10 | closed — `eslint-plugin-react-hooks@5.2.0` peer-deps cap at eslint 9; needs an ecosystem catch-up before retrying |

https://claude.ai/code/session_01LkUuKMh6Ro2JuTfH8n2AZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkUuKMh6Ro2JuTfH8n2AZe)_