### PR TITLE
backend: split play system blocks for stable-prefix prompt caching

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -366,7 +366,7 @@ class LLMClient:
         kwargs: dict[str, Any] = {
             "model": model,
             "system": _with_cache(system_blocks),
-            "messages": messages,
+            "messages": _with_message_cache(messages),
             "max_tokens": max_tokens,
         }
         if tools:
@@ -476,7 +476,7 @@ class LLMClient:
         kwargs: dict[str, Any] = {
             "model": model,
             "system": _with_cache(system_blocks),
-            "messages": messages,
+            "messages": _with_message_cache(messages),
             "max_tokens": max_tokens,
         }
         if tools:
@@ -580,17 +580,98 @@ class LLMClient:
 
 
 def _with_cache(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Place a cache breakpoint on the *last* system block.
+    """Place a cache breakpoint on the *first* system block.
 
-    Anthropic supports up to 4 cache breakpoints; placing one at the end of
-    the system block is the pattern that gives us per-session reuse for the
-    stable identity/mission/plan content.
+    The convention across the prompt builders (`build_play_system_blocks`,
+    `build_setup_system_blocks`, `build_aar_system_blocks`,
+    `build_guardrail_system_blocks`) is **stable content first**: the
+    first block carries identity / mission / hard boundaries / tool
+    protocol / frozen plan — content that does not change turn-to-turn
+    within a session. Subsequent blocks (when present) carry volatile
+    content (presence column, follow-ups, rate-limit notices).
+
+    Putting ``cache_control`` on the first block tells Anthropic to
+    cache the prefix [tools + first_block]. Volatile content in any
+    later block sits *after* the breakpoint, gets re-processed cheaply
+    each turn, and never invalidates the cached prefix. On a typical
+    play turn this turns ~5-7k input tokens into cache_reads at ~10%
+    of normal input price.
+
+    Anthropic supports up to 4 cache breakpoints per request; this
+    function uses 1. The other 3 are available — see ``_with_message_cache``
+    below for the multi-turn message-history breakpoint.
     """
 
     if not blocks:
         return blocks
     out = [dict(b) for b in blocks]
-    out[-1] = {**out[-1], "cache_control": {"type": "ephemeral"}}
+    out[0] = {**out[0], "cache_control": {"type": "ephemeral"}}
+    return out
+
+
+def _with_message_cache(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Place a cache breakpoint on the last message in the conversation.
+
+    For multi-turn play, the messages array grows as the conversation
+    progresses but the *prefix* (everything before the latest content)
+    is identical between turns. Placing a breakpoint on the last
+    message of turn N means turn N+1 reads the entire prior
+    conversation from cache instead of reprocessing it.
+
+    The breakpoint goes on the last message regardless of role — this
+    is the standard multi-turn pattern from Anthropic's docs. When the
+    last message is the per-call ``_TURN_REMINDER``, this turn's cache
+    won't be reused by the next turn (since the reminder lands at a
+    different position next turn), but the breakpoint is harmless and
+    we still benefit from message caching when the structure is stable
+    (briefing turn, recovery passes).
+
+    The content of the last message may already be a list of blocks
+    (recovery path with tool_results). In that case we add
+    ``cache_control`` to the last block. For string-content messages we
+    convert to a single text block carrying the cache marker.
+
+    Returns a NEW list with the cache marker applied; does not mutate
+    the caller's list.
+    """
+
+    if not messages:
+        return messages
+    out = [dict(m) for m in messages]
+    last = dict(out[-1])
+    content = last.get("content")
+    if isinstance(content, str):
+        last["content"] = [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+    elif isinstance(content, list) and content:
+        new_content = [dict(b) if isinstance(b, dict) else b for b in content]
+        # Find the last block that's a dict we can attach cache_control to.
+        for i in range(len(new_content) - 1, -1, -1):
+            blk = new_content[i]
+            if isinstance(blk, dict):
+                blk["cache_control"] = {"type": "ephemeral"}
+                break
+        last["content"] = new_content
+    else:
+        # Empty list / None / int / non-coercible content shape — we
+        # silently fall through with no breakpoint. Log the skip at
+        # WARNING so a future refactor passing an unexpected content
+        # shape doesn't quietly drop our ~10× cache-read win without
+        # any signal in the audit log. Per CLAUDE.md "Logging rules"
+        # silent fallback paths are debugging blockers.
+        _logger.warning(
+            "message_cache_skipped",
+            reason="non_coercible_content",
+            content_type=type(content).__name__,
+            role=last.get("role"),
+        )
+        return messages
+    out[-1] = last
     return out
 
 

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -631,12 +631,15 @@ def _with_message_cache(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ``cache_control`` to the last block. For string-content messages we
     convert to a single text block carrying the cache marker.
 
-    Returns a NEW list with the cache marker applied; does not mutate
-    the caller's list.
+    Always returns a NEW list — never aliases the caller's list.
+    On the empty-input or non-coercible-content paths the returned
+    copy carries no cache marker (logged at WARNING in the latter
+    case), so the caller can mutate the result freely without
+    affecting the input.
     """
 
     if not messages:
-        return messages
+        return list(messages)
     out = [dict(m) for m in messages]
     last = dict(out[-1])
     content = last.get("content")
@@ -659,18 +662,21 @@ def _with_message_cache(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         last["content"] = new_content
     else:
         # Empty list / None / int / non-coercible content shape — we
-        # silently fall through with no breakpoint. Log the skip at
-        # WARNING so a future refactor passing an unexpected content
-        # shape doesn't quietly drop our ~10× cache-read win without
-        # any signal in the audit log. Per CLAUDE.md "Logging rules"
-        # silent fallback paths are debugging blockers.
+        # fall through with no breakpoint. Log the skip at WARNING
+        # so a future refactor passing an unexpected content shape
+        # doesn't quietly drop our ~10× cache-read win without any
+        # signal in the audit log. Per CLAUDE.md "Logging rules"
+        # silent fallback paths are debugging blockers. We still
+        # return the (un-marked) copy ``out`` so the contract
+        # "always returns a new list" holds — callers don't need a
+        # second branch to handle aliasing.
         _logger.warning(
             "message_cache_skipped",
             reason="non_coercible_content",
             content_type=type(content).__name__,
             role=last.get("role"),
         )
-        return messages
+        return out
     out[-1] = last
     return out
 

--- a/backend/app/llm/prompts.py
+++ b/backend/app/llm/prompts.py
@@ -657,6 +657,16 @@ def build_play_system_blocks(
 ) -> list[dict[str, Any]]:
     """Compose the play-tier system block list.
 
+    Returns TWO text blocks: a **stable prefix** (Blocks 1-9 + the seated
+    roster identity table + plan + extension prompts — content that does
+    not change between turns within a session) followed by a **volatile
+    suffix** (presence column, follow-ups, rate-limit, presence-aware
+    addressing rules — content that flips turn-by-turn). The cache
+    breakpoint placed by ``LLMClient._with_cache`` lands on the stable
+    prefix, so tools + stable system content gets cached across every
+    turn while volatile content is re-processed cheaply per turn. This
+    cuts per-turn input cost by ~85-90% on cache hits.
+
     ``connected_role_ids`` / ``focused_role_ids`` are the role_ids that
     currently have at least one open WebSocket connection (or focused tab)
     on this session, sourced from
@@ -883,7 +893,13 @@ def build_play_system_blocks(
         _WORKSTREAMS_PLAY_NOTE if workstreams_enabled else ""
     )
 
-    blocks: list[str] = [
+    # STABLE PREFIX (Blocks 1-9): identity, mission, hard boundaries,
+    # style, realism, tool-use protocol, frozen plan, extension prompts,
+    # and roster-size strategy. None of these change turn-to-turn within
+    # a single session — exactly the content we want Anthropic to cache
+    # so each subsequent turn pays cache_read pricing (~10% of input)
+    # rather than full input pricing on the same ~5-7k tokens.
+    stable_blocks: list[str] = [
         "## Block 1 — Identity\n" + _IDENTITY,
         "## Block 2 — Mission\n" + _MISSION,
         "## Block 3 — Plan adherence\n" + _PLAN_ADHERENCE,
@@ -894,6 +910,15 @@ def build_play_system_blocks(
         "## Block 7 — Frozen scenario plan\n```json\n" + plan_json + "\n```",
         "## Block 8 — Active extension prompts\n" + extension_block,
         "## Block 9 — Roster-size strategy\n" + _ROSTER_STRATEGY[session.roster_size],
+    ]
+
+    # VOLATILE SUFFIX (Blocks 10-12): roster with live presence column
+    # (flips when players focus / unfocus / reconnect tabs), open per-
+    # role follow-ups (mutates as the AI tracks/resolves them), and the
+    # conditional critical-event rate-limit notice. Kept out of the
+    # cached prefix so a single presence flip doesn't invalidate the
+    # whole system block.
+    volatile_blocks: list[str] = [
         "## Block 10 — Roster (use these role_ids in tool calls)\n"
         + "### Seated\n"
         + seated_table
@@ -906,13 +931,14 @@ def build_play_system_blocks(
     # model "you're rate-limited until turn N" stops it from retrying
     # the same critical-event call across turns (observed in the
     # 2026-04-29 session: AI tried inject_critical_event on three
-    # consecutive turns after the first was rate-limited). Omitted on
-    # healthy turns so the cached system block stays stable.
+    # consecutive turns after the first was rate-limited). Lives in
+    # the volatile suffix because ``current_turn.index`` changes every
+    # turn anyway.
     if session.critical_inject_rate_limit_until is not None:
         cur = session.current_turn.index if session.current_turn else 0
         until = session.critical_inject_rate_limit_until
         if until > cur:
-            blocks.append(
+            volatile_blocks.append(
                 "## Block 12 — Critical-event budget\n"
                 f"You are RATE-LIMITED from `inject_critical_event` until "
                 f"turn {until} (current turn: {cur}). Your previous attempts "
@@ -926,8 +952,10 @@ def build_play_system_blocks(
                 "your way past."
             )
 
-    text = "\n\n".join(blocks)
-    return [{"type": "text", "text": text}]
+    return [
+        {"type": "text", "text": "\n\n".join(stable_blocks)},
+        {"type": "text", "text": "\n\n".join(volatile_blocks)},
+    ]
 
 
 def _build_followup_block(session: Session) -> str:

--- a/backend/app/llm/prompts.py
+++ b/backend/app/llm/prompts.py
@@ -657,15 +657,26 @@ def build_play_system_blocks(
 ) -> list[dict[str, Any]]:
     """Compose the play-tier system block list.
 
-    Returns TWO text blocks: a **stable prefix** (Blocks 1-9 + the seated
-    roster identity table + plan + extension prompts — content that does
-    not change between turns within a session) followed by a **volatile
-    suffix** (presence column, follow-ups, rate-limit, presence-aware
-    addressing rules — content that flips turn-by-turn). The cache
-    breakpoint placed by ``LLMClient._with_cache`` lands on the stable
-    prefix, so tools + stable system content gets cached across every
-    turn while volatile content is re-processed cheaply per turn. This
-    cuts per-turn input cost by ~85-90% on cache hits.
+    Returns TWO text blocks:
+
+    * **Stable prefix** — Blocks 1-9 only: identity, mission, plan
+      adherence, hard boundaries, style, realism rail, tool-use
+      protocol, the frozen scenario plan JSON, extension prompts, and
+      roster-size strategy. None of these change turn-to-turn within
+      a single session.
+    * **Volatile suffix** — Block 10 (the entire seated roster table
+      *including* the per-row ``presence`` column, the unseated-roles
+      list, and the presence-aware addressing rules), Block 11 (open
+      per-role follow-ups), and conditional Block 12 (critical-event
+      rate-limit notice). Every component here flips turn-by-turn —
+      presence flips when players un/focus tabs, follow-ups mutate as
+      they're tracked / resolved, and Block 12 only appears while a
+      rate limit is active.
+
+    The cache breakpoint placed by ``LLMClient._with_cache`` lands on
+    the stable prefix, so tools + stable system content gets cached
+    across every turn while volatile content is re-processed cheaply
+    per turn. This cuts per-turn input cost by ~85% on cache hits.
 
     ``connected_role_ids`` / ``focused_role_ids`` are the role_ids that
     currently have at least one open WebSocket connection (or focused tab)

--- a/backend/tests/test_chat_declutter_phase_a.py
+++ b/backend/tests/test_chat_declutter_phase_a.py
@@ -228,7 +228,10 @@ class TestPromptFlagGate:
         blocks = build_play_system_blocks(
             session, registry=registry, workstreams_enabled=False
         )
-        text = blocks[0]["text"].lower()
+        # ``build_play_system_blocks`` returns multiple blocks (stable
+        # prefix + volatile suffix); flatten so a future move of the
+        # workstream copy between blocks doesn't silently mask a leak.
+        text = "\n\n".join(b["text"] for b in blocks).lower()
         assert "workstream" not in text
 
     def test_play_prompt_on_mentions_address_role_field(self) -> None:
@@ -237,7 +240,7 @@ class TestPromptFlagGate:
         blocks = build_play_system_blocks(
             session, registry=registry, workstreams_enabled=True
         )
-        text = blocks[0]["text"]
+        text = "\n\n".join(b["text"] for b in blocks)
         assert "workstream_id" in text
         # Plan §5.2: explicitly NOT a body-text @-syntax directive.
         # Make sure the prompt didn't sprout one.
@@ -954,12 +957,18 @@ class TestPromptToolConsistencyFlagOn:
         registry = freeze_bundle(ExtensionBundle())
         session = _setup_session()
         play_session = _build_play_session()
+        # ``build_play_system_blocks`` returns multiple blocks (stable
+        # prefix + volatile suffix); flatten so the tool-name scan
+        # covers both. ``build_setup_system_blocks`` is still a single
+        # block but ``join`` works for both shapes uniformly.
+        play_blocks = build_play_system_blocks(
+            play_session, registry=registry, workstreams_enabled=True
+        )
+        setup_blocks = build_setup_system_blocks(session, workstreams_enabled=True)
         all_text = "\n".join(
             [
-                build_setup_system_blocks(session, workstreams_enabled=True)[0]["text"],
-                build_play_system_blocks(
-                    play_session, registry=registry, workstreams_enabled=True
-                )[0]["text"],
+                "\n".join(b["text"] for b in setup_blocks),
+                "\n".join(b["text"] for b in play_blocks),
                 # Tool descriptions count too.
                 "\n".join(
                     str(t.get("description", "")) for t in setup_tools_for(workstreams_enabled=True)

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -1959,7 +1959,11 @@ def test_critical_inject_rate_limit_until_visible_to_model() -> None:
     blocks = build_play_system_blocks(
         s, registry=FrozenRegistry(tools={}, resources={}, prompts={})
     )
-    text = blocks[0]["text"]
+    # build_play_system_blocks splits stable + volatile content across
+    # multiple text blocks for prompt-cache placement; Block 12 lives
+    # in the volatile suffix so an active rate limit doesn't invalidate
+    # the cached prefix.
+    text = "\n\n".join(b["text"] for b in blocks)
     assert "Block 12" in text, "rate-limited turn must include Block 12"
     assert "until turn 7" in text
 
@@ -1998,7 +2002,7 @@ def test_critical_inject_block_12_omitted_when_no_rate_limit() -> None:
     blocks = build_play_system_blocks(
         s, registry=FrozenRegistry(tools={}, resources={}, prompts={})
     )
-    text = blocks[0]["text"]
+    text = "\n\n".join(b["text"] for b in blocks)
     assert "Block 12" not in text
 
 
@@ -3241,7 +3245,7 @@ def test_play_block_10_lists_seated_and_unseated_roles() -> None:
         session,
         registry=FrozenRegistry(tools={}, resources={}, prompts={}),
     )
-    text = blocks[0]["text"]
+    text = "\n\n".join(b["text"] for b in blocks)
     # Every seated role.id must appear in the table so the model can pass
     # opaque ids.
     assert "`role-ciso`" in text
@@ -3458,7 +3462,7 @@ def test_play_system_prompt_includes_open_followups() -> None:
     registry = FrozenRegistry(tools={}, resources={}, prompts={})
 
     blocks = build_play_system_blocks(session, registry=registry)
-    text = blocks[0]["text"]
+    text = "\n\n".join(b["text"] for b in blocks)
     assert "Block 11 — Open per-role follow-ups" in text
     assert "(none open)" in text
 
@@ -3467,14 +3471,15 @@ def test_play_system_prompt_includes_open_followups() -> None:
         RoleFollowup(role_id="role-soc", prompt="Confluence findings?")
     )
     blocks2 = build_play_system_blocks(session, registry=registry)
-    text2 = blocks2[0]["text"]
+    text2 = "\n\n".join(b["text"] for b in blocks2)
     assert "Confluence findings?" in text2
     assert "role-soc" in text2
 
     # Resolved items drop out of the block.
     session.role_followups[0].status = "done"
     blocks3 = build_play_system_blocks(session, registry=registry)
-    assert "Confluence findings?" not in blocks3[0]["text"]
+    text3 = "\n\n".join(b["text"] for b in blocks3)
+    assert "Confluence findings?" not in text3
 
 
 def test_ai_auto_interjects_on_facilitator_mention(client: TestClient) -> None:

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -17,7 +17,7 @@ from typing import Any
 import pytest
 
 from app.config import Settings
-from app.llm.client import LLMClient
+from app.llm.client import LLMClient, _with_cache, _with_message_cache
 from tests.mock_anthropic import MockAnthropic, response, text_block
 
 
@@ -194,3 +194,204 @@ async def test_call_id_appears_in_in_flight(settings: Settings) -> None:
         messages=[{"role": "user", "content": "hi"}],
         session_id="sess-4",
     )
+
+
+# ---------------------------------------------------------------- cache helpers
+
+
+def test_with_cache_marks_first_block_only() -> None:
+    """``_with_cache`` plants the breakpoint on the first (stable) block.
+
+    The convention across all four prompt builders is *stable content
+    first* — Blocks 1-9 of the play tier sit in block[0]; volatile
+    presence / follow-ups / rate-limit live in block[1]. Putting
+    ``cache_control`` on block[0] tells Anthropic the cacheable prefix
+    ends there, which means a presence flip on the next turn doesn't
+    invalidate the cache.
+    """
+
+    blocks = [
+        {"type": "text", "text": "stable prefix"},
+        {"type": "text", "text": "volatile suffix"},
+    ]
+    out = _with_cache(blocks)
+    assert out[0]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in out[1]
+    # Original list must not be mutated.
+    assert "cache_control" not in blocks[0]
+
+
+def test_with_cache_single_block_still_marked() -> None:
+    """Setup / AAR / guardrail tiers return a single text block — the
+    breakpoint must still land on it (the only block IS the stable
+    prefix in those single-block tiers)."""
+
+    blocks = [{"type": "text", "text": "all stable"}]
+    out = _with_cache(blocks)
+    assert out[0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_with_cache_empty_returns_empty() -> None:
+    assert _with_cache([]) == []
+
+
+def test_with_message_cache_promotes_string_content() -> None:
+    """The standard message shape from ``_play_messages`` is
+    ``content: str``; the cache helper must promote that to a list of
+    text blocks so it can carry ``cache_control``."""
+
+    msgs = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "last"},
+    ]
+    out = _with_message_cache(msgs)
+    last_content = out[-1]["content"]
+    assert isinstance(last_content, list)
+    assert last_content[-1]["type"] == "text"
+    assert last_content[-1]["text"] == "last"
+    assert last_content[-1]["cache_control"] == {"type": "ephemeral"}
+    # Earlier messages untouched.
+    assert out[0]["content"] == "first"
+    # Original list must not be mutated.
+    assert msgs[-1]["content"] == "last"
+
+
+def test_with_message_cache_preserves_structured_content() -> None:
+    """The recovery / strict-retry path builds a list of
+    ``tool_result`` blocks plus a trailing text directive nudge. The
+    cache helper must NOT mutate ``tool_result`` blocks (they carry
+    ``tool_use_id`` / ``is_error`` semantics) — only the trailing
+    block gets the ``cache_control`` marker."""
+
+    recovery_blocks: list[dict[str, Any]] = [
+        {"type": "tool_result", "tool_use_id": "a", "content": "r1"},
+        {"type": "tool_result", "tool_use_id": "b", "content": "r2"},
+        {"type": "text", "text": "recovery directive"},
+    ]
+    msgs = [
+        {"role": "user", "content": "kickoff"},
+        {"role": "assistant", "content": "tool calls"},
+        {"role": "user", "content": recovery_blocks},
+    ]
+    out = _with_message_cache(msgs)
+    last_content = out[-1]["content"]
+    assert last_content[-1]["cache_control"] == {"type": "ephemeral"}
+    # The two ``tool_result`` blocks must NOT have grown a cache_control field.
+    assert "cache_control" not in last_content[0]
+    assert "cache_control" not in last_content[1]
+    # Original list must not be mutated.
+    assert "cache_control" not in recovery_blocks[-1]
+
+
+def test_with_message_cache_empty_returns_empty() -> None:
+    assert _with_message_cache([]) == []
+
+
+def test_with_cache_recovery_shape_marks_only_first_block() -> None:
+    """The recovery / strict-retry path appends a directive system
+    addendum on top of the play-tier two-block list (and the AAR
+    interject path may add more), producing a 3- or 4-block shape.
+    The cache breakpoint must still land on block[0] (the stable
+    prefix) and never on the appended addenda — a future
+    refactor that flipped to ``[-1]`` semantics would silently
+    relocate the breakpoint past the volatile suffix and pollute the
+    cache key with directive-specific text."""
+
+    blocks = [
+        {"type": "text", "text": "stable prefix"},
+        {"type": "text", "text": "volatile suffix"},
+        {"type": "text", "text": "recovery directive addendum"},
+        {"type": "text", "text": "extra addendum"},
+    ]
+    out = _with_cache(blocks)
+    assert out[0]["cache_control"] == {"type": "ephemeral"}
+    for i in range(1, len(out)):
+        assert "cache_control" not in out[i], f"block[{i}] should not be cached"
+
+
+def test_play_system_blocks_split_invariant() -> None:
+    """Regression net for the cache contract itself: the play-tier
+    builder MUST return TWO blocks (stable prefix + volatile suffix).
+    A future refactor merging them or moving Block 11 into the stable
+    prefix would silently break the cache invariant — Anthropic would
+    invalidate the cache on every per-turn flip and the ~85% input-
+    cost reduction this design buys would quietly disappear.
+    """
+
+    from app.extensions.registry import FrozenRegistry
+    from app.llm.prompts import build_play_system_blocks
+    from app.sessions.models import (
+        Role,
+        ScenarioBeat,
+        ScenarioInject,
+        ScenarioPlan,
+        Session,
+        SessionState,
+    )
+
+    session = Session(
+        scenario_prompt="x",
+        state=SessionState.AWAITING_PLAYERS,
+        roles=[Role(id="r1", label="CISO", is_creator=True)],
+        creator_role_id="r1",
+        plan=ScenarioPlan(
+            title="t",
+            executive_summary="s",
+            key_objectives=["k"],
+            narrative_arc=[
+                ScenarioBeat(beat=1, label="b", expected_actors=["CISO"])
+            ],
+            injects=[ScenarioInject(trigger="x", summary="y")],
+        ),
+    )
+    blocks = build_play_system_blocks(
+        session, registry=FrozenRegistry(tools={}, resources={}, prompts={})
+    )
+    assert len(blocks) == 2, (
+        f"play system blocks must split into 2 (stable + volatile); got {len(blocks)}"
+    )
+    stable, volatile = blocks
+    # Stable prefix carries Blocks 1-9 (Identity through Strategy).
+    assert "## Block 1 — Identity" in stable["text"]
+    assert "## Block 9 — Roster-size strategy" in stable["text"]
+    # Volatile suffix carries Block 10 (presence-bearing roster) and
+    # Block 11 (open follow-ups). Critically, the actual block headers
+    # must live ONLY in volatile so a presence flip doesn't invalidate
+    # the cached prefix.
+    assert "## Block 10 — Roster" in volatile["text"]
+    assert "## Block 11 — Open per-role follow-ups" in volatile["text"]
+    assert "## Block 10 — Roster" not in stable["text"]
+    assert "## Block 11 — Open per-role follow-ups" not in stable["text"]
+    # The presence column lives in volatile, not stable.
+    assert "| role_id | label | display_name | kind | presence |" in volatile["text"]
+    assert "| role_id | label | display_name | kind | presence |" not in stable["text"]
+
+
+def test_with_message_cache_logs_skip_on_non_coercible_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per CLAUDE.md "logging-and-debuggability" rule: the silent
+    fallback when message content has an unexpected shape (None,
+    int, empty list) must emit a WARNING so a future refactor
+    passing the wrong shape doesn't quietly drop the ~10× cache-
+    read win without any log signal."""
+
+    from app.llm import client as client_mod
+
+    captured: list[dict[str, Any]] = []
+
+    class _CapturingLogger:
+        def warning(self, event: str, **kw: Any) -> None:
+            captured.append({"event": event, **kw})
+
+    monkeypatch.setattr(client_mod, "_logger", _CapturingLogger())
+
+    # None content triggers the else branch.
+    msgs = [{"role": "user", "content": None}]
+    out = _with_message_cache(msgs)
+    assert out is msgs  # unchanged
+    assert any(c["event"] == "message_cache_skipped" for c in captured)
+    skip = next(c for c in captured if c["event"] == "message_cache_skipped")
+    assert skip["reason"] == "non_coercible_content"
+    assert skip["content_type"] == "NoneType"

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -390,7 +390,15 @@ def test_with_message_cache_logs_skip_on_non_coercible_content(
     # None content triggers the else branch.
     msgs = [{"role": "user", "content": None}]
     out = _with_message_cache(msgs)
-    assert out is msgs  # unchanged
+    # Contract: always returns a NEW list. The skip path returns the
+    # copy (no cache_control on it) so callers can mutate the result
+    # without affecting the input.
+    assert out is not msgs
+    assert out[0]["content"] is None
+    # No cache_control was added — empty/None content can't carry one.
+    assert "cache_control" not in out[0]
+    # Original list must not be mutated.
+    assert msgs[0]["content"] is None
     assert any(c["event"] == "message_cache_skipped" for c in captured)
     skip = next(c for c in captured if c["event"] == "message_cache_skipped")
     assert skip["reason"] == "non_coercible_content"

--- a/backend/tests/test_prompt_presence.py
+++ b/backend/tests/test_prompt_presence.py
@@ -81,13 +81,17 @@ def _play_text(
     connected: set[str] | None,
     focused: set[str] | None,
 ) -> str:
+    # ``build_play_system_blocks`` now returns multiple blocks (stable
+    # prefix + volatile suffix) so prompt-cache breakpoints can land on
+    # the stable content. Flatten across blocks so the assertions below
+    # check the rendered prompt as the model would see it.
     blocks = build_play_system_blocks(
         _session(),
         registry=_registry(),
         connected_role_ids=connected,
         focused_role_ids=focused,
     )
-    return blocks[0]["text"]
+    return "\n\n".join(b["text"] for b in blocks)
 
 
 # -------------------------------------------------------------- column shape
@@ -268,7 +272,7 @@ def test_play_table_sanitises_label_against_markdown_row_injection() -> None:
         connected_role_ids={"role-attacker"},
         focused_role_ids={"role-attacker"},
     )
-    text = blocks[0]["text"]
+    text = "\n\n".join(b["text"] for b in blocks)
     # The fake role_id must NOT appear in the rendered table as a
     # backticked ID — the newline that would have started a new row
     # must be defused.
@@ -314,6 +318,6 @@ def test_briefing_and_play_share_same_block_10() -> None:
         connected_role_ids={"role-ciso"},
         focused_role_ids={"role-ciso"},
     )
-    text = blocks[0]["text"]
+    text = "\n\n".join(b["text"] for b in blocks)
     assert "| role_id | label | display_name | kind | presence |" in text
     assert "Presence-aware addressing" in text

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -3,8 +3,24 @@
 The full system-prompt text lives in
 [`backend/app/llm/prompts.py`](../backend/app/llm/prompts.py); this
 document is the prose reference + design rationale. Each per-tier
-prompt is composed at runtime and a cache breakpoint is placed on the
-last system block so per-session reuse is cheap.
+prompt is composed at runtime.
+
+**Prompt caching.** `build_play_system_blocks` returns the system
+prompt as **two text blocks** — a stable prefix (Blocks 1–9, ~85% of
+play-tier system tokens) and a volatile suffix (Block 10 roster +
+presence column, Block 11 follow-ups, conditional Block 12 rate-limit
+notice). `LLMClient._with_cache` plants an `ephemeral` cache breakpoint
+on the stable prefix so the entire ~5–7k-token preamble (plus the
+deterministic tool list rendered before it) cache-reads at ~10% of
+input price on every subsequent turn within a session. Volatile
+content sits *after* the breakpoint and is reprocessed cheaply per
+turn — a single presence flip never invalidates the prefix.
+
+`LLMClient._with_message_cache` plants a second breakpoint on the
+last message of every call, so multi-turn play also benefits from
+incremental message-history caching. Setup, AAR, and guardrail tiers
+return a single block and behave the same as the pre-split contract:
+the breakpoint sits on the only block.
 
 > **Engine-side guardrails first.** The prompts express the
 > facilitator's intent, but the engine does NOT trust the model to
@@ -90,8 +106,12 @@ parser.
 
 ## Play-tier system blocks
 
-Composed by `build_play_system_blocks(session, registry)` and cached
-on the last block.
+Composed by `build_play_system_blocks(session, registry)` and returned
+as two text blocks: a **stable prefix** (Blocks 1–9) and a **volatile
+suffix** (Blocks 10–12). The cache breakpoint lands on the stable
+prefix; volatile content stays out of the cache key so per-turn flips
+(presence column, follow-up status, rate-limit) never invalidate the
+~85% of system tokens that don't change within a session.
 
 ### Block 1 — Identity
 
@@ -301,8 +321,10 @@ instead. Pre-fix the AI was observed retrying the same
 `inject_critical_event` call on three consecutive turns after the
 first attempt was rate-limited; the strict-retry feedback only
 covered the same turn, so each new turn the AI tried again blind.
-Block is omitted on healthy turns to keep the cached system block
-stable.
+Block is conditional. It also lives in the **volatile suffix** (along
+with Block 10's presence column and Block 11's follow-up list), so
+flipping it on or off — and the per-turn `current_turn.index` it
+references — never invalidates the cached stable prefix.
 
 ---
 


### PR DESCRIPTION
## Summary

Cuts per-turn input cost on the play tier by ~85% via two prompt-cache restructurings:

- **Split `build_play_system_blocks` into stable prefix + volatile suffix.** Blocks 1–9 (Identity, Mission, Plan adherence, Hard boundaries, Style, Realism, Tool-use protocol, Frozen scenario plan, Extension prompts, Roster-size strategy) now render as block[0]; Blocks 10–12 (presence-bearing roster, open follow-ups, conditional rate-limit notice) render as block[1]. `LLMClient._with_cache` plants the `cache_control: ephemeral` marker on the first block, so the cached prefix `[tools + stable system]` survives turn-to-turn flips of presence / follow-ups / rate-limit. Verified byte-identical: rendering the same session at different turns / presence states produces the same stable-block bytes.
- **Add `_with_message_cache` for multi-turn message caching.** Plants a second cache breakpoint on the last message of every call so subsequent turns read prior conversation history at cache_read pricing instead of reprocessing. Handles string-content (promotes to `[{type: "text", ..., cache_control}]`), list-content recovery shapes (preserves `tool_result` blocks, marks the trailing text block), and emits a `message_cache_skipped` WARNING on non-coercible content (per CLAUDE.md silent-fallback rule).

`docs/prompts.md` updated to describe the two-block contract.

## Why

The single-block prompt put all stable + volatile content under one cache breakpoint. A presence flip (player un/focuses a tab), a tracked follow-up, or a rate-limit notice silently invalidated the cache for ~25k chars on every turn. With the split, ~85% of system tokens (the stable prefix) get `cache_read` pricing (~10% of input rate) on every cached turn within a session.

## Sub-agent review

Per CLAUDE.md, ran QA / Security / Prompt-Expert / Product reviews in parallel before push. Skipped UI/UX and User-agent reviews — the change is purely server-side cache infrastructure with no user-visible behavior change.

- **Security**: clean. `_sanitize_table_cell` + `_escape_fence_tokens` still run on every call; cache key is `(API key, exact byte prefix)` so different sessions produce different prefix hashes; `_with_message_cache` shallow-copies and only mutates the trailing block.
- **Prompt Expert**: APPROVE. Cross-block references all resolve, block ordering preserved, `test_prompt_tool_consistency.py` passes.
- **QA**: 2 HIGH (missing unit tests / structural invariant), 1 MEDIUM (3 stale `blocks[0]["text"]` sites in `test_chat_declutter_phase_a.py`), 1 LOW debugging-blocker (silent fallback in `_with_message_cache`). **All addressed in this commit** — 9 new tests covering both helpers, the multi-block recovery shape, the structural 2-block invariant, and the WARNING-on-skip behavior.
- **Product**: 3 MEDIUMs deferred as follow-ups (see below). Verdict was "ships value as-is".

## Deferred follow-ups (tracked here, not in this PR)

- Extend the stable+volatile split to `build_setup_system_blocks`, `build_aar_system_blocks`, and `build_guardrail_system_blocks`. Setup and AAR fire once per session each (modest impact); guardrail fires on every player message and would be the bigger absolute win.
- "Prompt trim candidates" sweep through the Prompt Expert agent — looking for redundant restatements between Block 3 plan-adherence and Block 6 tool-protocol, etc. Out of scope for this PR (caching gives a bigger lever at lower risk).
- Audit `effort` / tier choices for guardrail and other low-stakes calls; surface candidates for downshift to Haiku + `effort: "low"`.

## Test plan

- [x] `pytest tests/ --ignore=tests/live` → **764 passed, 1 skipped** (was 755 before; +9 new tests)
- [x] `ruff check app/llm/client.py app/llm/prompts.py tests/...` → clean
- [x] `mypy app/llm/client.py app/llm/prompts.py` → clean
- [x] Verified stable prefix is byte-identical across turn / presence changes
- [x] Verified `_with_cache` puts marker on `blocks[0]` for both 1-block (setup/AAR/guardrail) and N-block (play, recovery) shapes
- [x] Verified `_with_message_cache` does not mutate `tool_result` blocks in recovery-path content
- [ ] Live-API smoke (run `backend/scripts/run-live-tests.sh` before merge to confirm no model-routing regression — this PR touches `app/llm/client.py` and `app/llm/prompts.py` so the always-do checklist requires it)

https://claude.ai/code/session_01MvYJW3cyK22J4qJ8z752Rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvYJW3cyK22J4qJ8z752Rp)_