### PR TITLE
frontend: prominent "drafting scenario plan" banner on LOOKS READY

### DIFF
--- a/frontend/src/__tests__/SetupView.planPanel.test.tsx
+++ b/frontend/src/__tests__/SetupView.planPanel.test.tsx
@@ -66,6 +66,7 @@ function baseProps() {
     onPickOption: vi.fn(),
     busy: false,
     busyMessage: null,
+    draftingPlan: false,
   };
 }
 
@@ -179,5 +180,87 @@ describe("SetupView — with-plan branch", () => {
       name: /APPROVE & START LOBBY/i,
     });
     expect(approve).toBeDisabled();
+  });
+});
+
+/**
+ * The plan-drafting wait is 5–30 s of non-streaming LLM work; pre-fix,
+ * the operator only saw the small typing dots inside the chat
+ * transcript and the LOOKS READY button reading as "stuck." The
+ * ``draftingPlan`` prop renders a prominent in-chat banner with the
+ * brand DieLoader so the wait reads as an explicit, named step.
+ *
+ * The banner intentionally relies on ``<DieLoader>``'s own
+ * ``role="status" aria-live="polite"`` rather than wrapping in a
+ * second status region (nested live regions are flaky across screen
+ * readers). The label inside DieLoader carries the timing
+ * expectation so a single announcement covers both pieces.
+ */
+describe("SetupView — draftingPlan banner", () => {
+  it("does NOT render the banner when draftingPlan is false", () => {
+    render(<SetupView snapshot={fakeSnapshot(null)} {...baseProps()} />);
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders the prominent banner when draftingPlan is true and no plan yet", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        busyMessage="Drafting the scenario plan…"
+        draftingPlan
+      />,
+    );
+    const banner = screen.getByTestId("drafting-plan-banner");
+    expect(banner).toBeInTheDocument();
+    // The DieLoader label is the load-bearing copy — names the step
+    // ("Drafting scenario plan") and sets a timing expectation
+    // ("typically 10–30 sec"). The operator's complaint was "feels
+    // stuck"; the timing window is what turns "stuck" into "patient."
+    expect(
+      within(banner).getByText(/Drafting scenario plan/i),
+    ).toBeInTheDocument();
+    expect(within(banner).getByText(/10–30 sec/i)).toBeInTheDocument();
+  });
+
+  it("hides the banner once a plan exists, even if draftingPlan is still true", () => {
+    // Race-guard regression test: the Facilitator clears
+    // ``draftingPlan`` as soon as the plan lands, but a render-cycle
+    // race could leave both true for a frame. The ``!hasPlan`` guard
+    // in the JSX must hide the banner when a plan is present so the
+    // operator never sees a "drafting" caption flashing over a new
+    // plan card. Passing ``draftingPlan={true}`` AND a plan
+    // exercises the guard directly (vs. the prior tautological
+    // ``draftingPlan={false}`` test the QA agent flagged).
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(fakePlan())}
+        {...baseProps()}
+        draftingPlan
+      />,
+    );
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the small BusyChip while the prominent banner is showing", () => {
+    // UI/UX + user-persona reviews flagged BusyChip + banner +
+    // chat-typing-dots as redundant indicators. While
+    // ``draftingPlan=true``, only the banner should be visible. The
+    // BusyChip resumes for the post-plan finalize step.
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        busyMessage="Drafting the scenario plan…"
+        draftingPlan
+      />,
+    );
+    // Banner is present, chip text is NOT.
+    expect(screen.getByTestId("drafting-plan-banner")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Drafting the scenario plan…/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/SetupView.planPanel.test.tsx
+++ b/frontend/src/__tests__/SetupView.planPanel.test.tsx
@@ -263,4 +263,41 @@ describe("SetupView — draftingPlan banner", () => {
       screen.queryByText(/Drafting the scenario plan…/),
     ).not.toBeInTheDocument();
   });
