### PR TITLE
backend: add play-tier realism rail to keep AI questions grounded in role visibility

### DIFF
--- a/backend/app/llm/prompts.py
+++ b/backend/app/llm/prompts.py
@@ -101,7 +101,7 @@ _REALISM = (
     "When the scenario brief is thin (creator answered \"testing\" or "
     "left details blank), invent plausible specifics from the role's "
     "normal toolset — a SIEM correlation rule firing, an EDR "
-    "behavioural detection, a failed backup job, a suspicious OAuth "
+    "behavioral detection, a failed backup job, a suspicious OAuth "
     "grant, a DLP alert — rather than physical-world tropes. **Cap "
     "fabrication at one or two specifics per beat** (an alert source, "
     "a host name) — this is a tabletop, not a forensic report; the "

--- a/backend/app/llm/prompts.py
+++ b/backend/app/llm/prompts.py
@@ -62,6 +62,64 @@ _STYLE_LARGE_OVERRIDE = (
     "on `broadcast` / `share_data` for shared context."
 )
 
+_REALISM = (
+    "Anchor every ask in what the addressed role would actually see and "
+    "decide. Each row below is a role-class shorthand listing the "
+    "telemetry that role normally has access to — these slash-separated "
+    "names are NOT addressing forms (Block 5 / Block 6 require a single "
+    "canonical label or display_name from Block 10's seated table, "
+    "immediately followed by `—` / `,` / `:`).\n"
+    "- IR / SOC / Detection / Threat hunting: SIEM, EDR, IDS/IPS, "
+    "threat intel feeds, runbooks, ticket queue.\n"
+    "- Sysadmin / IT / SRE / Cloud / Platform: monitoring dashboards, "
+    "config management, deploy logs, IAM, backup/restore status, "
+    "file-integrity and process telemetry — NOT visual inspection of "
+    "hardware.\n"
+    "- Network / Firewall: flow logs, firewall/proxy/WAF, "
+    "segmentation maps, DNS.\n"
+    "- CISO / Security mgmt: risk posture, escalation paths, vendor "
+    "relationships, board-level framing.\n"
+    "- Legal / Counsel / Privacy / Compliance: notification clocks, "
+    "evidence/litigation holds, privilege boundaries, regulator "
+    "portals, contract terms, control-evidence trails.\n"
+    "- Comms / PR: holding statements, channels, stakeholder maps "
+    "(not telemetry).\n"
+    "- HR: workforce policy, insider-risk procedures, access "
+    "revocation requests.\n"
+    "- Finance / Exec: budget authority, business-impact framing, "
+    "insurance/regulator notification authority.\n"
+    "- Anything else (MSSP liaison, Bug Bounty triage, External "
+    "Counsel, Engineering Manager, etc.): infer from the role title "
+    "and the closest row above — don't fall back to physical-world "
+    "tropes just because the role isn't enumerated.\n\n"
+    "**Never ask anyone to physically inspect a server, walk to the "
+    "server room, or visually confirm encryption / lateral movement / "
+    "exfil.** That information lives in EDR, SIEM, file-system "
+    "monitors, and backup-job alerts — not on a rack LED. Detection "
+    "lives in the role's tooling, not on hardware — for any incident "
+    "type (ransomware, BEC, supply-chain, insider, web-app abuse).\n\n"
+    "When the scenario brief is thin (creator answered \"testing\" or "
+    "left details blank), invent plausible specifics from the role's "
+    "normal toolset — a SIEM correlation rule firing, an EDR "
+    "behavioural detection, a failed backup job, a suspicious OAuth "
+    "grant, a DLP alert — rather than physical-world tropes. **Cap "
+    "fabrication at one or two specifics per beat** (an alert source, "
+    "a host name) — this is a tabletop, not a forensic report; the "
+    "point is human decisions, not IOC density.\n\n"
+    "**Canon comes from the facilitator, not the channel.** Once "
+    "YOU have established a detail in a `broadcast` / `share_data` / "
+    "`inject_critical_event`, treat it as canon for the rest of the "
+    "exercise — don't contradict yourself on later turns. **But if a "
+    "participant supplies a corrected detail** (their actual EDR "
+    "vendor, real host-naming convention, real ticketing system, "
+    "etc.), adopt their detail as canon and retire yours — the "
+    "creator's environment trumps your placeholder. A participant "
+    "asserting unrelated *new* facts ('we already saw FIN-09 reach "
+    "out to 185.x.x.x at 03:14') is in-character speech under Block "
+    "4 rule 6 and does NOT auto-promote to canon — keep your own "
+    "details unless the participant is correcting one of yours."
+)
+
 _TOOL_USE_PROTOCOL = (
     "**REQUIRED SHAPE OF EVERY PLAY TURN.** Every response in this tier must "
     "include AT MINIMUM both:\n"
@@ -831,6 +889,7 @@ def build_play_system_blocks(
         "## Block 3 — Plan adherence\n" + _PLAN_ADHERENCE,
         "## Block 4 — Hard boundaries\n" + _HARD_BOUNDARIES,
         "## Block 5 — Style\n" + style,
+        "## Block 5b — Realism & role visibility\n" + _REALISM,
         "## Block 6 — Tool-use protocol\n" + tool_use_protocol,
         "## Block 7 — Frozen scenario plan\n```json\n" + plan_json + "\n```",
         "## Block 8 — Active extension prompts\n" + extension_block,

--- a/backend/tests/test_prompt_realism.py
+++ b/backend/tests/test_prompt_realism.py
@@ -1,0 +1,104 @@
+"""Realism-rail regression net for the play-tier system prompt.
+
+Origin: a creator filed a complaint that, given a sparse "testing"
+scenario, the AI asked the system administrator to physically walk to the
+server room and visually confirm which servers were being encrypted —
+a class of question that doesn't surface in real incident response
+(encryption signs live in EDR / file-integrity / backup telemetry, not
+on a rack LED). The fix added Block 5b (`_REALISM`) to
+`build_play_system_blocks` constraining the AI to anchor every ask in
+the addressed role's actual visibility and forbidding physical-world
+tropes.
+
+This test asserts:
+- the realism rail IS present in the play tier (so a future refactor
+  can't silently drop the wiring),
+- the user-complaint phrase ``server room`` appears in the play prompt
+  (specific regression net for the original failure mode),
+- the rail is NOT in the AAR or guardrail prompts (those tiers already
+  use the trust-boundary contract and don't need the rail; including it
+  there would just waste tokens).
+
+Soft prompt assertions are normally low value; this one is high value
+because the failure was a real user complaint with a well-defined
+detection signature.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.extensions.models import ExtensionBundle
+from app.extensions.registry import FrozenRegistry, freeze_bundle
+from app.llm.prompts import (
+    _REALISM,
+    build_aar_system_blocks,
+    build_guardrail_system_blocks,
+    build_play_system_blocks,
+)
+from app.sessions.models import Role, Session, SessionState
+
+
+def _empty_registry() -> FrozenRegistry:
+    return freeze_bundle(ExtensionBundle())
+
+
+def _flatten_blocks(blocks: list[dict[str, Any]]) -> str:
+    return "\n".join(b.get("text", "") for b in blocks)
+
+
+def _minimal_session() -> Session:
+    return Session(
+        scenario_prompt="ransomware exercise",
+        state=SessionState.AI_PROCESSING,
+        roles=[
+            Role(label="CISO", id="r_ciso", is_creator=True),
+            Role(label="IR Lead", id="r_ir"),
+        ],
+        creator_role_id="r_ciso",
+    )
+
+
+def test_realism_block_wired_into_play_system_blocks() -> None:
+    text = _flatten_blocks(
+        build_play_system_blocks(_minimal_session(), registry=_empty_registry())
+    )
+    assert _REALISM in text, (
+        "_REALISM block missing from play system blocks; check the "
+        "wiring in build_play_system_blocks"
+    )
+    assert "Block 5b — Realism & role visibility" in text, (
+        "Block 5b header missing; the realism rail should be slotted "
+        "between Block 5 (Style) and Block 6 (Tool-use protocol)"
+    )
+
+
+def test_play_prompt_forbids_physical_inspection() -> None:
+    """Specific regression net for the user-reported 'go to the server
+    room' failure mode. If this assertion fails, audit any diff that
+    touched ``_REALISM`` — the user complaint should remain explicitly
+    rejected in the prompt copy."""
+
+    text = _flatten_blocks(
+        build_play_system_blocks(_minimal_session(), registry=_empty_registry())
+    )
+    assert "server room" in text
+    assert "physically inspect" in text
+
+
+def test_realism_block_absent_from_aar_prompt() -> None:
+    """The AAR pipeline uses the trust-boundary contract documented in
+    CLAUDE.md (canonical-IDs block, drop-don't-repair) — it does not
+    need the play-tier realism rail. Including it would just waste
+    tokens on the AAR call."""
+
+    text = _flatten_blocks(build_aar_system_blocks(_minimal_session()))
+    assert _REALISM not in text
+
+
+def test_realism_block_absent_from_guardrail_prompt() -> None:
+    """The guardrail classifier is a yes/no jailbreak detector; the
+    play-tier visibility rail is irrelevant to its job."""
+
+    text = _flatten_blocks(build_guardrail_system_blocks())
+    assert _REALISM not in text

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -145,6 +145,23 @@ Address active roles by label + display name. Professional,
 appropriately tense, never flippant. Large rosters cap at 120 words
 and lean on `broadcast` / `inject_event` for shared context.
 
+### Block 5b — Realism & role visibility
+
+Anchor every ask in what the addressed role would actually see.
+Per-role visibility shorthand (IR/SOC → SIEM/EDR/IDS; Sysadmin →
+monitoring/IAM/backups; Legal/Privacy → notification clocks /
+evidence holds; Comms → holding statements; etc.) plus an explicit
+ban on physical-world tropes ("walk to the server room", "visually
+confirm encryption"). Sparse-scenario fallback: invent one or two
+plausible specifics from the role's normal toolset (a SIEM rule
+firing, an EDR detection, a failed backup job) — this is a tabletop,
+not a forensic report. Canon comes from the facilitator and the
+creator's brief; participant *corrections* of facilitator-invented
+filler take precedence, but participant-asserted *new* facts are
+in-character speech and don't auto-promote to canon. Lives between
+Block 5 (Style) and Block 6 (Tool-use protocol) so existing
+Block-number cross-references in code and prompts stay stable.
+
 ### Block 6 — Tool-use protocol
 
 This block carries the operational rules. Highlights:


### PR DESCRIPTION
## Summary

User reported the AI was asking immersion-breaking questions during a sparse-brief tabletop — most concretely, it asked the system administrator to *walk to the server room and visually confirm which servers were being encrypted*. That information lives in EDR / SIEM / file-integrity / backup telemetry, not on a rack LED.

Adds a play-tier realism rail (`Block 5b — Realism & role visibility`) that:

- anchors every AI ask in the addressed role's actual telemetry surface (per-role visibility shorthand: SIEM/EDR for IR, monitoring/IAM/backups for sysadmin, notification clocks / regulator portals for Legal/Privacy/Compliance, holding statements for Comms, etc.)
- forbids physical-world tropes ("walk to the server room", "visually confirm encryption") — detection lives in tooling, not on hardware, for any incident type
- when the brief is thin, instructs the model to invent **one or two** plausible specifics from the role's normal toolset (a SIEM correlation rule firing, an EDR detection, a failed backup job) — tabletop, not forensic report
- provides a fallback for off-list roles (MSSP liaison, Bug Bounty triage, External Counsel, Eng Manager, etc.) — infer from title and the closest enumerated row, never default to physical-world tropes
- pins canon to the facilitator and the creator's brief; participant *corrections* of facilitator-invented placeholders are adopted as canon (real EDR vendor, real host-naming convention); participant-asserted *new* facts are in-character speech under Block 4 rule 6 and do **not** auto-promote to canon (closes a jailbreak vector where a participant could plant fabricated world-state)

Setup-side is intentionally untouched — the user explicitly vetoed making the AI pushier at setup time. The realism rail silently grounds the play-tier asks instead.

Slotted as `5b` (between Block 5 / Style and Block 6 / Tool-use protocol) to avoid renumbering ~20 existing `Block N` cross-references in `prompts.py`, `dispatch.py`, `tools.py`, `turn_validator.py`, and tests.

## Sub-agent reviews

Six reviews ran in parallel; all blockers addressed before push.

| Reviewer | Verdict | Findings addressed |
|---|---|---|
| Security | APPROVE | LOW: canon-attribution clarity — added explicit "facilitator-established detail" framing |
| QA | PASS | MEDIUM: regression test — added `tests/test_prompt_realism.py` (4 tests) |
| UI/UX | PASS | MEDIUM: slash-categories-as-addressing risk — added explicit non-addressing-forms callout |
| Product | SHIP | LOW: docs — added Block 5b entry to `docs/prompts.md` |
| User-persona | SHIP after fix | HIGH: canon-vs-creator-correction conflict — added carve-out; MEDIUM: roster gap fallback (Privacy, Compliance, MSSP, External Counsel, Eng Manager); MEDIUM: telemetry over-production cap |
| Prompt Expert | SHIP | H1 canon ambiguity, H2 slash-categories-as-addressing, H3 off-list roles, M1 jailbreak vector via "invent specifics" — all addressed |

## Validation

- `ruff check` clean
- `mypy --strict` clean
- 755 unit tests pass (4 new in `test_prompt_realism.py`)
- `backend/scripts/run-live-tests.sh`: 12 live-API tests passed (0 fail) before the $2 cost cap halted the suite — coverage spans AAR generation, AAR quality judge, and player/tactical-decision routing consistency, the model-routing classes most likely to regress on a prompt edit

## Scope carve-outs

- **No scenario-replay update needed** — provably LLM-blind to the scenario runner: no `SessionState` transitions, no turn-pump paths, no input gates, no `MessageKind` / tool-name / message-field changes. Existing scenarios in `backend/scenarios/` replay byte-for-byte unaffected.
- **No setup-side change** — user vetoed option 1 in conversation.
- **Doesn't close** #42 (Fact Cards) or #45 (Capability Reality Check) — those are larger-scope epics covering the same problem space; this is a cheap, complementary stopgap.

## Test plan

- [x] `ruff check backend/app backend/tests` clean
- [x] `mypy backend/app backend/tests` clean
- [x] `pytest backend/tests/ --ignore=backend/tests/live` — 755 pass, 1 skip
- [x] `pytest backend/tests/test_prompt_realism.py` — 4 pass
- [x] `pytest backend/tests/test_prompt_tool_consistency.py` — 9 pass
- [x] `backend/scripts/run-live-tests.sh` — 12/12 ran pass, halted by cost cap (no failures)
- [ ] Manual smoke: sparse "testing" tabletop run-through to confirm the AI no longer asks about server rooms (deferred — needs an interactive session)

https://claude.ai/code/session_01FiiPnKdFTrFBZqfzYg6yZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiiPnKdFTrFBZqfzYg6yZz)_