### PR TITLE
frontend: replace AI bubble ring stack with bubble-body border

### DIFF
--- a/frontend/src/__tests__/Transcript.test.tsx
+++ b/frontend/src/__tests__/Transcript.test.tsx
@@ -126,10 +126,15 @@ describe("Transcript", () => {
     const m3 = container.querySelector("#msg-m3");
     expect(m1).not.toBeNull();
     expect(m3).not.toBeNull();
-    // Tailwind ring class names — m3 has them, m1 doesn't. Post-redesign
-    // the ring color is `--warn` (was amber) — same semantic ("you owe a
-    // response"), brand-aligned token.
-    expect(m1?.className).not.toContain("ring-warn");
-    expect(m3?.className).toContain("ring-warn");
+    // The highlight rides on the bubble body's border — swapping the
+    // default ``border-ink-600`` for ``border-warn`` — instead of a
+    // ring stack on the article. m3 (latest AI bubble) shows the
+    // warn border; m1 (earlier AI bubble) keeps the default ink-600.
+    const m1Bubble = m1?.querySelector('[data-message-kind="ai"]');
+    const m3Bubble = m3?.querySelector('[data-message-kind="ai"]');
+    expect(m1Bubble?.className).not.toContain("border-warn");
+    expect(m1Bubble?.className).toContain("border-ink-600");
+    expect(m3Bubble?.className).toContain("border-warn");
+    expect(m3Bubble?.className).not.toContain("border-ink-600");
   });
 });

