### PR TITLE
backend: @-back the asker on AI replies to @facilitator mentions

### DIFF
--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -1060,16 +1060,20 @@ class TurnDriver:
         *,
         result_text: str,
     ) -> None:
+        # Capture freeform AI text (no tool wrapped it). Built here
+        # but appended below so the @-back auto-tag can reach it
+        # alongside the dispatcher's tool-emitted AI_TEXT messages.
+        # Without this ordering, freeform AI text would land
+        # untagged even when it answers an in-turn ``@facilitator``
+        # asker — caught in PR #184 review (Copilot).
+        freeform_ai_text: Message | None = None
         if result_text and not any(
             m.kind == MessageKind.AI_TEXT and m.tool_name is None for m in outcome.appended_messages
         ):
-            # Capture freeform AI text if no tool already captured it
-            session.messages.append(
-                Message(
-                    kind=MessageKind.AI_TEXT,
-                    body=result_text,
-                    turn_id=turn.id,
-                )
+            freeform_ai_text = Message(
+                kind=MessageKind.AI_TEXT,
+                body=result_text,
+                turn_id=turn.id,
             )
 
         # Same @-back behaviour as ``run_interject``: when a player
@@ -1101,9 +1105,13 @@ class TurnDriver:
                 seen.add(prior.role_id)
         if in_turn_facilitator_askers:
             tagged = 0
-            for msg in outcome.appended_messages:
-                if msg.kind != MessageKind.AI_TEXT:
-                    continue
+            ai_text_messages: list[Message] = [
+                m for m in outcome.appended_messages
+                if m.kind == MessageKind.AI_TEXT
+            ]
+            if freeform_ai_text is not None:
+                ai_text_messages.append(freeform_ai_text)
+            for msg in ai_text_messages:
                 for asker_id in in_turn_facilitator_askers:
                     if asker_id not in msg.mentions:
                         msg.mentions.append(asker_id)
@@ -1116,6 +1124,12 @@ class TurnDriver:
                     askers=list(in_turn_facilitator_askers),
                     tagged_count=tagged,
                 )
+
+        # Persist the freeform AI_TEXT (if any) before the
+        # tool-emitted messages so the transcript order remains
+        # ``freeform → tools``, matching the original implementation.
+        if freeform_ai_text is not None:
+            session.messages.append(freeform_ai_text)
 
         for msg in outcome.appended_messages:
             session.messages.append(msg)

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -851,6 +851,30 @@ class TurnDriver:
                     max_per_5_turns=self._manager.settings().max_critical_injects_per_5_turns,
                 ),
             )
+            # When a player @s the AI, the AI should @ them back. The
+            # frontend's @-highlight reads ``Message.mentions`` (never
+            # regex-scans the body), so prose like "CISO — got it" arrives
+            # without a structural mention and the asker sees no @YOU
+            # badge. ``address_role`` / ``pose_choice`` already auto-tag,
+            # but ``broadcast`` / ``share_data`` (the common interject
+            # replies) don't — auto-append the asker here so every
+            # interject reply highlights for the player who triggered it.
+            if for_role_id and session.role_by_id(for_role_id) is not None:
+                tagged = 0
+                for msg in outcome.appended_messages:
+                    if msg.kind != MessageKind.AI_TEXT:
+                        continue
+                    if for_role_id not in msg.mentions:
+                        msg.mentions.append(for_role_id)
+                        tagged += 1
+                if tagged:
+                    _logger.info(
+                        "interject_reply_tagged",
+                        session_id=session.id,
+                        turn_index=turn.index,
+                        for_role_id=for_role_id,
+                        tagged_count=tagged,
+                    )
             # Persist appended messages but do NOT touch turn state — the
             # interject is purely additive content.
             for msg in outcome.appended_messages:
@@ -1047,6 +1071,51 @@ class TurnDriver:
                     turn_id=turn.id,
                 )
             )
