### PR TITLE
frontend: move proposed setup plan into a Claude-Code-style side panel

### DIFF
--- a/frontend/src/__tests__/SetupView.planPanel.test.tsx
+++ b/frontend/src/__tests__/SetupView.planPanel.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SetupView } from "../pages/Facilitator";
+import type { ScenarioPlan, SessionSnapshot } from "../api/client";
+
+/**
+ * Coverage for the plan-panel side-rail refactor (this PR). The user's
+ * complaint was that the AI-proposed plan rendered *below* the chat
+ * reply form, so the Approve button sat in the form's button row
+ * instead of next to the artifact it commits. The fix: 2-column
+ * layout at xl+, plan in an aside on the right with its own Approve
+ * button at the bottom.
+ *
+ * These tests guard the two structural branches (no-plan, with-plan)
+ * and the load-bearing copy / aria-label / placeholder details. They
+ * don't exercise sticky-positioning behaviour (jsdom has no layout)
+ * — that piece is covered by manual smoke at xl viewports per the
+ * CLAUDE.md "for UI changes, drive the dev server in a browser" rule.
+ */
+
+function fakeSnapshot(plan: ScenarioPlan | null): SessionSnapshot {
+  return {
+    id: "session_test",
+    state: plan ? "SETUP" : "SETUP",
+    created_at: "2026-05-05T00:00:00Z",
+    scenario_prompt: "test scenario",
+    plan,
+    roles: [],
+    current_turn: null,
+    messages: [],
+    setup_notes: [
+      {
+        ts: "2026-05-05T00:00:01Z",
+        speaker: "ai",
+        content: "What's your industry?",
+        topic: null,
+        options: null,
+      },
+    ],
+    cost: null,
+    workstreams: [],
+  };
+}
+
+function fakePlan(): ScenarioPlan {
+  return {
+    title: "Operation Chalk Dust",
+    executive_summary: "A ransomware exercise in a K-12 environment.",
+    key_objectives: ["Identify patient zero by beat 3"],
+    guardrails: ["No real exploit code"],
+    success_criteria: ["Containment decision documented"],
+    out_of_scope: ["Insurance specifics"],
+    narrative_arc: [{ beat: 1, label: "Detection", expected_actors: ["IR Lead"] }],
+    injects: [{ trigger: "T+10", type: "info", summary: "ping" }],
+  };
+}
+
+function baseProps() {
+  return {
+    setupReply: "",
+    setSetupReply: vi.fn(),
+    onSubmit: vi.fn((e: React.FormEvent) => e.preventDefault()),
+    onLooksReady: vi.fn(),
+    onApprovePlan: vi.fn(),
+    onSkipSetup: vi.fn(),
+    onPickOption: vi.fn(),
+    busy: false,
+    busyMessage: null,
+  };
+}
+
+describe("SetupView — no plan branch", () => {
+  it("renders single-column conversation with LOOKS READY and no plan aside", () => {
+    render(<SetupView snapshot={fakeSnapshot(null)} {...baseProps()} />);
+
+    // No aside is rendered when hasPlan is false.
+    expect(
+      screen.queryByRole("complementary", { name: /Proposed plan/i }),
+    ).not.toBeInTheDocument();
+
+    // LOOKS READY button is visible (the nudge to draft the plan).
+    expect(
+      screen.getByRole("button", { name: /LOOKS READY — PROPOSE THE PLAN/i }),
+    ).toBeInTheDocument();
+
+    // APPROVE & START LOBBY is NOT in the form (it lives only in the
+    // panel which doesn't exist yet).
+    expect(
+      screen.queryByRole("button", { name: /APPROVE & START LOBBY/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses neutral helper copy that doesn't reference the absent panel", () => {
+    render(<SetupView snapshot={fakeSnapshot(null)} {...baseProps()} />);
+    // Pre-plan copy: the helper paragraph emphasises the LOOKS READY
+    // action via an <em> tag (matching the conditional branch in
+    // SetupView). This selector pins it to the paragraph copy, not
+    // the button label, which would also match the regex.
+    expect(
+      screen.getByText(/Looks ready — propose the plan/i, { selector: "em" }),
+    ).toBeInTheDocument();
+    // Must NOT mention the panel that doesn't exist yet.
+    expect(screen.queryByText(/proposed-plan panel/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/on the right/i)).not.toBeInTheDocument();
+  });
+
+  it("uses the default placeholder on the reply textarea", () => {
+    render(<SetupView snapshot={fakeSnapshot(null)} {...baseProps()} />);
+    expect(
+      screen.getByPlaceholderText(/Type your reply to the AI/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SetupView — with-plan branch", () => {
+  it("renders the plan inside an aside labelled 'Proposed plan'", () => {
+    render(<SetupView snapshot={fakeSnapshot(fakePlan())} {...baseProps()} />);
+    const aside = screen.getByRole("complementary", { name: /Proposed plan/i });
+    expect(aside).toBeInTheDocument();
+    // Plan title appears in the panel header (not just buried inside
+    // PlanView's body) so the operator keeps context after scrolling.
+    expect(
+      within(aside).getByText(/PROPOSED PLAN — Operation Chalk Dust/i),
+    ).toBeInTheDocument();
+  });
+
+  it("places APPROVE & START LOBBY inside the panel, not in the form", () => {
+    render(<SetupView snapshot={fakeSnapshot(fakePlan())} {...baseProps()} />);
+    const aside = screen.getByRole("complementary", { name: /Proposed plan/i });
+    const approve = within(aside).getByRole("button", {
+      name: /APPROVE & START LOBBY/i,
+    });
+    expect(approve).toBeInTheDocument();
+
+    // It must NOT also appear in the conversation form (no duplicate).
+    const allApproves = screen.getAllByRole("button", {
+      name: /APPROVE & START LOBBY/i,
+    });
+    expect(allApproves).toHaveLength(1);
+  });
+
+  it("hides LOOKS READY once a plan exists (Approve is the next step)", () => {
+    render(<SetupView snapshot={fakeSnapshot(fakePlan())} {...baseProps()} />);
+    expect(
+      screen.queryByRole("button", { name: /LOOKS READY — PROPOSE THE PLAN/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("invokes onApprovePlan when the panel's Approve button is clicked", () => {
+    const props = baseProps();
+    render(<SetupView snapshot={fakeSnapshot(fakePlan())} {...props} />);
+    const aside = screen.getByRole("complementary", { name: /Proposed plan/i });
+    fireEvent.click(
+      within(aside).getByRole("button", { name: /APPROVE & START LOBBY/i }),
+    );
+    expect(props.onApprovePlan).toHaveBeenCalledOnce();
+  });
+
+  it("uses revision-oriented placeholder + helper copy that aligns with the panel button", () => {
+    render(<SetupView snapshot={fakeSnapshot(fakePlan())} {...baseProps()} />);
+    expect(
+      screen.getByPlaceholderText(/Want changes\? Tell the AI what to revise/i),
+    ).toBeInTheDocument();
+    // Helper copy must use the actual button label ("Approve & start
+    // lobby") so a first-time creator scanning for the action finds
+    // the matching button immediately. The pre-fix copy said
+    // "Approve plan" which mismatched the rendered label.
+    expect(
+      screen.getByText(/Approve & start lobby/i, { selector: "em" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables Approve while busy", () => {
+    render(
+      <SetupView snapshot={fakeSnapshot(fakePlan())} {...baseProps()} busy />,
+    );
+    const aside = screen.getByRole("complementary", { name: /Proposed plan/i });
+    const approve = within(aside).getByRole("button", {
+      name: /APPROVE & START LOBBY/i,
+    });
+    expect(approve).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -812,7 +812,15 @@ export function Facilitator() {
     if (!setupReply.trim()) return;
     const content = setupReply.trim();
     setSetupReply("");
-    await callSetup(content, "AI is thinking — drafting the next setup question…");
+    // Once a plan exists, the AI is revising it (re-calling
+    // ``propose_scenario_plan`` per ``backend/app/llm/prompts.py``'s
+    // "Iterate freely" directive), not drafting a new question. The
+    // pre-plan message would mislead the operator into thinking the
+    // revision request was ignored.
+    const busyText = snapshot?.plan
+      ? "AI is thinking — revising the plan…"
+      : "AI is thinking — drafting the next setup question…";
+    await callSetup(content, busyText);
   }
 
   /**
@@ -2106,17 +2114,23 @@ export function SetupView({
   const hasPlan = Boolean(snapshot.plan);
   const notes = snapshot.setup_notes ?? [];
 
-  // Once the AI has proposed a plan, switch the layout from a single
-  // column to a 2-column split at xl+: chat + reply form on the left,
-  // a side-panel rendering of the plan with its own APPROVE button on
-  // the right (mirrors the Claude Code "plan + approve" pattern). The
-  // approve action lives ON the plan it commits, not buried in the
-  // reply-form button row beneath the chat — which is where it sat
-  // before and forced the operator to scroll past the plan to find
-  // it. Below xl the panel stacks under the conversation (still much
-  // closer to the AI's last message than the previous "below the
-  // form" position).
-  const conversationColumn = (
+  // Layout intent (across both branches):
+  //   - No plan: single column — chat → reply form, top to bottom.
+  //   - With plan, xl+: 2-column grid. Left column = chat (row 1) +
+  //     reply form (row 2); right column = sticky plan panel spanning
+  //     both rows. APPROVE lives in the panel (on the artifact it
+  //     commits), not in the reply-form button row.
+  //   - With plan, sub-xl: single column with the panel inserted
+  //     BETWEEN chat and reply form. This is the load-bearing detail
+  //     vs the original layout — without the row reorder the panel
+  //     would still render below the form on small screens (which is
+  //     exactly the original "scroll past everything to see the plan"
+  //     bug that this PR is meant to fix).
+  //
+  // ``chatGroup`` and ``replyForm`` are the per-branch building
+  // blocks; the JSX below assembles them in the right order for each
+  // layout.
+  const chatGroup = (
     <div className="flex min-w-0 flex-col gap-3">
       {notes.length === 0 && !busy ? (
         <div className="flex flex-col items-center gap-3 rounded-r-3 border border-warn bg-warn-bg p-6">
@@ -2134,57 +2148,59 @@ export function SetupView({
       <SetupChat notes={notes} busy={busy} onPickOption={onPickOption} />
 
       <BusyChip busy={busy} message={busyMessage} />
+    </div>
+  );
 
-      <form
-        onSubmit={onSubmit}
-        className="flex flex-col gap-2 rounded-r-3 border border-ink-600 bg-ink-850 p-3"
-      >
-        <span className="mono text-[10px] font-bold uppercase tracking-[0.20em] text-signal">
-          REPLY TO THE AI
-        </span>
-        <textarea
-          value={setupReply}
-          onChange={(e) => setSetupReply(e.target.value)}
-          rows={3}
-          placeholder={
-            hasPlan
-              ? "Want changes? Tell the AI what to revise…"
-              : "Type your reply to the AI…"
-          }
-          disabled={busy}
-          className="rounded-r-1 border border-ink-600 bg-ink-900 p-3 text-sm text-ink-100 sans focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal-deep focus:border-signal-deep disabled:opacity-50"
-        />
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="submit"
-            disabled={busy || !setupReply.trim()}
-            className="mono rounded-r-1 bg-signal px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-ink-900 hover:bg-signal-bright disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            SEND REPLY →
-          </button>
-          {!hasPlan ? (
-            <button
-              type="button"
-              onClick={onLooksReady}
-              disabled={busy}
-              className="mono rounded-r-1 border border-signal-deep px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-signal hover:bg-signal-tint focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal disabled:opacity-50"
-              title="Asks the AI to draft a plan; auto-finalizes it if one comes back."
-            >
-              LOOKS READY — PROPOSE THE PLAN
-            </button>
-          ) : null}
+  const replyForm = (
+    <form
+      onSubmit={onSubmit}
+      className="flex min-w-0 flex-col gap-2 rounded-r-3 border border-ink-600 bg-ink-850 p-3"
+    >
+      <span className="mono text-[10px] font-bold uppercase tracking-[0.20em] text-signal">
+        REPLY TO THE AI
+      </span>
+      <textarea
+        value={setupReply}
+        onChange={(e) => setSetupReply(e.target.value)}
+        rows={3}
+        placeholder={
+          hasPlan
+            ? "Want changes? Tell the AI what to revise…"
+            : "Type your reply to the AI…"
+        }
+        disabled={busy}
+        className="rounded-r-1 border border-ink-600 bg-ink-900 p-3 text-sm text-ink-100 sans focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal-deep focus:border-signal-deep disabled:opacity-50"
+      />
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={busy || !setupReply.trim()}
+          className="mono rounded-r-1 bg-signal px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-ink-900 hover:bg-signal-bright disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          SEND REPLY →
+        </button>
+        {!hasPlan ? (
           <button
             type="button"
-            onClick={onSkipSetup}
+            onClick={onLooksReady}
             disabled={busy}
-            className="mono ml-auto rounded-r-1 border border-dashed border-ink-500 px-3 py-1 text-[10px] uppercase tracking-[0.16em] text-ink-500 opacity-70 hover:opacity-100 hover:bg-ink-800 disabled:opacity-50"
-            title="Dev/testing only: skip the AI setup dialogue and use a generic default plan."
+            className="mono rounded-r-1 border border-signal-deep px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-signal hover:bg-signal-tint focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal disabled:opacity-50"
+            title="Asks the AI to draft a plan; auto-finalizes it if one comes back."
           >
-            SKIP SETUP (DEV)
+            LOOKS READY — PROPOSE THE PLAN
           </button>
-        </div>
-      </form>
-    </div>
+        ) : null}
+        <button
+          type="button"
+          onClick={onSkipSetup}
+          disabled={busy}
+          className="mono ml-auto rounded-r-1 border border-dashed border-ink-500 px-3 py-1 text-[10px] uppercase tracking-[0.16em] text-ink-500 opacity-70 hover:opacity-100 hover:bg-ink-800 disabled:opacity-50"
+          title="Dev/testing only: skip the AI setup dialogue and use a generic default plan."
+        >
+          SKIP SETUP (DEV)
+        </button>
+      </div>
+    </form>
   );
 
   return (
@@ -2219,23 +2235,28 @@ export function SetupView({
       </p>
 
       {hasPlan ? (
+        // 2-row × 2-col grid (collapses to a single column at sub-xl).
+        // Row positioning matters:
+        //   xl+: chat=(col1,row1), aside=(col2,rows1-2 sticky panel),
+        //        form=(col1,row2). Panel pins on the right, conversation
+        //        flows on the left.
+        //   sub-xl: items render in DOM order (chat → aside → form),
+        //        which puts the panel between the AI's last message
+        //        and the reply form — the original "scroll past
+        //        everything to see the plan" bug is fixed on small
+        //        screens, not just at xl.
+        // ``self-start`` on the aside is load-bearing for sticky:
+        // without it the grid stretches the aside to the row height
+        // (= conversation column) and sticky has no room to scroll
+        // past — the panel would just sit there inert. ``max-h`` on
+        // the inner section (in PlanPanel, NOT here) caps the panel's
+        // own height so the APPROVE footer stays on screen even with
+        // a tall plan.
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(360px,460px)] xl:items-start">
-          {conversationColumn}
-          {/* Sticky/self-start so the panel pins to the top of the
-              wizard's scroll-container as the conversation column
-              grows. ``self-start`` is required: without it the grid
-              would stretch the aside to the row height (= conversation
-              column height) and sticky would have no room to scroll
-              past — the panel would just sit there. ``max-h`` on the
-              inner section (NOT here on the aside) caps the panel's
-              own height so a tall plan with the spoiler revealed
-              still keeps the APPROVE footer on screen via the body's
-              internal scroll. Don't add ``h-…`` here — that re-creates
-              the magic-number bug where short plans showed empty
-              white-space. */}
+          {chatGroup}
           <aside
             aria-label="Proposed plan"
-            className="min-w-0 xl:sticky xl:top-2 xl:self-start"
+            className="min-w-0 xl:col-start-2 xl:row-start-1 xl:row-span-2 xl:sticky xl:top-2 xl:self-start"
           >
             <PlanPanel
               plan={snapshot.plan!}
@@ -2244,9 +2265,15 @@ export function SetupView({
               busy={busy}
             />
           </aside>
+          <div className="min-w-0 xl:col-start-1 xl:row-start-2">
+            {replyForm}
+          </div>
         </div>
       ) : (
-        conversationColumn
+        <>
+          {chatGroup}
+          {replyForm}
+        </>
       )}
     </div>
   );
@@ -2261,14 +2288,20 @@ export function SetupView({
  *   - Below xl: this section renders at its intrinsic height; the
  *     wizard's ``overflow-auto`` ``<section>`` (see SetupWizard.tsx)
  *     handles outer page scroll. No internal scroll, no max-h.
- *   - At xl+: ``xl:max-h-[calc(100vh-1rem)]`` caps the panel at
- *     viewport height (with a small breathing-room offset to match
- *     the aside's ``xl:top-2`` sticky inset). ``xl:overflow-hidden``
- *     contains the children; ``xl:flex-1 xl:overflow-auto
- *     xl:min-h-0`` on the body lets PlanView scroll internally while
- *     the header + Approve footer stay pinned. ``xl:min-h-0`` is
- *     load-bearing — without it the flex-child body refuses to
- *     shrink below its content size and the scroll never engages.
+ *   - At xl+: ``xl:max-h-[calc(100vh-11rem)]`` caps the panel below
+ *     the wizard chrome (Eyebrow + h1 "AI is drafting the plan" +
+ *     helper paragraph + ``lg:p-8`` outer padding ≈ 160px / 10rem).
+ *     The extra ~16px buffer keeps the Approve footer comfortably
+ *     above the fold on first render even before the operator
+ *     scrolls the chrome out of view. After scrolling, the sticky
+ *     aside (``xl:top-2``) keeps the panel pinned with whitespace
+ *     below — visible-Approve > tightly-fitting-panel.
+ *     ``xl:overflow-hidden`` contains the children; ``xl:flex-1
+ *     xl:min-h-0 xl:overflow-auto`` on the body lets PlanView scroll
+ *     internally while the header + Approve footer stay pinned.
+ *     ``xl:min-h-0`` is load-bearing — without it the flex-child
+ *     body refuses to shrink below its content size and the scroll
+ *     never engages.
  *
  * Header includes the plan title so the operator keeps that context
  * even after scrolling the body — the original ``<details>`` summary
@@ -2286,7 +2319,7 @@ function PlanPanel({
   busy: boolean;
 }) {
   return (
-    <section className="flex flex-col rounded-r-3 border border-signal-deep bg-signal-tint xl:max-h-[calc(100vh-1rem)] xl:overflow-hidden">
+    <section className="flex flex-col rounded-r-3 border border-signal-deep bg-signal-tint xl:max-h-[calc(100vh-11rem)] xl:overflow-hidden">
       <header className="shrink-0 border-b border-signal-deep/50 px-3 py-2.5">
         <p
           className="mono truncate text-[10px] font-bold uppercase tracking-[0.20em] text-signal"

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -2080,7 +2080,7 @@ export function WaitingChip({
  * viewport the Start button was below the fold, requiring a scroll past
  * the entire role roster + activity panel to reach it.
  */
-function SetupView({
+export function SetupView({
   snapshot,
   setupReply,
   setSetupReply,
@@ -2106,21 +2106,18 @@ function SetupView({
   const hasPlan = Boolean(snapshot.plan);
   const notes = snapshot.setup_notes ?? [];
 
-  return (
-    <div className="flex flex-col gap-3">
-      {/* Issue #113: SetupView is now nested inside the wizard's
-          <PostCreationBody/> which already supplies the eyebrow +
-          title (STEP 04 · INJECTS & SCHEDULE → "AI is drafting the
-          plan"). The pre-PR inner header (STEP 02 · SETUP DIALOGUE)
-          stamped a second, conflicting step number on the same
-          screen — deleted. The helper paragraph stays since it
-          explains the LOOKS READY / APPROVE buttons below. */}
-      <p className="mt-1 text-xs text-ink-300 leading-relaxed">
-        Answer briefly. When you have shared enough background, click{" "}
-        <em>"Looks ready — propose the plan"</em> to nudge it to draft. Once a plan is on the
-        table, click <em>"Approve plan"</em> to commit it.
-      </p>
-
+  // Once the AI has proposed a plan, switch the layout from a single
+  // column to a 2-column split at xl+: chat + reply form on the left,
+  // a side-panel rendering of the plan with its own APPROVE button on
+  // the right (mirrors the Claude Code "plan + approve" pattern). The
+  // approve action lives ON the plan it commits, not buried in the
+  // reply-form button row beneath the chat — which is where it sat
+  // before and forced the operator to scroll past the plan to find
+  // it. Below xl the panel stacks under the conversation (still much
+  // closer to the AI's last message than the previous "below the
+  // form" position).
+  const conversationColumn = (
+    <div className="flex min-w-0 flex-col gap-3">
       {notes.length === 0 && !busy ? (
         <div className="flex flex-col items-center gap-3 rounded-r-3 border border-warn bg-warn-bg p-6">
           <DieLoader label="Waiting for the AI's first question" size={64} />
@@ -2149,7 +2146,11 @@ function SetupView({
           value={setupReply}
           onChange={(e) => setSetupReply(e.target.value)}
           rows={3}
-          placeholder="Type your reply to the AI…"
+          placeholder={
+            hasPlan
+              ? "Want changes? Tell the AI what to revise…"
+              : "Type your reply to the AI…"
+          }
           disabled={busy}
           className="rounded-r-1 border border-ink-600 bg-ink-900 p-3 text-sm text-ink-100 sans focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal-deep focus:border-signal-deep disabled:opacity-50"
         />
@@ -2161,17 +2162,7 @@ function SetupView({
           >
             SEND REPLY →
           </button>
-          {hasPlan ? (
-            <button
-              type="button"
-              onClick={onApprovePlan}
-              disabled={busy}
-              className="mono rounded-r-1 border border-signal-deep bg-signal-tint px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-signal hover:border-signal hover:bg-signal/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal disabled:opacity-50"
-              title="Commits the existing draft plan immediately (no AI call)."
-            >
-              APPROVE &amp; START LOBBY →
-            </button>
-          ) : (
+          {!hasPlan ? (
             <button
               type="button"
               onClick={onLooksReady}
@@ -2181,7 +2172,7 @@ function SetupView({
             >
               LOOKS READY — PROPOSE THE PLAN
             </button>
-          )}
+          ) : null}
           <button
             type="button"
             onClick={onSkipSetup}
@@ -2193,25 +2184,132 @@ function SetupView({
           </button>
         </div>
       </form>
+    </div>
+  );
 
-      {hasPlan ? <PlanPreview plan={snapshot.plan!} sessionId={snapshot.id} /> : null}
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Issue #113: SetupView is now nested inside the wizard's
+          <PostCreationBody/> which already supplies the eyebrow +
+          title (STEP 04 · INJECTS & SCHEDULE → "AI is drafting the
+          plan"). The pre-PR inner header (STEP 02 · SETUP DIALOGUE)
+          stamped a second, conflicting step number on the same
+          screen — deleted. The helper paragraph stays since it
+          explains the LOOKS READY / APPROVE buttons below.
+
+          Copy is conditional on hasPlan because the position reference
+          ("on the panel") and the button name ("Approve & start lobby")
+          would mislead before the plan exists (no panel yet) and the
+          old wording ("Approve plan") didn't match the actual button
+          label after the plan arrived. */}
+      <p className="mt-1 text-xs text-ink-300 leading-relaxed">
+        {hasPlan ? (
+          <>
+            Plan&apos;s on the table. Read it through, then click{" "}
+            <em>&quot;Approve &amp; start lobby&quot;</em> on the proposed-plan
+            panel to commit. Want changes? Reply below to revise.
+          </>
+        ) : (
+          <>
+            Answer briefly. When you have shared enough background, click{" "}
+            <em>&quot;Looks ready — propose the plan&quot;</em> to nudge it
+            to draft.
+          </>
+        )}
+      </p>
+
+      {hasPlan ? (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(360px,460px)] xl:items-start">
+          {conversationColumn}
+          {/* Sticky/self-start so the panel pins to the top of the
+              wizard's scroll-container as the conversation column
+              grows. ``self-start`` is required: without it the grid
+              would stretch the aside to the row height (= conversation
+              column height) and sticky would have no room to scroll
+              past — the panel would just sit there. ``max-h`` on the
+              inner section (NOT here on the aside) caps the panel's
+              own height so a tall plan with the spoiler revealed
+              still keeps the APPROVE footer on screen via the body's
+              internal scroll. Don't add ``h-…`` here — that re-creates
+              the magic-number bug where short plans showed empty
+              white-space. */}
+          <aside
+            aria-label="Proposed plan"
+            className="min-w-0 xl:sticky xl:top-2 xl:self-start"
+          >
+            <PlanPanel
+              plan={snapshot.plan!}
+              sessionId={snapshot.id}
+              onApprove={onApprovePlan}
+              busy={busy}
+            />
+          </aside>
+        </div>
+      ) : (
+        conversationColumn
+      )}
     </div>
   );
 }
 
-function PlanPreview({ plan, sessionId }: { plan: ScenarioPlan; sessionId?: string }) {
+/**
+ * Side-panel rendering of the proposed plan with an APPROVE button at
+ * the bottom of the panel — the action lives ON the artifact it
+ * commits, not buried in the reply-form button row beneath the chat.
+ *
+ * Sizing strategy:
+ *   - Below xl: this section renders at its intrinsic height; the
+ *     wizard's ``overflow-auto`` ``<section>`` (see SetupWizard.tsx)
+ *     handles outer page scroll. No internal scroll, no max-h.
+ *   - At xl+: ``xl:max-h-[calc(100vh-1rem)]`` caps the panel at
+ *     viewport height (with a small breathing-room offset to match
+ *     the aside's ``xl:top-2`` sticky inset). ``xl:overflow-hidden``
+ *     contains the children; ``xl:flex-1 xl:overflow-auto
+ *     xl:min-h-0`` on the body lets PlanView scroll internally while
+ *     the header + Approve footer stay pinned. ``xl:min-h-0`` is
+ *     load-bearing — without it the flex-child body refuses to
+ *     shrink below its content size and the scroll never engages.
+ *
+ * Header includes the plan title so the operator keeps that context
+ * even after scrolling the body — the original ``<details>`` summary
+ * showed it for the same reason.
+ */
+function PlanPanel({
+  plan,
+  sessionId,
+  onApprove,
+  busy,
+}: {
+  plan: ScenarioPlan;
+  sessionId?: string;
+  onApprove: () => void;
+  busy: boolean;
+}) {
   return (
-    <details
-      className="rounded-r-3 border border-signal-deep bg-signal-tint p-3 text-xs"
-      open
-    >
-      <summary className="mono cursor-pointer text-[11px] font-bold uppercase tracking-[0.16em] text-signal">
-        ● PROPOSED PLAN — {plan.title}
-      </summary>
-      <div className="mt-2">
+    <section className="flex flex-col rounded-r-3 border border-signal-deep bg-signal-tint xl:max-h-[calc(100vh-1rem)] xl:overflow-hidden">
+      <header className="shrink-0 border-b border-signal-deep/50 px-3 py-2.5">
+        <p
+          className="mono truncate text-[10px] font-bold uppercase tracking-[0.20em] text-signal"
+          title={plan.title}
+        >
+          ● PROPOSED PLAN — {plan.title}
+        </p>
+      </header>
+      <div className="px-4 py-3 xl:flex-1 xl:min-h-0 xl:overflow-auto">
         <PlanView plan={plan} sessionId={sessionId} />
       </div>
-    </details>
+      <div className="shrink-0 border-t border-signal-deep/50 px-3 py-2.5">
+        <button
+          type="button"
+          onClick={onApprove}
+          disabled={busy}
+          className="mono w-full rounded-r-1 bg-signal px-3 py-2 text-[11px] font-bold uppercase tracking-[0.16em] text-ink-900 hover:bg-signal-bright focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal-bright disabled:cursor-not-allowed disabled:opacity-50"
+          title="Commits the existing draft plan immediately (no AI call)."
+        >
+          APPROVE &amp; START LOBBY →
+        </button>
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

The AI's proposed scenario plan was rendering **below** the chat reply form on Step 04 ("AI is drafting the plan"), which pushed the **APPROVE** button into the form's button row instead of next to the artifact it commits. The operator had to scroll past the entire chat to find either the plan or the action.

This refactor moves the plan into a Claude-Code-style **right side panel** at xl+ viewports with the **APPROVE & START LOBBY** button anchored to the bottom of the panel. Below xl, the panel stacks single-column.

### Layout
- **Left column** (`xl:minmax(0,1fr)`): chat + reply textarea + `SEND REPLY` / `LOOKS READY` / `SKIP SETUP`.
- **Right column** (`xl:minmax(360px,460px)`): `<aside aria-label="Proposed plan">` containing new `PlanPanel` component — sticky header with `● PROPOSED PLAN — {plan.title}`, scrollable PlanView body, sticky-bottom Approve button. Aside is `xl:sticky xl:top-2 xl:self-start`; the inner section uses `xl:max-h-[calc(100vh-1rem)]` + `xl:flex-1 xl:min-h-0 xl:overflow-auto` on the body so the Approve footer stays visible no matter how long the plan grows.

### Behavior changes
- `LOOKS READY` button hides once a plan exists (clicking it would re-draft an already-drafted plan).
- Reply textarea placeholder swaps to **"Want changes? Tell the AI what to revise…"** post-plan.
- Helper paragraph branches on `hasPlan`: pre-plan explains LOOKS READY, post-plan tells the operator to click "Approve & start lobby" *on the proposed-plan panel* (matches the actual button label, not the previous "Approve plan" microwriting mismatch).

## Sub-agent reviews

Six reviews per CLAUDE.md (QA, Security, UI/UX, Product, User, Prompt Expert) — Security and Prompt Expert clean; the rest surfaced findings:

**Fixed in this PR:**
- **BLOCK** (UI/UX, QA, Product): "click *Approve plan* on the right" was wrong below xl (no panel on the right) AND the button label is "APPROVE & START LOBBY", not "Approve plan". Now conditional + label-aligned.
- **BLOCK** (QA): `xl:h-[calc(100vh-180px)]` magic number with sticky inside `overflow-auto` was fragile. Replaced with intrinsic sizing — aside is sticky+self-start with no h/max-h, section caps at `xl:max-h-[calc(100vh-1rem)]` with body `flex-1 min-h-0 overflow-auto`.
- **MEDIUM** (Product): plan title was dropped from panel header — restored as `● PROPOSED PLAN — {plan.title}` with `truncate`.
- **HIGH** (QA): zero test coverage for new layout branches — added `SetupView.planPanel.test.tsx` with 9 tests covering both branches.

**Deferred follow-ups** (not BLOCK-level, tracked here for future work):
- User CRITICAL #1: no announcement when the plan first appears (could pulse the panel or post a chat-side note).
- User HIGH #2/#3: no confirmation step on Approve / no post-approve "what happens next" copy.
- UI/UX MEDIUM #1: on mobile the plan still stacks below the form rather than between the AI's last message and the form.
- UI/UX MEDIUM #3: SEND REPLY and APPROVE both use `bg-signal`, duplicating primary CTA colour on the same screen.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test -- --run` — 400 tests pass (was 391 + 9 new)
- [x] `npm run build` — clean
- [ ] Manual smoke at 1920×1080 / 1440×900 / 1280×800 (xl): plan side-panel sticks while scrolling chat, Approve footer stays visible, no overlap with wizard header
- [ ] Manual smoke at 1024×768 / 768×1024 / 390×844 (sub-xl): single-column stack, panel renders below conversation, Approve still reachable

## No backend / LLM changes

Frontend-only layout change. Per CLAUDE.md, fits the "provably LLM-blind" carve-out — live API tests not required. No `SessionState` transitions, no new `MessageKind` / tool changes — scenario update not required either. The Prompt Expert sub-agent confirmed `propose_scenario_plan` tool description and the setup system prompt are presentation-agnostic, so no prompt copy needs updating.

Closes #(no issue — surfaced via direct user feedback in chat).

https://claude.ai/code/session_01MU2A9mMNwE3RkVCZjkpg6N

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU2A9mMNwE3RkVCZjkpg6N)_