+
+  it("keeps option chips disabled while drafting (concurrency regression guard)", () => {
+    // PR #186 review BLOCK from Copilot: the original
+    // ``busy={busy && !draftingPlan}`` pass-through to <SetupChat>
+    // collapsed the chip-disable flag and the typing-indicator
+    // visibility into one prop, which re-enabled the latest AI
+    // question's option chips during the in-flight LOOKS READY
+    // request. A click on a chip would dispatch a second
+    // overlapping ``api.setupReply()`` (``callSetup`` has no
+    // already-busy gate). Fix: split into ``busy`` (chip disable)
+    // and ``aiTyping`` (indicator visibility); pass full ``busy``
+    // for the disable. This test pins that invariant: with
+    // ``draftingPlan=true`` AND a chip-bearing AI question as the
+    // last note, every chip must be ``disabled``.
+    const snapshotWithOptions: SessionSnapshot = {
+      ...fakeSnapshot(null),
+      setup_notes: [
+        {
+          ts: "2026-05-05T00:00:01Z",
+          speaker: "ai",
+          content: "Pick one:",
+          topic: "preference",
+          options: ["Option A", "Option B"],
+        },
+      ],
+    };
+    render(
+      <SetupView
+        snapshot={snapshotWithOptions}
+        {...baseProps()}
+        busy
+        draftingPlan
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Option A" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Option B" })).toBeDisabled();
+  });
 });

--- a/frontend/src/components/SetupChat.tsx
+++ b/frontend/src/components/SetupChat.tsx
@@ -3,7 +3,19 @@ import { ChatIndicator } from "./ChatIndicator";
 
 interface Props {
   notes: SetupNoteView[];
+  /** Operation in flight — disables the quick-pick option chips on
+   *  the latest AI question so the operator can't dispatch a second
+   *  ``api.setupReply()`` while one is already running. Decoupled
+   *  from the typing-indicator visibility (see ``aiTyping``) so a
+   *  consumer can show its own prominent wait state without also
+   *  re-enabling chip clicks (PR #186 review: that combination was a
+   *  concurrency bug). */
   busy?: boolean;
+  /** Show the small "AI Facilitator is typing…" bouncing dots inside
+   *  the chat region. Distinct from ``busy``: the consumer may want
+   *  to suppress the dots while a more prominent banner is the
+   *  dominant indicator (e.g. SetupView's drafting-plan banner). */
+  aiTyping?: boolean;
   onPickOption?: (option: string) => void;
 }
 