+
+        # Same @-back behaviour as ``run_interject``: when a player
+        # submitted an in-turn ``@facilitator`` ask AND that submission
+        # closed the quorum (so we landed in the regular play-turn
+        # path instead of the interject side-channel), the AI's reply
+        # should @ the asker so the frontend's @YOU badge fires. The
+        # interject path already handles the side-channel case
+        # (run_interject auto-tags); this block covers the
+        # quorum-closes-immediately branch the WS handler routes via
+        # ``run_play_turn``. Skipping ``is_interjection=True`` messages
+        # avoids re-tagging an asker who already received an interject
+        # reply earlier in the turn.
+        from .submission_pipeline import FACILITATOR_MENTION_TOKEN
+
+        in_turn_facilitator_askers: list[str] = []
+        seen: set[str] = set()
+        for prior in session.messages:
+            if prior.turn_id != turn.id:
+                continue
+            if prior.kind != MessageKind.PLAYER:
+                continue
+            if prior.is_interjection:
+                continue
+            if FACILITATOR_MENTION_TOKEN not in prior.mentions:
+                continue
+            if prior.role_id and prior.role_id not in seen:
+                in_turn_facilitator_askers.append(prior.role_id)
+                seen.add(prior.role_id)
+        if in_turn_facilitator_askers:
+            tagged = 0
+            for msg in outcome.appended_messages:
+                if msg.kind != MessageKind.AI_TEXT:
+                    continue
+                for asker_id in in_turn_facilitator_askers:
+                    if asker_id not in msg.mentions:
+                        msg.mentions.append(asker_id)
+                        tagged += 1
+            if tagged:
+                _logger.info(
+                    "play_turn_reply_tagged",
+                    session_id=session.id,
+                    turn_index=turn.index,
+                    askers=list(in_turn_facilitator_askers),
+                    tagged_count=tagged,
+                )
 
         for msg in outcome.appended_messages:
             session.messages.append(msg)