--- a/frontend/src/__tests__/Transcript.test.tsx
+++ b/frontend/src/__tests__/Transcript.test.tsx
@@ -136,5 +136,120 @@ describe("Transcript", () => {
     expect(m1Bubble?.className).toContain("border-ink-600");
     expect(m3Bubble?.className).toContain("border-warn");
     expect(m3Bubble?.className).not.toContain("border-ink-600");
+    // Belt-and-braces against the original visual bug: the row-level
+    // ring stack must be GONE from the article. If a future refactor
+    // re-adds ``ring-warn`` / ``ring-2`` / ``ring-offset-*`` /
+    // ``shadow-[...]`` to the article (in addition to the new border)
+    // the broken outer-outline regression is back even though the
+    // border check above would still pass.
+    expect(m3?.className).not.toMatch(/\bring-/);
+    expect(m3?.className).not.toContain("shadow-");
+    expect(m1?.className).not.toMatch(/\bring-/);
+  });
+
+  it("an @-mentioned AI bubble swaps to border-warn; critical inject keeps border-crit", () => {
+    // Two newly-coupled paths land in the same `borderClass` ladder:
+    // mention → warn, critical inject → crit. The crit branch is
+    // first in the ladder so a critical inject that ALSO mentions
+    // the viewer must keep its red border (the security-relevant
+    // signal wins over the focus signal).
+    const messages = [
+      {
+        id: "ai-mention",
+        ts: new Date().toISOString(),
+        role_id: null,
+        kind: "ai_text",
+        body: "AI bubble that @-tags the viewer.",
+        tool_name: "broadcast",
+        tool_args: null,
+        workstream_id: null,
+        mentions: ["r1"],
+      },
+      {
+        id: "crit-mention",
+        ts: new Date().toISOString(),
+        role_id: null,
+        kind: "critical_inject",
+        body: "Critical inject that ALSO @-tags the viewer.",
+        tool_name: "critical_inject",
+        tool_args: null,
+        workstream_id: null,
+        mentions: ["r1"],
+      },
+    ];
+    const { container } = render(
+      <Transcript messages={messages} roles={ROLES} selfRoleId="r1" />,
+    );
+    const aiBubble = container
+      .querySelector("#msg-ai-mention")
+      ?.querySelector('[data-message-kind="ai"]');
+    const critBubble = container
+      .querySelector("#msg-crit-mention")
+      ?.querySelector('[data-message-kind="ai"]');
+    expect(aiBubble?.className).toContain("border-warn");
+    expect(aiBubble?.className).not.toContain("border-crit");
+    expect(critBubble?.className).toContain("border-crit");
+    expect(critBubble?.className).not.toContain("border-warn");
+  });
+
+  it("an @-mentioned player bubble swaps to border-warn; self bubbles keep signal-tint", () => {
+    // The player ladder is: self → signal-tint, mention → warn,
+    // default → ink-600. A self-authored bubble that ALSO mentions
+    // the viewer (rare but legal — a player tagging themselves)
+    // keeps the signal-tinted self treatment because the signal
+    // "this is yours" outranks "you got mentioned" for self-posts.
+    const messages = [
+      {
+        id: "p-mention",
+        ts: new Date().toISOString(),
+        role_id: "r2",
+        kind: "player",
+        body: "Other player bubble mentioning the viewer.",
+        tool_name: null,
+        tool_args: null,
+        workstream_id: null,
+        mentions: ["r1"],
+      },
+      {
+        id: "p-self",
+        ts: new Date().toISOString(),
+        role_id: "r1",
+        kind: "player",
+        body: "Self-authored bubble (no mention).",
+        tool_name: null,
+        tool_args: null,
+        workstream_id: null,
+        mentions: [],
+      },
+    ];
+    const rolesWithSecond: RoleView[] = [
+      ...ROLES,
+      {
+        id: "r2",
+        label: "IR Lead",
+        display_name: "Sam",
+        kind: "player",
+        token_version: 0,
+        is_creator: false,
+      },
+    ];
+    const { container } = render(
+      <Transcript
+        messages={messages}
+        roles={rolesWithSecond}
+        selfRoleId="r1"
+      />,
+    );
+    const mentionedBubble = container
+      .querySelector("#msg-p-mention")
+      ?.querySelector('[data-message-kind="chat"]');
+    const selfBubble = container
+      .querySelector("#msg-p-self")
+      ?.querySelector('[data-message-kind="chat"]');
+    expect(mentionedBubble?.className).toContain("border-warn");
+    expect(mentionedBubble?.className).not.toContain("border-signal-deep");
+    expect(selfBubble?.className).toContain("border-signal-deep");
+    expect(selfBubble?.className).toContain("bg-signal-tint");
+    expect(selfBubble?.className).not.toContain("border-warn");
   });
 });

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -417,8 +417,20 @@ export function Transcript({
           // sits OUTSIDE that border on a dedicated rail so the two
           // signals don't collide (UI/UX review specifically asked we
           // avoid recoloring the critical-inject red).
-          const dotColor = isCritical ? "bg-crit" : "bg-signal";
-          const labelColor = isCritical ? "text-crit" : "text-signal";
+          // Header chrome — dot + label colour. Critical injects keep
+          // their crit-red emphasis; highlighted bubbles (your turn or
+          // @-mentioned) shift to warn so the dot, label, border, and
+          // @YOU badge all read as one amber focus signal.
+          const dotColor = isCritical
+            ? "bg-crit"
+            : isHighlighted
+              ? "bg-warn"
+              : "bg-signal";
+          const labelColor = isCritical
+            ? "text-crit"
+            : isHighlighted
+              ? "text-warn"
+              : "text-signal";
           // Bubble border. Critical injects keep their crit-red
           // emphasis. Otherwise, when the viewer owes a response on
           // this turn (focus) OR this message @-mentions them, swap

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -350,13 +350,17 @@ export function Transcript({
         const isInterjection = isPlayer && m.is_interjection;
         const isSelf =
           isPlayer && selfRoleId != null && m.role_id === selfRoleId;
-        // ``ring-warn`` highlight on the latest AI bubble when the viewer
-        // is the active responder. Critical injects already carry their
-        // own crit emphasis, so skip the ring there.
-        const focusRing =
-          highlightLastAi && idx === lastAiIndex && m.kind === "ai_text"
-            ? "ring-2 ring-warn ring-offset-1 ring-offset-ink-900 shadow-[0_0_0_2px_color-mix(in_oklch,var(--warn)_15%,transparent)]"
-            : "";
+        // Amber-border highlight on the latest AI bubble when the
+        // viewer is the active responder. Critical injects already
+        // carry their own crit emphasis, so skip the highlight there.
+        // The highlight rides on the bubble body's border (swapping
+        // ``border-ink-600`` for ``border-warn``) rather than a ring
+        // stack on the outer row — a ring around the article wraps
+        // the avatar + stripe + bubble together and reads as broken
+        // chrome instead of a focus signal. 1px border matches the
+        // brand pattern in ``app-screens.jsx``.
+        const isFocusHit =
+          !!highlightLastAi && idx === lastAiIndex && m.kind === "ai_text";
         const ts = new Date(m.ts).toLocaleTimeString();
         // Phase B chat-declutter — track-bar stripe + structural
         // @-highlight. The stripe is 3 px on the left edge of the
@@ -368,9 +372,7 @@ export function Transcript({
         const stripeColor = colorForWorkstream(m.workstream_id, declaredOrder);
         const isMentioned =
           selfRoleId != null && (m.mentions ?? []).includes(selfRoleId);
-        const mentionRing = isMentioned && !isCritical
-          ? "ring-2 ring-warn ring-offset-1 ring-offset-ink-900"
-          : "";
+        const isHighlighted = (isFocusHit || isMentioned) && !isCritical;
         const landmarks = landmarksByMessageId.get(m.id) ?? [];
 
         if (isSystem) {
@@ -417,15 +419,16 @@ export function Transcript({
           // avoid recoloring the critical-inject red).
           const dotColor = isCritical ? "bg-crit" : "bg-signal";
           const labelColor = isCritical ? "text-crit" : "text-signal";
+          // Bubble border. Critical injects keep their crit-red
+          // emphasis. Otherwise, when the viewer owes a response on
+          // this turn (focus) OR this message @-mentions them, swap
+          // the default ink-600 border for warn — same amber colour
+          // signal as the @YOU badge.
           const borderClass = isCritical
             ? "border border-crit border-l-2 bg-crit-bg"
-            : "border border-ink-600 bg-ink-800";
-          // Outer ring stacks: focus-ring (active turn) + mention-ring
-          // (you got @-tagged). Both fade gracefully via Tailwind's
-          // ring composition; we never apply both simultaneously
-          // because the active-turn role is also the most likely
-          // mention target — collapsing to one amber ring is cleaner.
-          const outerRing = focusRing || mentionRing;
+            : isHighlighted
+              ? "border border-warn bg-ink-800"
+              : "border border-ink-600 bg-ink-800";
           return (
             <Landmarks
               key={`grp-${m.id}`}
@@ -440,7 +443,7 @@ export function Transcript({
                 data-message-id={m.id}
                 data-workstream-id={m.workstream_id ?? ""}
                 onContextMenu={(e) => handleContextMenu(e, m)}
-                className={`scroll-mt-24 flex min-w-0 gap-3 ${outerRing}`}
+                className="scroll-mt-24 flex min-w-0 gap-3"
               >
                 <div
                   aria-hidden="true"
@@ -526,10 +529,15 @@ export function Transcript({
         const roleLabel = role?.label ?? "—";
         const code = roleCode(roleLabel);
         const displayName = role?.display_name ?? "";
+        // Player bubble border. Mention-of-self swaps to warn (same
+        // signal as AI bubbles); self-bubbles keep their signal-tinted
+        // background since the viewer rarely needs to be reminded
+        // they mentioned themselves.
         const bubbleColour = isSelf
           ? "border border-signal-deep bg-signal-tint"
-          : "border border-ink-600 bg-ink-800";
-        const playerOuterRing = mentionRing; // focus-ring is AI-only
+          : isHighlighted
+            ? "border border-warn bg-ink-800"
+            : "border border-ink-600 bg-ink-800";
         return (
           <Landmarks
             key={`grp-${m.id}`}
@@ -544,7 +552,7 @@ export function Transcript({
               data-message-id={m.id}
               data-workstream-id={m.workstream_id ?? ""}
               onContextMenu={(e) => handleContextMenu(e, m)}
-              className={`scroll-mt-24 flex min-w-0 gap-3 pl-6 ${playerOuterRing}`}
+              className="scroll-mt-24 flex min-w-0 gap-3 pl-6"
             >
               <div className="flex min-w-0 flex-1 flex-col items-end gap-1.5">
                 <header className="mono flex flex-wrap items-baseline justify-end gap-2 text-[10px] font-bold uppercase tracking-[0.14em]">


### PR DESCRIPTION
## Summary

The latest-AI focus highlight (and @-mention highlight) rode on the outer `<article>` as a `ring-2 ring-warn ring-offset-1 ring-offset-ink-900` plus a 2 px warn-15% box-shadow — about 5 px of effect wrapping the whole row (avatar + workstream stripe + bubble). It read as broken chrome: visibly thick, partly hidden where the avatar's own border met it, and the bottom edge fell off-viewport on long messages.

Reported by user: "The yellow border on highlights just looks kind of broken… The color is fine, but A. its really big, and B. Its only on the top right side."

## Fix

Moves the highlight onto the bubble body's existing 1 px border instead of stacking ring + offset + shadow on the article:

- `border-ink-600` swaps to `border-warn` when the viewer owes a response on this turn OR is @-mentioned by the message.
- Same amber semantic as before; now consistent with the brand pattern in `design/handoff/source/app-screens.jsx` (single 1 px border, no ring stacks).
- Both AI and player bubbles use the unified `isHighlighted` predicate; critical-inject border still wins.

## Test plan

- [x] `npm test -- --run` (404/404 passing)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Updated `Transcript.test.tsx` to assert the inner bubble's class (`border-warn`) instead of the article's ring class
- [ ] Visual confirmation in browser by user — please check that (a) the latest AI bubble shows a thin amber border when it's your turn, (b) @-mentioned messages also show the amber border, and (c) critical injects still show their red border without the amber overlap

https://claude.ai/code/session_01CtvNDVHtJoBGYRVPMmLzrq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtvNDVHtJoBGYRVPMmLzrq)_