@@ -14,7 +26,7 @@ interface Props {
  * supplied option chips, the latest message renders them as quick-pick
  * buttons that send the option text as the next reply.
  */
-export function SetupChat({ notes, busy, onPickOption }: Props) {
+export function SetupChat({ notes, busy, aiTyping, onPickOption }: Props) {
   if (notes.length === 0) {
     return (
       <div className="mono rounded-r-3 border border-ink-600 bg-ink-850 p-3 text-[11px] uppercase tracking-[0.06em] text-ink-400">
@@ -70,7 +82,7 @@ export function SetupChat({ notes, busy, onPickOption }: Props) {
           </div>
         );
       })}
-      {busy && lastAiNote ? (
+      {aiTyping && lastAiNote ? (
         <div className="flex justify-start">
           <ChatIndicator label="AI Facilitator is typing…" tone="ai" />
         </div>

--- a/frontend/src/components/brand/DieLoader.tsx
+++ b/frontend/src/components/brand/DieLoader.tsx
@@ -8,13 +8,32 @@ import type { CSSProperties } from "react";
  * generation. Don't sprinkle this everywhere — the brand mark is the
  * one hero asset and it loses meaning if it competes with itself.
  *
- * For small in-flow indicators (e.g. "AI is typing…"), keep using the
- * <ChatIndicator> bouncing-dots pattern. This component is for whole-
- * screen / whole-region wait states only.
+ * Two acceptable usage patterns:
+ *
+ *   1. **Whole-screen / whole-region wait** — initial page load,
+ *      JoinIntro waiting room, AAR generation popup. ``size`` 96+,
+ *      centered.
+ *
+ *   2. **Named in-chat wait state** — a labelled banner inside an
+ *      otherwise interactive surface (chat group, sidebar) that
+ *      claims attention for a specific, ephemeral wait. ``size`` 64,
+ *      bordered + tinted background. The banner replaces (rather
+ *      than augments) the smaller "AI is typing…" bouncing-dots
+ *      indicator for the duration of that named wait.
+ *      Examples: ``SetupView`` "Waiting for the AI's first
+ *      question" empty state, ``SetupView`` "Drafting scenario
+ *      plan" wait banner.
+ *
+ * For ambient "AI is typing…" indicators outside of a named wait
+ * (e.g. mid-Q&A in setup, mid-turn in play), keep using the
+ * ``<ChatIndicator>`` bouncing-dots pattern — the DieLoader would
+ * over-claim attention there.
  *
  * ``size`` defaults to 96 (works well centered on a viewport-filling
  * surface). ``label`` is the mono caption beneath; pass ``null`` to
- * suppress.
+ * suppress. The component supplies its own ``role="status"`` +
+ * ``aria-live="polite"``; do NOT wrap the consumer in a second
+ * status region (nested live regions confuse screen readers).
  */
 interface Props {
   size?: number;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -243,6 +243,23 @@ export function Facilitator() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
+  // Prominent in-chat indicator for the LOOKS-READY → propose-plan path.
+  // Distinct from ``busy`` because the chat-region DieLoader needs to
+  // be visible *only* during the plan-drafting wait — not during the
+  // dozen other things that flip ``busy`` (regular Q&A reply,
+  // finalize, skip-setup-dev, etc.). The setup tier is non-streaming
+  // so we can't detect mid-call whether the model chose
+  // ``ask_setup_question`` vs ``propose_scenario_plan``; the explicit
+  // button click is the one moment we *know* what's coming, so we
+  // light the banner client-side there.
+  //
+  // Implicit-nudge gap (tracked follow-up): when the AI decides to
+  // propose during a regular reply turn (not LOOKS READY), the
+  // operator still sees only the small typing dots until the plan
+  // lands. Closing that gap requires either streaming the setup tier
+  // (so the model's tool choice is observable mid-call) or a
+  // mid-call "now drafting" WS event. Out of scope for this PR.
+  const [draftingPlan, setDraftingPlan] = useState(false);
   const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed" | "error" | "kicked" | "rejected" | "session-gone">("connecting");
 
   // Live AI text streaming was producing visible mid-flight rewrites:
@@ -889,12 +906,17 @@ export function Facilitator() {
       return;
     }
     setBusy(true);
-    setBusyMessage("Asking the AI to draft the plan…");
+    setDraftingPlan(true);
+    setBusyMessage("Drafting the scenario plan… typically 10–30 seconds.");
     try {
       const reply = await api.setupReply(state.sessionId, state.token, NUDGE_PROPOSE);
       const snap = await api.getSession(state.sessionId, state.token);
       setSnapshot(snap);
       if (snap.plan) {
+        // Plan landed — drop the prominent drafting banner so the
+        // operator's eye moves to the plan card; the smaller BusyChip
+        // continues to communicate the fast finalize step.
+        setDraftingPlan(false);
         setBusyMessage("Plan drafted — finalizing…");
         await api.setupFinalize(state.sessionId, state.token);
         const after = await api.getSession(state.sessionId, state.token);
@@ -926,6 +948,7 @@ export function Facilitator() {
     } finally {
       setBusy(false);
       setBusyMessage(null);
+      setDraftingPlan(false);
     }
   }
 
@@ -1237,6 +1260,7 @@ export function Facilitator() {
           }
           busy={busy}
           busyMessage={busyMessage}
+          draftingPlan={draftingPlan}
         />
       );
     } else if (wizardReadyForReview && snapshot.plan) {
@@ -2152,6 +2176,7 @@ export function SetupView({
   onPickOption,
   busy,
   busyMessage,
+  draftingPlan,
 }: {
   snapshot: SessionSnapshot;
   setupReply: string;
@@ -2163,6 +2188,14 @@ export function SetupView({
   onPickOption: (option: string) => void;
   busy: boolean;
   busyMessage: string | null;
+  /** True from the moment the operator clicks LOOKS READY → PROPOSE THE
+   *  PLAN until either the plan arrives or an error surfaces. Drives a
+   *  prominent in-chat banner so the operator has unambiguous feedback
+   *  during the 5–30 s plan-drafting wait (otherwise the small typing
+   *  dots in the chat read as "stuck"). Required, not optional —
+   *  every call site already passes it explicitly and a default would
+   *  silently hide the indicator if a future site forgets. */
+  draftingPlan: boolean;
 }) {
   const hasPlan = Boolean(snapshot.plan);
   const notes = snapshot.setup_notes ?? [];
@@ -2198,9 +2231,50 @@ export function SetupView({
         </div>
       ) : null}
 
-      <SetupChat notes={notes} busy={busy} onPickOption={onPickOption} />
+      {/* Mask the in-chat typing dots while the prominent
+          drafting-plan banner is the dominant indicator (UI/UX +
+          user-persona reviews flagged the parallel indicators as
+          duplicate UI). The dots resume for every other AI-busy
+          state (regular Q&A reply, finalize, dev-skip). */}
+      <SetupChat
+        notes={notes}
+        busy={busy && !draftingPlan}
+        onPickOption={onPickOption}
+      />
 
-      <BusyChip busy={busy} message={busyMessage} />
+      {/* Brand DieLoader as a named in-chat wait state. The DieLoader
+          itself supplies ``role="status"`` + ``aria-live="polite"``;
+          this wrapper deliberately does NOT add another live region
+          (UI/UX review: nested aria-live blocks let screen readers
+          drop the inner caption). The label carries the timing
+          expectation inline so screen readers announce the full
+          message in one pass.
+
+          ``!hasPlan`` race guard: the Facilitator clears
+          ``draftingPlan`` as soon as the plan lands, but a
+          render-cycle race could leave both true for a frame. Hiding
+          the banner once a plan exists makes that race a no-op
+          rather than a "drafting" caption flashing over the new plan
+          card. */}
+      {draftingPlan && !hasPlan ? (
+        <div
+          data-testid="drafting-plan-banner"
+          className="flex flex-col items-center gap-3 rounded-r-3 border border-signal-deep bg-signal-tint p-6"
+        >
+          <DieLoader
+            label="Drafting scenario plan · typically 10–30 sec"
+            size={64}
+          />
+        </div>
+      ) : null}
+
+      {/* Suppress the small chip while the prominent banner above is
+          claiming the operator's attention (UI/UX review: three
+          parallel indicators read as duplicate UI). The chip continues
+          to communicate the fast post-plan finalize step
+          (``busyMessage = "Plan drafted — finalizing…"``) and every
+          other ``busy`` state. */}
+      <BusyChip busy={busy && !draftingPlan} message={busyMessage} />
     </div>
   );
 

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -2231,14 +2231,20 @@ export function SetupView({
         </div>
       ) : null}
 
-      {/* Mask the in-chat typing dots while the prominent
-          drafting-plan banner is the dominant indicator (UI/UX +
-          user-persona reviews flagged the parallel indicators as
-          duplicate UI). The dots resume for every other AI-busy
-          state (regular Q&A reply, finalize, dev-skip). */}
+      {/* ``busy`` is the full in-flight flag — keeps the option
+          chips on the latest AI question disabled so the operator
+          can't dispatch a second ``api.setupReply()`` while a
+          LOOKS-READY draft is mid-air (PR #186 review block).
+          ``aiTyping`` is the indicator-only flag: suppress the
+          small bouncing dots while the prominent drafting-plan
+          banner below is the dominant signal, otherwise mirror
+          ``busy``. The two flags are deliberately split — combining
+          them would silently re-enable chip clicks during the
+          draft. */}
       <SetupChat
         notes={notes}
-        busy={busy && !draftingPlan}
+        busy={busy}
+        aiTyping={busy && !draftingPlan}
         onPickOption={onPickOption}
       />
 


### PR DESCRIPTION
## Summary

Operator feedback (verbatim):

> "When the AI has asked all of its questions it takes a long time to generate the plan and its not clear that it is currently generating a plan. It feels like it just gets stuck."

The 5–30 s plan-drafting wait after clicking **LOOKS READY → PROPOSE THE PLAN** had three small indicators (typing dots inside chat, a `BusyChip` pill, and the disabled-button visual state) all easy to miss with the operator's eye on the just-clicked button. This PR adds a prominent in-chat banner that names the step and sets a timing expectation.

## What changed

- **`Facilitator.tsx`** — added a `draftingPlan` boolean state, set true on `handleLooksReady` entry and cleared in finally / when the plan lands. Threaded as a required prop to `<SetupView>`.
- **`SetupView`** — when `draftingPlan && !hasPlan`, renders a prominent `<DieLoader size={64}>` banner with the label "Drafting scenario plan · typically 10–30 sec." During this window the small `BusyChip` and the chat-region typing dots are both suppressed so the banner is the dominant indicator (no parallel/redundant signals).
- **`DieLoader`** docstring — formalized the "named in-chat wait state" usage pattern. The existing "Waiting for the AI's first question" empty state already used the pattern; the docstring now documents both that precedent and this banner as acceptable consumers, plus calls out the nested-aria-live pitfall.

## Sub-agent review fallout (addressed in-PR)

Initial draft also appended a synthetic AI `SetupNote` from the dispatcher ("I have enough to draft a plan…"). Six sub-agent reviews collectively flagged this as the wrong tool for the job:

| Severity | Reviewer | Finding |
|---|---|---|
| CRITICAL | QA | Note feeds back through `_setup_messages` into the LLM's perceived conversation history — model sees its own fabricated commitment. |
| BLOCK | QA | Note duplicates verbatim on every revision `propose_scenario_plan` call. |
| HIGH | QA | Breaks `awaitingReply` derivation that gates the browser-tab pending dot. |
| HIGH | Prompt Expert | "click APPROVE" UI-button reference leaks into model history. |
| HIGH | Product | Violates the model-output trust boundary in spirit (puts words in the AI's mouth). |
| HIGH | UI/UX | Outer wrapper `role="status"` + DieLoader's own status region created nested aria-live blocks (screen readers drop the inner caption). |
| HIGH | UI/UX | DieLoader docstring contradicted the existing in-chat usage. |
| HIGH | User-persona | BusyChip + banner + chat typing dots = three indicators saying the same thing. |

**Resolution**: dropped the synthetic note entirely; the prominent banner alone solves the original "feels stuck" complaint without putting words in the AI's mouth or polluting the LLM history. Tightened the banner to a single DieLoader (no outer status region, no separate paragraph). Suppressed BusyChip + chat typing dots while the banner is showing. Updated the DieLoader docstring. Added a `!hasPlan` race guard so the banner can't flash over a newly-arrived plan card.

## Implicit-nudge gap (deferred)

When the AI decides to propose during a regular Q&A reply turn (not a LOOKS READY click), the operator still sees only the small typing dots until the plan lands. This was the larger half of the original complaint per the Product reviewer. Closing it requires either streaming the setup tier (so the model's tool choice is observable mid-call) or a new "drafting started" WS event triggered by streamed `content_block_start` for `propose_scenario_plan`. **Out of scope for this PR — recommend a Phase-3 follow-up issue.**

## Test plan

- [x] `frontend && npm test -- --run` — 408 pass (+4 net new banner tests under "draftingPlan banner": default-off, on-when-true with copy assertions, race-guard with plan, BusyChip suppression).
- [x] `frontend && npm run lint` — clean.
- [x] `frontend && npm run typecheck` — clean.
- [x] `backend && pytest -q` — 739 pass / 50 skipped (no behavior change; backend dispatcher untouched in final diff).
- [x] `backend && ruff check .` — clean.
- [x] `backend && mypy app` — clean.
- [x] Live: `tests/live/test_workstreams_setup_routing.py` PASSES; $0.06 spend (belt-and-braces; final diff is frontend-only).
- [ ] Manual smoke: click LOOKS READY in a real session → confirm banner appears, BusyChip + typing dots are hidden, banner clears when the plan card arrives.

🤖 Generated with [Claude Code](https://claude.ai/code) — session https://claude.ai/code/session_01NcFQ2ZxLGZneqXisWZiCnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcFQ2ZxLGZneqXisWZiCnR)_