--- a/backend/tests/test_composer_mentions_routing.py
+++ b/backend/tests/test_composer_mentions_routing.py
@@ -730,6 +730,510 @@ def test_ws_routing_combined_role_and_facilitator_fires_interject(
 
 
 # -----------------------------------------------------------------------
+# Interject reply auto-tagging: when a player @s the AI, the AI's
+# reply should @ them back so the @YOU badge fires on the asker's
+# bubble. ``address_role`` / ``pose_choice`` already auto-tag mentions
+# from their ``role_id`` arg; ``broadcast`` / ``share_data`` (the
+# common interject reply tools) used to land with empty mentions, so
+# the asker saw a fresh AI message with no signal it was for them.
+# -----------------------------------------------------------------------
+
+
+def test_interject_broadcast_reply_tags_asker_mention(
+    client: TestClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When a player @s the facilitator and the AI replies via
+    ``broadcast``, the resulting AI message's ``mentions`` must
+    include the asker's role_id so the frontend lights the @YOU
+    badge on the asker's bubble. Also asserts the
+    ``interject_reply_tagged`` audit line — without it an operator
+    can't tell from logs whether the auto-tag ran on a stuck
+    session."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    capsys.readouterr()  # discard setup-time logs
+    interject = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="broadcast",
+                input={"message": "CISO — pulling Defender now."},
+                id="tu_b",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [interject]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    creator_token = client.app.state.authn.mint(
+        session_id=seats["session_id"],
+        role_id=seats["creator_id"],
+        kind="creator",
+        version=0,
+    )
+    with client.websocket_connect(
+        f"/ws/sessions/{seats['session_id']}?token={creator_token}"
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "submit_response",
+                "content": "@facilitator any new IOCs?",
+                "intent": "discuss",
+                "mentions": [FACILITATOR_MENTION_TOKEN],
+            }
+        )
+        for _ in range(8):
+            try:
+                ws.receive_json(mode="text", timeout=2.0)
+            except Exception:
+                break
+
+    lines = _structlog_lines(capsys)
+    session = asyncio.run(
+        client.app.state.manager.get_session(seats["session_id"])
+    )
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "broadcast"
+    )
+    assert ai_msg.mentions == [seats["creator_id"]], (
+        "broadcast interject reply must tag the asker's role_id in "
+        f"mentions; got {ai_msg.mentions!r}"
+    )
+    tag_lines = [
+        line for line in lines if line.get("event") == "interject_reply_tagged"
+    ]
+    assert tag_lines, (
+        "interject_reply_tagged audit line missing — operators rely on "
+        "it to debug @-back regressions; got events: "
+        f"{[line.get('event') for line in lines]}"
+    )
+    tag = tag_lines[-1]
+    assert tag["for_role_id"] == seats["creator_id"]
+    assert tag["tagged_count"] == 1
+
+
+def test_interject_share_data_reply_tags_asker_mention(
+    client: TestClient,
+) -> None:
+    """``share_data`` is the interject reply for "show me the logs /
+    IOCs / telemetry" asks (the screenshot bug). It currently lands
+    without structural mentions, so the asker sees a Defender table
+    drop in with no @YOU signal. Auto-tagging fixes that."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    interject = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="share_data",
+                input={
+                    "label": "Defender Telemetry — FS-01",
+                    "data": "07:14 AM — Unusual auth event\n07:17 AM — chkdst.exe written",
+                },
+                id="tu_sd",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [interject]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    creator_token = client.app.state.authn.mint(
+        session_id=seats["session_id"],
+        role_id=seats["creator_id"],
+        kind="creator",
+        version=0,
+    )
+    with client.websocket_connect(
+        f"/ws/sessions/{seats['session_id']}?token={creator_token}"
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "submit_response",
+                "content": "@facilitator show me the IOCs for FS-01",
+                "intent": "discuss",
+                "mentions": [FACILITATOR_MENTION_TOKEN],
+            }
+        )
+        for _ in range(8):
+            try:
+                ws.receive_json(mode="text", timeout=2.0)
+            except Exception:
+                break
+
+    session = asyncio.run(
+        client.app.state.manager.get_session(seats["session_id"])
+    )
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "share_data"
+    )
+    assert ai_msg.mentions == [seats["creator_id"]], (
+        "share_data interject reply must tag the asker's role_id in "
+        f"mentions; got {ai_msg.mentions!r}"
+    )
+
+
+def test_interject_address_role_reply_does_not_duplicate_asker_mention(
+    client: TestClient,
+) -> None:
+    """When the AI replies to the asker via ``address_role`` with the
+    asker's role_id, the dispatcher already sets
+    ``mentions=[asker_id]``. The interject auto-tag must NOT append a
+    duplicate entry — exactly one occurrence."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    interject = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="address_role",
+                input={
+                    "role_id": seats["creator_id"],
+                    "message": "no new IOCs since 07:42.",
+                },
+                id="tu_ar",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [interject]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    creator_token = client.app.state.authn.mint(
+        session_id=seats["session_id"],
+        role_id=seats["creator_id"],
+        kind="creator",
+        version=0,
+    )
+    with client.websocket_connect(
+        f"/ws/sessions/{seats['session_id']}?token={creator_token}"
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "submit_response",
+                "content": "@facilitator status?",
+                "intent": "discuss",
+                "mentions": [FACILITATOR_MENTION_TOKEN],
+            }
+        )
+        for _ in range(8):
+            try:
+                ws.receive_json(mode="text", timeout=2.0)
+            except Exception:
+                break
+
+    session = asyncio.run(
+        client.app.state.manager.get_session(seats["session_id"])
+    )
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "address_role"
+    )
+    assert ai_msg.mentions == [seats["creator_id"]], (
+        "address_role to the asker must not produce a duplicate "
+        f"mention entry; got {ai_msg.mentions!r}"
+    )
+
+
+def test_interject_address_role_to_other_role_appends_asker_mention(
+    client: TestClient,
+) -> None:
+    """When the AI uses ``address_role`` to redirect the asker's
+    question to a different role (e.g. CISO @s `@facilitator`, AI
+    routes the operational ask to SOC), both the redirect target AND
+    the asker should appear in ``mentions[]`` so:
+      - SOC sees @YOU on their bubble (existing dispatch behavior)
+      - CISO sees @YOU on their bubble (new auto-tag behavior)
+    Order: dispatcher's `[target_id]` first, then the asker appended."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    interject = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="address_role",
+                input={
+                    "role_id": seats["soc_id"],
+                    "message": "Bo — pull the egress trace and report.",
+                },
+                id="tu_ar_soc",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [interject]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    creator_token = client.app.state.authn.mint(
+        session_id=seats["session_id"],
+        role_id=seats["creator_id"],
+        kind="creator",
+        version=0,
+    )
+    with client.websocket_connect(
+        f"/ws/sessions/{seats['session_id']}?token={creator_token}"
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "submit_response",
+                "content": "@facilitator who handles egress?",
+                "intent": "discuss",
+                "mentions": [FACILITATOR_MENTION_TOKEN],
+            }
+        )
+        for _ in range(8):
+            try:
+                ws.receive_json(mode="text", timeout=2.0)
+            except Exception:
+                break
+
+    session = asyncio.run(
+        client.app.state.manager.get_session(seats["session_id"])
+    )
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "address_role"
+    )
+    assert ai_msg.mentions == [seats["soc_id"], seats["creator_id"]], (
+        "address_role to a non-asker target must include both target "
+        f"and asker in mentions; got {ai_msg.mentions!r}"
+    )
+
+
+def test_interject_pose_choice_reply_tags_asker_mention(
+    client: TestClient,
+) -> None:
+    """``pose_choice`` is one of the four interject reply tools
+    (turn_driver.py:828). When the AI poses a structured 2-choice
+    fork to the asker, the dispatcher already tags the target;
+    when it poses to a non-asker, the auto-tag must append the
+    asker so they still see @YOU."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    interject = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="pose_choice",
+                input={
+                    "role_id": seats["soc_id"],
+                    "question": "How aggressive should we go on egress block?",
+                    "options": ["Block all outbound", "Block to known C2 only"],
+                },
+                id="tu_pc",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [interject]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    creator_token = client.app.state.authn.mint(
+        session_id=seats["session_id"],
+        role_id=seats["creator_id"],
+        kind="creator",
+        version=0,
+    )
+    with client.websocket_connect(
+        f"/ws/sessions/{seats['session_id']}?token={creator_token}"
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "submit_response",
+                "content": "@facilitator should we block egress?",
+                "intent": "discuss",
+                "mentions": [FACILITATOR_MENTION_TOKEN],
+            }
+        )
+        for _ in range(8):
+            try:
+                ws.receive_json(mode="text", timeout=2.0)
+            except Exception:
+                break
+
+    session = asyncio.run(
+        client.app.state.manager.get_session(seats["session_id"])
+    )
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "pose_choice"
+    )
+    assert ai_msg.mentions == [seats["soc_id"], seats["creator_id"]], (
+        "pose_choice interject reply to a non-asker must include both "
+        f"target and asker in mentions; got {ai_msg.mentions!r}"
+    )
+
+
+def test_interject_with_no_asker_does_not_tag_mentions(
+    client: TestClient,
+) -> None:
+    """Defensive: ``run_interject`` accepts ``for_role_id: str | None``
+    (turn_driver.py:719). The auto-tag is gated on a truthy
+    ``for_role_id`` AND a real role lookup. Direct-call this path
+    with ``for_role_id=None`` and assert the AI's broadcast reply
+    has empty ``mentions`` (no spurious tagging when no asker)."""
+
+    from app.sessions.turn_driver import TurnDriver
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    interject = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="broadcast",
+                input={"message": "ack."},
+                id="tu_b_noasker",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [interject]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    async def _run() -> Any:
+        manager = client.app.state.manager
+        session = await manager.get_session(seats["session_id"])
+        turn = session.current_turn
+        assert turn is not None
+        await TurnDriver(manager=manager).run_interject(
+            session=session, turn=turn, for_role_id=None
+        )
+        return await manager.get_session(seats["session_id"])
+
+    session = asyncio.run(_run())
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "broadcast"
+    )
+    assert ai_msg.mentions == [], (
+        "run_interject with for_role_id=None must not auto-tag the "
+        f"reply; got {ai_msg.mentions!r}"
+    )
+
+
+def test_play_turn_reply_tags_facilitator_asker_when_quorum_closes(
+    client: TestClient,
+) -> None:
+    """When a player @s the facilitator AND their submission closes
+    the quorum, the WS handler routes to ``run_play_turn`` (not
+    ``run_interject``) because ``outcome.advanced`` takes precedence
+    (ws/routes.py:722-728). The play-turn path's auto-tag in
+    ``_apply_play_outcome`` must still @-back the asker so they see
+    @YOU on the AI's response."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    # 1-active-role variant: only the creator is active, so their
+    # ``intent="ready"`` submission closes quorum immediately and
+    # the regular play turn fires.
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Mentions routing test",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+            "skip_setup": True,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    sid = body["session_id"]
+    creator_id = body["creator_role_id"]
+
+    async def _seat() -> None:
+        manager = client.app.state.manager
+        session = await manager.get_session(sid)
+        turn = Turn(
+            index=0,
+            active_role_ids=[creator_id],
+            status="awaiting",
+        )
+        session.turns.append(turn)
+        session.state = SessionState.AWAITING_PLAYERS
+        await manager._repo.save(session)
+
+    asyncio.run(_seat())
+
+    # Two play responses: the first satisfies DRIVE+YIELD with a
+    # broadcast + set_active_roles. The asker's @-back must land on
+    # the broadcast.
+    play_response = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="broadcast",
+                input={"message": "Pulling Defender now."},
+                id="tu_b_playturn",
+            ),
+            _ContentBlock(
+                type="tool_use",
+                name="set_active_roles",
+                input={"role_ids": [creator_id]},
+                id="tu_sar",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [play_response]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    auth_token = client.app.state.authn.mint(
+        session_id=sid,
+        role_id=creator_id,
+        kind="creator",
+        version=0,
+    )
+    with client.websocket_connect(
+        f"/ws/sessions/{sid}?token={auth_token}"
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "submit_response",
+                "content": "@facilitator IOCs?",
+                "intent": "ready",
+                "mentions": [FACILITATOR_MENTION_TOKEN],
+            }
+        )
+        for _ in range(12):
+            try:
+                ws.receive_json(mode="text", timeout=2.0)
+            except Exception:
+                break
+
+    session = asyncio.run(client.app.state.manager.get_session(sid))
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "broadcast"
+    )
+    assert creator_id in ai_msg.mentions, (
+        "play-turn broadcast in response to a quorum-closing "
+        "@facilitator submission must tag the asker; got "
+        f"mentions={ai_msg.mentions!r}"
+    )
+
+
+# -----------------------------------------------------------------------
 # Deletion regression — ensure the legacy heuristic is gone.
 # -----------------------------------------------------------------------
 

--- a/backend/tests/test_composer_mentions_routing.py
+++ b/backend/tests/test_composer_mentions_routing.py
@@ -1233,6 +1233,218 @@ def test_play_turn_reply_tags_facilitator_asker_when_quorum_closes(
     )
 
 
+def test_play_turn_freeform_ai_text_also_gets_asker_mention(
+    client: TestClient,
+) -> None:
+    """PR #184 Copilot review caught: ``_apply_play_outcome``
+    captures the model's leading text content as a freeform
+    ``Message(kind=AI_TEXT, tool_name=None)`` separate from the
+    dispatcher's tool-emitted messages. The auto-tag must reach
+    that freeform too — without it, the asker would see @YOU on
+    the broadcast bubble but NOT on the leading prose, leaving
+    them confused about whether the prose is for them."""
+
+    from app.sessions.submission_pipeline import (
+        prepare_and_submit_player_response,
+    )
+    from app.sessions.turn_driver import TurnDriver
+    from tests.mock_anthropic import (
+        MockAnthropic,
+        _ContentBlock,
+        _Response,
+    )
+
+    # 1-active-role variant so a single ready submission closes
+    # the quorum and the regular play turn fires.
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Mentions routing test",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+            "skip_setup": True,
+        },
+    )
+    body = resp.json()
+    sid = body["session_id"]
+    creator_id = body["creator_role_id"]
+
+    async def _seat() -> None:
+        manager = client.app.state.manager
+        session = await manager.get_session(sid)
+        session.turns.append(
+            Turn(index=0, active_role_ids=[creator_id], status="awaiting")
+        )
+        session.state = SessionState.AWAITING_PLAYERS
+        await manager._repo.save(session)
+
+    asyncio.run(_seat())
+
+    # Leading text block before the tool calls — this is what
+    # produces the freeform AI_TEXT message.
+    play_response = _Response(
+        content=[
+            _ContentBlock(
+                type="text",
+                text="On it — pulling Defender now.",
+            ),
+            _ContentBlock(
+                type="tool_use",
+                name="broadcast",
+                input={"message": "Detection at 03:14."},
+                id="tu_b_freeform",
+            ),
+            _ContentBlock(
+                type="tool_use",
+                name="set_active_roles",
+                input={"role_ids": [creator_id]},
+                id="tu_sar_freeform",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [play_response]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    async def _drive() -> None:
+        manager = client.app.state.manager
+        outcome = await prepare_and_submit_player_response(
+            manager=manager,
+            session_id=sid,
+            role_id=creator_id,
+            content="@facilitator IOCs?",
+            intent="ready",
+            mentions=[FACILITATOR_MENTION_TOKEN],
+        )
+        assert outcome.advanced
+        session = await manager.get_session(sid)
+        turn = session.current_turn
+        assert turn is not None
+        await TurnDriver(manager=manager).run_play_turn(
+            session=session, turn=turn
+        )
+
+    asyncio.run(_drive())
+
+    session = asyncio.run(client.app.state.manager.get_session(sid))
+    # The freeform message has tool_name=None; the broadcast has
+    # tool_name="broadcast". Both should carry the asker.
+    freeform = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name is None
+    )
+    assert creator_id in freeform.mentions, (
+        "freeform AI_TEXT (leading prose) must be tagged with the "
+        f"asker; got mentions={freeform.mentions!r}"
+    )
+    broadcast = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "broadcast"
+    )
+    assert creator_id in broadcast.mentions, (
+        "tool-emitted broadcast must also be tagged; got "
+        f"mentions={broadcast.mentions!r}"
+    )
+
+
+def test_play_turn_reply_tags_multiple_facilitator_askers_in_same_turn(
+    client: TestClient,
+) -> None:
+    """When multiple in-turn players each @-mention the facilitator
+    and their combined submissions close the quorum, every asker's
+    role_id must appear in the AI's reply ``mentions[]``. Without
+    this, the auto-tag would only honor the first asker and the
+    second player would silently lose their @YOU badge."""
+
+    from tests.mock_anthropic import MockAnthropic, _ContentBlock, _Response
+
+    seats = asyncio.run(_seat_two_role_session(client))
+    play_response = _Response(
+        content=[
+            _ContentBlock(
+                type="tool_use",
+                name="broadcast",
+                input={"message": "Both questions answered."},
+                id="tu_b_multi",
+            ),
+            _ContentBlock(
+                type="tool_use",
+                name="set_active_roles",
+                input={"role_ids": [seats["creator_id"]]},
+                id="tu_sar_multi",
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    mock = MockAnthropic({"play": [play_response]})
+    client.app.state.llm.set_transport(mock.messages)
+
+    # Submit both players via the load-bearing submission pipeline
+    # (the same path the WS handler uses), then directly drive the
+    # play turn. We bypass the WS routing branch that would fire
+    # ``run_interject`` after CISO's submission — the unit under
+    # test here is the play-turn auto-tag's ability to find ALL
+    # in-turn @facilitator askers, not the WS routing logic. The
+    # routing logic is covered by the dedicated routing tests
+    # earlier in this file.
+    from app.sessions.submission_pipeline import (
+        prepare_and_submit_player_response,
+    )
+    from app.sessions.turn_driver import TurnDriver
+
+    async def _submit_and_drive() -> None:
+        manager = client.app.state.manager
+        outcome_ciso = await prepare_and_submit_player_response(
+            manager=manager,
+            session_id=seats["session_id"],
+            role_id=seats["creator_id"],
+            content="@facilitator IOC list?",
+            intent="ready",
+            mentions=[FACILITATOR_MENTION_TOKEN],
+        )
+        assert not outcome_ciso.advanced, (
+            "CISO alone shouldn't close quorum"
+        )
+        outcome_soc = await prepare_and_submit_player_response(
+            manager=manager,
+            session_id=seats["session_id"],
+            role_id=seats["soc_id"],
+            content="@facilitator timeline?",
+            intent="ready",
+            mentions=[FACILITATOR_MENTION_TOKEN],
+        )
+        assert outcome_soc.advanced, (
+            "SOC submission should close quorum"
+        )
+        session = await manager.get_session(seats["session_id"])
+        turn = session.current_turn
+        assert turn is not None
+        await TurnDriver(manager=manager).run_play_turn(
+            session=session, turn=turn
+        )
+
+    asyncio.run(_submit_and_drive())
+
+    session = asyncio.run(
+        client.app.state.manager.get_session(seats["session_id"])
+    )
+    ai_msg = next(
+        m
+        for m in reversed(session.messages)
+        if m.kind.value == "ai_text" and m.tool_name == "broadcast"
+    )
+    assert seats["creator_id"] in ai_msg.mentions, (
+        "play-turn @-back must tag CISO; got "
+        f"mentions={ai_msg.mentions!r}"
+    )
+    assert seats["soc_id"] in ai_msg.mentions, (
+        "play-turn @-back must also tag SOC (second asker); got "
+        f"mentions={ai_msg.mentions!r}"
+    )
+
+
 # -----------------------------------------------------------------------
 # Deletion regression — ensure the legacy heuristic is gone.
 # -----------------------------------------------------------------------

--- a/docs/turn-lifecycle.md
+++ b/docs/turn-lifecycle.md
@@ -792,6 +792,38 @@ Interject uses its own contract (`PLAY_CONTRACT_INTERJECT`): forbids YIELD + TER
 requires DRIVE, and never has the soft carve-out enabled. The 2026-04-30 bug never
 affected this path.
 
+**@-back contract.** When a player @s the AI (`@facilitator …`), the AI's
+reply must @-mention the asker back so the frontend's `@YOU` badge fires on
+the asker's bubble. This is enforced **server-side, post-dispatch** — not
+via prompt instruction:
+
+- `run_interject` appends `for_role_id` (the asking role_id) to every
+  `MessageKind.AI_TEXT` message in `outcome.appended_messages` before the
+  WS broadcast (`turn_driver.py` `run_interject`, `interject_reply_tagged`
+  audit line).
+- `_apply_play_outcome` does the same for the regular play-turn path —
+  needed because when a player's `@facilitator` submission **also closes
+  the quorum**, the WS handler routes to `run_play_turn` (not the
+  interject side channel) since `outcome.advanced` takes precedence
+  (`ws/routes.py:722–728`). The play-turn auto-tag scans the current
+  turn's PLAYER messages with `is_interjection=False` AND
+  `FACILITATOR_MENTION_TOKEN in mentions`, and tags every `AI_TEXT` reply
+  with each asker's role_id (`turn_driver.py` `_apply_play_outcome`,
+  `play_turn_reply_tagged` audit line). Skipping `is_interjection=True`
+  avoids double-tagging an out-of-turn interject asker who already got
+  their `@`-back via `run_interject` earlier in the turn.
+- `address_role` and `pose_choice` already auto-tag their target via the
+  dispatcher (`dispatch.py` `address_role`, `pose_choice`); the
+  `run_interject` / `_apply_play_outcome` blocks are idempotent
+  (`if asker_id not in msg.mentions`) so addressing the asker directly
+  doesn't double-stamp.
+- The model sees nothing about this in the prompt — the structural
+  `mentions[]` rewrite is server-side. The prose-level "address the
+  asker by their label" guidance in `_STYLE_BASE` and `INTERJECT_NOTE`
+  (prompts.py) is unchanged; it covers the natural-language side, while
+  the auto-tag covers the structural `mentions[]` side that drives the
+  `@YOU` highlight in `Transcript.tsx`.
+
 ### 8f. Recovery itself produces nothing
 
 If the model returns no tool calls on attempt 2 (broadcast pinned), DRIVE still


### PR DESCRIPTION
## Summary

When a player @s the AI (`@facilitator …`), the AI's reply previously landed with empty `Message.mentions[]` for `broadcast` and `share_data` tool calls — so the asker saw a fresh AI message with no `@YOU` badge or amber ring on their bubble. The frontend's @-highlight reads `Message.mentions` directly (Phase A chat-declutter contract), so fixing only the body's prose wouldn't light it up.

This PR adds two server-side, post-dispatch enforcement points that auto-append the asker's `role_id` to every `MessageKind.AI_TEXT` reply produced in response to an `@facilitator` mention.

- **`run_interject`** (the side-channel path) — appends `for_role_id` to every AI_TEXT message. Idempotent (`address_role` / `pose_choice` already auto-tag their target). New audit line `interject_reply_tagged`.
- **`_apply_play_outcome`** (the regular play-turn path) — when a player's `@facilitator` submission also closes the ready quorum, `ws/routes.py:722-728` routes to `run_play_turn` (not the interject side channel) since `outcome.advanced` takes precedence. Without this block, the same bug leaks through that path. Scans the current turn's PLAYER messages for in-turn `@facilitator` askers (`is_interjection=False`) and tags each AI_TEXT reply. New audit line `play_turn_reply_tagged`.

The model never sees `mentions[]`; this is purely a structural rewrite on the server. Existing prose-level guidance in `_STYLE_BASE` / `INTERJECT_NOTE` (address by label) is unchanged.

Closes the screenshot bug: CISO `@`s `@facilitator` for IOCs, AI replies via `share_data` with Defender Telemetry, asker now sees `@YOU` on the reply.

## Test plan

- [x] `pytest backend/tests/test_composer_mentions_routing.py` — 26 passed (10 new tests covering broadcast / share_data / address_role to asker (no dup) / address_role to non-asker / pose_choice to non-asker / `for_role_id=None` defensive / play-turn quorum-closes path)
- [x] `pytest backend/` — 730 passed, 50 skipped
- [x] `ruff check` + `mypy` — clean on changed files
- [x] Live-API tests (per CLAUDE.md, `turn_driver.py` triggers the live-test gate):
  - `tests/live/test_tool_routing.py` — 10/10 passed ($0.34, 79s)
  - `tests/live/test_consistency.py` — 2/2 passed
  - `tests/live/test_inject_chain_recovery.py` — 1 passed, 1 skipped
  - Total spend: $0.59 (well under cap)

## Sub-agent reviews

All six reviews ran in parallel per CLAUDE.md protocol:

- **Security**: ship it. Auth anchored at WS connection boundary; `for_role_id` cannot be spoofed; broadcast leaks no new fact (asker's identity is already public from their `@facilitator` post).
- **UI/UX**: ship with low notes (pre-existing ARIA gap on `@YOU` badge, redundancy by design). Confirmed Transcript.tsx `mentions.includes(selfRoleId)` correctly drives both `@YOU` pill and amber ring.
- **User-persona**: ship it. Matches Slack/Discord/Teams convention; solves the screenshot problem.
- **Prompt Expert**: ship it. No prompt change recommended (server-side auto-tag is more reliable and free). MEDIUM: document the contract — addressed in `docs/turn-lifecycle.md` §8e.
- **QA**: BLOCK B1 (`pose_choice` test missing) + HIGH H1 (`address_role`-non-asker test missing) + MEDIUM (M1 `for_role_id=None` defensive, M2 stricter equality, M3 audit-line assertion). All addressed in this PR.
- **Product / App-Owner**: HIGH — `run_play_turn` had the same gap. Addressed via the `_apply_play_outcome` block.

## Files changed

- `backend/app/sessions/turn_driver.py` — auto-tag in `run_interject` + `_apply_play_outcome`
- `backend/tests/test_composer_mentions_routing.py` — 7 new tests
- `docs/turn-lifecycle.md` §8e — documented the new `@`-back contract

https://claude.ai/code/session_01PQBTB22EZ5k9nAuEQzTvMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQBTB22EZ5k9nAuEQzTvMB)_