### PR TITLE
frontend: fix four UI regressions from recent setup-flow rework

### DIFF
--- a/frontend/src/__tests__/JoinIntro.waiting.test.tsx
+++ b/frontend/src/__tests__/JoinIntro.waiting.test.tsx
@@ -82,6 +82,33 @@ describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
     ).toBeNull();
   });
 
+  it("hasName=true, sessionState=READY → 'finalising the lobby' copy variant", () => {
+    // Plan is finalised, creator is gathering players in the lobby.
+    // Pre-fix this state fell through to the chat view (sessionState
+    // was not in the waiting list), so a player who joined here saw
+    // a blank transcript with a disabled composer, then got yanked
+    // BACK to the waiting screen the moment the creator hit Start
+    // (state went READY → BRIEFING). Now we hold them on JoinIntro
+    // for the full SETUP → READY → BRIEFING arc.
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="READY"
+        hasName
+        joinedDisplayName="Bridget"
+      />,
+    );
+    expect(screen.getByTestId("join-intro-waiting")).toBeInTheDocument();
+    expect(
+      screen.getByText(/finalising the lobby/i),
+    ).toBeInTheDocument();
+    // BRIEFING-specific copy must NOT appear — the AI hasn't started
+    // a brief yet during READY.
+    expect(
+      screen.queryByText(/AI is preparing the scenario brief/i),
+    ).toBeNull();
+  });
+
   it("tip carousel rotates after the configured interval", () => {
     render(
       <JoinIntro

--- a/frontend/src/__tests__/Play.e2e.test.tsx
+++ b/frontend/src/__tests__/Play.e2e.test.tsx
@@ -211,6 +211,24 @@ describe("Play page e2e — state transitions", () => {
     ).toBeInTheDocument();
   });
 
+  it("READY: surfaces the lobby-finalising waiting variant (no chat shell)", async () => {
+    // Pre-fix the player jumped straight into the chat shell when
+    // state hit READY (creator approved plan, lobby open) and then
+    // got yanked BACK to a waiting screen the moment the creator
+    // hit Start. Now the player stays on JoinIntro for the full
+    // SETUP → READY → BRIEFING arc.
+    const ready = _setupSnapshot();
+    ready.state = "READY";
+    vi.spyOn(api, "getSession").mockImplementation(async () => ready);
+    render(<Play sessionId="s-test" token={_socToken()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("join-intro-waiting")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/finalising the lobby/i)).toBeInTheDocument();
+    // Composer must NOT render — the player can't act in READY.
+    expect(screen.queryByPlaceholderText(/type your response/i)).toBeNull();
+  });
+
   it("PLAY (AWAITING_PLAYERS): shows the chat layout and a reachable Composer", async () => {
     vi.spyOn(api, "getSession").mockImplementation(async () => _playSnapshot());
     render(<Play sessionId="s-test" token={_socToken()} />);

--- a/frontend/src/__tests__/SetupChat.scroll.test.tsx
+++ b/frontend/src/__tests__/SetupChat.scroll.test.tsx
@@ -1,0 +1,179 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SetupChat } from "../components/SetupChat";
+import type { SetupNoteView } from "../api/client";
+
+/**
+ * Lock the auto-scroll contract added in May 2026 for the user-reported
+ * bug "Step 04 transcript window doesn't auto-scroll." A future refactor
+ * (someone extracts the chat into a sub-component, wraps it in a
+ * virtualizer, etc.) without these tests would silently regress —
+ * scrollTop stuck at 0 reads as "the chat is broken" but doesn't
+ * throw.
+ */
+
+function note(overrides: Partial<SetupNoteView>): SetupNoteView {
+  return {
+    speaker: overrides.speaker ?? "ai",
+    content: overrides.content ?? "Hi, what's the scenario?",
+    topic: overrides.topic ?? null,
+    options: overrides.options ?? null,
+    ts: overrides.ts ?? "2026-05-07T00:00:00Z",
+  };
+}
+
+describe("SetupChat — auto-scroll on note arrival", () => {
+  it("pins to the bottom on first render", () => {
+    const notes = [note({ speaker: "ai", content: "first" })];
+    const { container } = render(<SetupChat notes={notes} />);
+    const log = container.querySelector("[role='log']") as HTMLDivElement;
+    // jsdom doesn't lay out — scrollHeight / clientHeight default to 0.
+    // We assert the assignment happened (scrollTop is settable here)
+    // by mocking the layout values and re-running the effect via a
+    // re-render with a new note count.
+    Object.defineProperty(log, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(log, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    log.scrollTop = 0; // reset
+    // Re-render with a new note to fire the effect.
+    const { container: c2 } = render(
+      <SetupChat
+        notes={[note({ speaker: "ai", content: "first" }), note({ speaker: "creator", content: "second" })]}
+      />,
+    );
+    const log2 = c2.querySelector("[role='log']") as HTMLDivElement;
+    Object.defineProperty(log2, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(log2, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    // First-render path: wasNearBottomRef defaults to true, so the
+    // effect set scrollTop = scrollHeight. Confirm the slot at least
+    // received a numeric set (jsdom doesn't clamp).
+    expect(typeof log2.scrollTop).toBe("number");
+  });
+
+  it("does NOT clobber scrollTop when the user has scrolled up (User Agent HIGH)", () => {
+    // User Agent review caught this as HIGH: pre-fix the auto-pin was
+    // unconditional, which yanked an operator who'd scrolled up to
+    // re-read a clarifying question right back to the bottom on every
+    // WS event. The near-bottom gate (80px threshold) is the
+    // canonical fix.
+    const notesA = [
+      note({ speaker: "ai", content: "Q1" }),
+      note({ speaker: "creator", content: "A1" }),
+      note({ speaker: "ai", content: "Q2" }),
+    ];
+    const { container, rerender } = render(<SetupChat notes={notesA} />);
+    const log = container.querySelector("[role='log']") as HTMLDivElement;
+    // Mock layout so the scroll handler can compute distance.
+    Object.defineProperty(log, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(log, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    // Simulate the operator scrolling up: scrollTop = 0 means we're
+    // at the top, ~600px from the bottom.
+    log.scrollTop = 0;
+    log.dispatchEvent(new Event("scroll"));
+    // Add a new note. Pre-fix this would set scrollTop = 1000.
+    const notesB = [...notesA, note({ speaker: "ai", content: "Q3" })];
+    rerender(<SetupChat notes={notesB} />);
+    // Expect scrollTop still 0 — the gate prevented the pin.
+    expect(log.scrollTop).toBe(0);
+  });
+
+  it("DOES pin to the bottom when the user is near the bottom on a new note", () => {
+    const notesA = [
+      note({ speaker: "ai", content: "Q1" }),
+      note({ speaker: "creator", content: "A1" }),
+    ];
+    const { container, rerender } = render(<SetupChat notes={notesA} />);
+    const log = container.querySelector("[role='log']") as HTMLDivElement;
+    Object.defineProperty(log, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+      writable: true,
+    });
+    Object.defineProperty(log, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    // Simulate the operator near the bottom: 1000 - 600 - 400 = 0px
+    // distance from bottom (well within the 80px threshold).
+    log.scrollTop = 600;
+    log.dispatchEvent(new Event("scroll"));
+    // New note arrives; scrollHeight grows.
+    Object.defineProperty(log, "scrollHeight", {
+      configurable: true,
+      value: 1100,
+      writable: true,
+    });
+    const notesB = [...notesA, note({ speaker: "ai", content: "Q3" })];
+    rerender(<SetupChat notes={notesB} />);
+    // Effect should have set scrollTop to scrollHeight (1100).
+    expect(log.scrollTop).toBe(1100);
+  });
+
+  it("re-fires the pin when aiTyping flips on (operator near bottom)", () => {
+    // The typing indicator renders an inline ChatIndicator that grows
+    // the layout — auto-scroll keeps it visible.
+    const notes = [note({ speaker: "ai", content: "Q1" })];
+    const { container, rerender } = render(<SetupChat notes={notes} />);
+    const log = container.querySelector("[role='log']") as HTMLDivElement;
+    Object.defineProperty(log, "scrollHeight", {
+      configurable: true,
+      value: 600,
+      writable: true,
+    });
+    Object.defineProperty(log, "clientHeight", {
+      configurable: true,
+      value: 600,
+    });
+    log.scrollTop = 0; // 600 - 0 - 600 = 0 → at bottom
+    log.dispatchEvent(new Event("scroll"));
+    Object.defineProperty(log, "scrollHeight", {
+      configurable: true,
+      value: 700,
+      writable: true,
+    });
+    rerender(<SetupChat notes={notes} aiTyping />);
+    expect(log.scrollTop).toBe(700);
+  });
+
+  it("renders the empty-state placeholder when no notes (no scroll target)", () => {
+    const { queryByRole, getByText } = render(<SetupChat notes={[]} />);
+    expect(queryByRole("log")).toBeNull();
+    expect(getByText(/Setup hasn't started yet/i)).toBeInTheDocument();
+  });
+
+  // Sanity: make sure the option-chip handler still wires through —
+  // the auto-scroll changes shouldn't have touched the chip path.
+  it("calls onPickOption when an option chip is clicked", () => {
+    const handler = vi.fn();
+    const notes = [
+      note({
+        speaker: "ai",
+        content: "Pick one",
+        options: ["A", "B"],
+      }),
+    ];
+    const { getByRole } = render(
+      <SetupChat notes={notes} onPickOption={handler} />,
+    );
+    const btn = getByRole("button", { name: "A" });
+    btn.click();
+    expect(handler).toHaveBeenCalledWith("A");
+  });
+});

--- a/frontend/src/__tests__/SetupChat.scroll.test.tsx
+++ b/frontend/src/__tests__/SetupChat.scroll.test.tsx
@@ -23,44 +23,6 @@ function note(overrides: Partial<SetupNoteView>): SetupNoteView {
 }
 
 describe("SetupChat — auto-scroll on note arrival", () => {
-  it("pins to the bottom on first render", () => {
-    const notes = [note({ speaker: "ai", content: "first" })];
-    const { container } = render(<SetupChat notes={notes} />);
-    const log = container.querySelector("[role='log']") as HTMLDivElement;
-    // jsdom doesn't lay out — scrollHeight / clientHeight default to 0.
-    // We assert the assignment happened (scrollTop is settable here)
-    // by mocking the layout values and re-running the effect via a
-    // re-render with a new note count.
-    Object.defineProperty(log, "scrollHeight", {
-      configurable: true,
-      value: 1000,
-    });
-    Object.defineProperty(log, "clientHeight", {
-      configurable: true,
-      value: 400,
-    });
-    log.scrollTop = 0; // reset
-    // Re-render with a new note to fire the effect.
-    const { container: c2 } = render(
-      <SetupChat
-        notes={[note({ speaker: "ai", content: "first" }), note({ speaker: "creator", content: "second" })]}
-      />,
-    );
-    const log2 = c2.querySelector("[role='log']") as HTMLDivElement;
-    Object.defineProperty(log2, "scrollHeight", {
-      configurable: true,
-      value: 1000,
-    });
-    Object.defineProperty(log2, "clientHeight", {
-      configurable: true,
-      value: 400,
-    });
-    // First-render path: wasNearBottomRef defaults to true, so the
-    // effect set scrollTop = scrollHeight. Confirm the slot at least
-    // received a numeric set (jsdom doesn't clamp).
-    expect(typeof log2.scrollTop).toBe("number");
-  });
-
   it("does NOT clobber scrollTop when the user has scrolled up (User Agent HIGH)", () => {
     // User Agent review caught this as HIGH: pre-fix the auto-pin was
     // unconditional, which yanked an operator who'd scrolled up to

--- a/frontend/src/__tests__/SetupLobbyView.cta.test.tsx
+++ b/frontend/src/__tests__/SetupLobbyView.cta.test.tsx
@@ -1,0 +1,238 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SetupLobbyView } from "../components/setup/SetupLobbyView";
+import type { ScenarioPlan, RoleView } from "../api/client";
+
+/**
+ * Lock the lobby-side launch / advance CTAs added in May 2026.
+ *
+ * Pre-fix the wizard auto-advanced to step 6 (Review) the moment the
+ * plan was finalised, bypassing the lobby entirely. The fix lands
+ * the creator on step 5 (Invite players) by default, so the lobby
+ * itself owns the primary launch CTA — and a secondary "REVIEW &
+ * LAUNCH →" affordance is exposed for creators who want a
+ * presence-aware confirmation screen.
+ *
+ * Both CTAs are gated on the launch readiness criteria (plan
+ * finalised + ≥ 2 player roles) AND on the parent wiring the
+ * corresponding handler — so an unmet gate hides the button
+ * entirely (sidecar status copy explains why).
+ */
+
+function role(overrides: Partial<RoleView>): RoleView {
+  return {
+    id: overrides.id ?? "r-test",
+    label: overrides.label ?? "Player",
+    display_name: overrides.display_name ?? null,
+    kind: overrides.kind ?? "player",
+    is_creator: overrides.is_creator ?? false,
+    token_version: overrides.token_version ?? 0,
+  };
+}
+
+function fakePlan(): ScenarioPlan {
+  return {
+    title: "Test plan",
+    executive_summary: "summary",
+    key_objectives: ["obj 1"],
+    guardrails: [],
+    success_criteria: [],
+    out_of_scope: [],
+    narrative_arc: [],
+    injects: [{ trigger: "T+10", type: "info", summary: "ping" }],
+  };
+}
+
+const COMMON_PROPS = {
+  sessionId: "sess-1",
+  creatorToken: "creator-token",
+  busy: false,
+  connectedRoleIds: new Set<string>(),
+  onRoleAdded: vi.fn(),
+  onRoleChanged: vi.fn(),
+  onError: vi.fn(),
+};
+
+describe("SetupLobbyView — CTAs (lobby-as-launch-surface)", () => {
+  it("plan + ≥2 players + onLaunchSession wired: START SESSION CTA renders and fires", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    const onLaunch = vi.fn();
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        onLaunchSession={onLaunch}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /start session/i });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onLaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("no plan: START SESSION CTA suppressed, sidecar status reads 'Plan not finalized'", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={null}
+        playerCount={2}
+        onLaunchSession={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /start session/i }),
+    ).toBeNull();
+    expect(
+      screen.getByText(/plan not finalized yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("only 1 player role: START SESSION suppressed, sidecar status reads 'Need at least 2'", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso]}
+        plan={fakePlan()}
+        playerCount={1}
+        onLaunchSession={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /start session/i }),
+    ).toBeNull();
+    expect(
+      screen.getByText(/need at least 2 player roles/i),
+    ).toBeInTheDocument();
+  });
+
+  it("onLaunchSession not wired: START SESSION CTA suppressed even when gates met", () => {
+    // Defensive: parent must explicitly opt in by wiring the handler.
+    // Pre-fix the wizard auto-advanced to step 6 in this case, so a
+    // "gates met but no handler" was unreachable. Now it's possible
+    // (e.g. parent forgot to wire) and the CTA stays hidden — the
+    // sidecar status copy still explains the state.
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        // onLaunchSession intentionally omitted
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /start session/i }),
+    ).toBeNull();
+  });
+
+  it("plan + ≥2 players + onAdvanceToReview wired: REVIEW & LAUNCH affordance renders and fires", () => {
+    // Secondary affordance for creators who want a presence-aware
+    // confirmation before launch. Distinct from the rail click (also
+    // valid) because the affordance lives in the natural reading
+    // path of the sidecar.
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    const onAdvance = vi.fn();
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        onLaunchSession={vi.fn()}
+        onAdvanceToReview={onAdvance}
+      />,
+    );
+    const btn = screen.getByRole("button", {
+      name: /advance to step 6/i,
+    });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it("REVIEW & LAUNCH suppressed when launch gates not met", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso]}
+        plan={fakePlan()}
+        playerCount={1}
+        onAdvanceToReview={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /advance to step 6/i }),
+    ).toBeNull();
+  });
+
+  it("REVIEW & LAUNCH suppressed when handler not wired (parent opt-in)", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        onLaunchSession={vi.fn()}
+        // onAdvanceToReview intentionally omitted
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /advance to step 6/i }),
+    ).toBeNull();
+  });
+
+  it("busy: both CTAs disabled but still rendered (so a dropped network response can't strand the user)", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        busy={true}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        onLaunchSession={vi.fn()}
+        onAdvanceToReview={vi.fn()}
+      />,
+    );
+    const start = screen.getByRole("button", { name: /STARTING…/i });
+    expect(start).toBeDisabled();
+    const advance = screen.getByRole("button", {
+      name: /advance to step 6/i,
+    });
+    expect(advance).toBeDisabled();
+  });
+
+  it("ready-state sidecar copy invites the user to share invite links + launch", () => {
+    // Pre-fix the sidecar said "Ready — advance to step 06 to review
+    // and launch." Now the lobby IS the launch surface, so the copy
+    // points to the action that matters: share invites then launch.
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        onLaunchSession={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/share invite links and launch/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/__tests__/SetupWizard.test.tsx
@@ -158,13 +158,35 @@ describe("SetupWizard — phase routing (issue #113)", () => {
     expect(screen.queryByText(/step 06/i)).not.toBeInTheDocument();
   });
 
-  it("ready + plan + ≥2 players: highlights step 06 (Review & launch)", () => {
+  it("ready + plan + ≥2 players (default): lands on step 05 — review only via explicit advance", () => {
+    // After plan finalisation we land on step 5 (Invite players) so
+    // the creator can share join links and confirm the lobby BEFORE
+    // reviewing. Step 6 is only reached when ``advancedToReview`` is
+    // explicitly true (rail click on step 6, or the lobby's "REVIEW
+    // & LAUNCH" affordance).
     render(
       <SetupWizard
         phase="ready"
         {...baseProps()}
         snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
         playerCount={2}
+        postCreationContent={<div data-testid="lobby-slot">lobby</div>}
+      />,
+    );
+    expect(screen.getByText(/step 05 · invite players/i)).toBeInTheDocument();
+    expect(screen.queryByText(/step 06 · review/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("lobby-slot")).toBeInTheDocument();
+  });
+
+  it("ready + plan + ≥2 players + advancedToReview=true: highlights step 06 (Review & launch)", () => {
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
+        playerCount={2}
+        advancedToReview={true}
+        setAdvancedToReview={vi.fn()}
         postCreationContent={<div data-testid="review-slot">review</div>}
       />,
     );
@@ -210,20 +232,21 @@ describe("SetupWizard — rail back-nav (User HIGH#2)", () => {
   });
 });
 
-describe("SetupWizard — lobby ↔ review back-nav (presence-aware launch)", () => {
-  it("ready + lobbyOverride=true: pins step 5 even when launch gates are met", () => {
-    // Plan finalized + 3 player roles → step 6 normally. Setting
-    // lobbyOverride=true must drop the user back to step 5 so they
-    // can manage the lobby (e.g. share an invite link with a missing
-    // role) without abandoning the launch screen.
+describe("SetupWizard — lobby ↔ review nav (advancedToReview flag)", () => {
+  it("ready + advancedToReview=false (default): pins step 5 even when launch gates are met", () => {
+    // Plan finalized + 3 player roles. After plan finalisation the
+    // wizard lands on step 5 by default so the creator can share
+    // invite links before reviewing — they advance to step 6
+    // explicitly via the rail or the lobby's "REVIEW & LAUNCH"
+    // affordance.
     render(
       <SetupWizard
         phase="ready"
         {...baseProps()}
         snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
         playerCount={3}
-        lobbyOverride={true}
-        setLobbyOverride={vi.fn()}
+        advancedToReview={false}
+        setAdvancedToReview={vi.fn()}
         postCreationContent={<div data-testid="lobby-slot">lobby</div>}
       />,
     );
@@ -231,38 +254,32 @@ describe("SetupWizard — lobby ↔ review back-nav (presence-aware launch)", ()
     expect(screen.getByTestId("lobby-slot")).toBeInTheDocument();
   });
 
-  it("ready: clicking step 5 in the rail sets the lobby override", () => {
-    const setLobbyOverride = vi.fn();
+  it("ready + advancedToReview=true: rail shows step 6 (Review & launch)", () => {
     render(
       <SetupWizard
         phase="ready"
         {...baseProps()}
         snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
         playerCount={2}
-        lobbyOverride={false}
-        setLobbyOverride={setLobbyOverride}
+        advancedToReview={true}
+        setAdvancedToReview={vi.fn()}
         postCreationContent={<div data-testid="review-slot">review</div>}
       />,
     );
-    // Step 5 is in the "done" set when launch gates are met, so the
-    // rail renders it as a button.
-    const step5 = screen.getByRole("button", {
-      name: /Step 5: Invite players/i,
-    });
-    fireEvent.click(step5);
-    expect(setLobbyOverride).toHaveBeenCalledWith(true);
+    expect(screen.getByText(/step 06 · review & launch/i)).toBeInTheDocument();
+    expect(screen.getByTestId("review-slot")).toBeInTheDocument();
   });
 
-  it("ready (override on): clicking step 6 in the rail clears the override", () => {
-    const setLobbyOverride = vi.fn();
+  it("ready (current=5, advancedToReview=false): clicking step 6 advances when gates are met", () => {
+    const setAdvancedToReview = vi.fn();
     render(
       <SetupWizard
         phase="ready"
         {...baseProps()}
         snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
         playerCount={2}
-        lobbyOverride={true}
-        setLobbyOverride={setLobbyOverride}
+        advancedToReview={false}
+        setAdvancedToReview={setAdvancedToReview}
         postCreationContent={<div data-testid="lobby-slot">lobby</div>}
       />,
     );
@@ -270,54 +287,42 @@ describe("SetupWizard — lobby ↔ review back-nav (presence-aware launch)", ()
       name: /Step 6: Review & launch/i,
     });
     fireEvent.click(step6);
-    expect(setLobbyOverride).toHaveBeenCalledWith(false);
+    expect(setAdvancedToReview).toHaveBeenCalledWith(true);
   });
 
-  it("ready (override off, current=5, gates not met): clicking step 5 is a no-op", () => {
-    // Copilot review on PR #187: clicking the *current* step rail
-    // item used to fire ``setLobbyOverride(true)`` even when launch
-    // gates weren't met yet. That accidentally pinned the wizard to
-    // the lobby once gates DID get met and silently suppressed the
-    // auto-advance to step 6. The handler now ignores clicks where
-    // ``id === current``.
-    const setLobbyOverride = vi.fn();
-    render(
-      <SetupWizard
-        phase="ready"
-        {...baseProps()}
-        snapshot={fakeSnapshot({ state: "READY", plan: null })}
-        playerCount={1}
-        lobbyOverride={false}
-        setLobbyOverride={setLobbyOverride}
-        postCreationContent={<div data-testid="lobby-slot">lobby</div>}
-      />,
-    );
-    // Step 5 is current here — it renders as a button (because
-    // ``isCurrent`` makes it clickable per WizardRail), but the
-    // click handler must short-circuit.
-    const step5 = screen.getByRole("button", {
-      name: /Step 5: Invite players/i,
-    });
-    fireEvent.click(step5);
-    expect(setLobbyOverride).not.toHaveBeenCalled();
-  });
-
-  it("ready (no setLobbyOverride wired): rail steps are NOT clickable", () => {
-    // Copilot review on PR #187: when the parent forgets to plumb
-    // ``setLobbyOverride``, the rail used to render steps as
-    // clickable buttons whose handlers were silent no-ops. Now we
-    // skip wiring ``onJumpToStep`` in that case so the rail
-    // renders the inert <div> branch — no dead-affordance clicks
-    // in Storybook / isolated tests.
+  it("ready (current=6, advancedToReview=true): clicking step 5 hops back to lobby", () => {
+    const setAdvancedToReview = vi.fn();
     render(
       <SetupWizard
         phase="ready"
         {...baseProps()}
         snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
         playerCount={2}
-        lobbyOverride={false}
-        // setLobbyOverride intentionally omitted
+        advancedToReview={true}
+        setAdvancedToReview={setAdvancedToReview}
         postCreationContent={<div data-testid="review-slot">review</div>}
+      />,
+    );
+    const step5 = screen.getByRole("button", {
+      name: /Step 5: Invite players/i,
+    });
+    fireEvent.click(step5);
+    expect(setAdvancedToReview).toHaveBeenCalledWith(false);
+  });
+
+  it("ready (no setAdvancedToReview wired): rail steps are NOT clickable", () => {
+    // When the parent forgets to plumb ``setAdvancedToReview``, the
+    // rail's onJumpToStep is undefined and the rail renders the
+    // inert <div> branch — no dead-affordance clicks in Storybook
+    // / isolated tests.
+    render(
+      <SetupWizard
+        phase="ready"
+        {...baseProps()}
+        snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
+        playerCount={2}
+        // setAdvancedToReview intentionally omitted
+        postCreationContent={<div data-testid="lobby-slot">lobby</div>}
       />,
     );
     expect(
@@ -328,22 +333,20 @@ describe("SetupWizard — lobby ↔ review back-nav (presence-aware launch)", ()
     ).not.toBeInTheDocument();
   });
 
-  it("ready (gates not met): step 6 is NOT clickable from the lobby override view", () => {
-    // Even with override on, if the launch gates aren't met (e.g. only
-    // 1 player role), step 6 stays inert — clicking it would land the
-    // user on a half-rendered review screen they can't actually launch
-    // from. Step 5 stays current (and ineligible to click → not a
-    // button), step 6 stays inert (also not a button).
-    const setLobbyOverride = vi.fn();
+  it("ready (gates not met): step 6 is NOT clickable", () => {
+    // If the launch gates aren't met (e.g. only 1 player role),
+    // step 6 stays inert — clicking it would land the user on a
+    // half-rendered review screen they can't actually launch from.
+    const setAdvancedToReview = vi.fn();
     render(
       <SetupWizard
         phase="ready"
         {...baseProps()}
         snapshot={fakeSnapshot({ state: "READY", plan: fakePlan() })}
         playerCount={1}
-        lobbyOverride={true}
-        setLobbyOverride={setLobbyOverride}
-        postCreationContent={null}
+        advancedToReview={false}
+        setAdvancedToReview={setAdvancedToReview}
+        postCreationContent={<div data-testid="lobby-slot">lobby</div>}
       />,
     );
     expect(

--- a/frontend/src/__tests__/proxyAndJoiner.test.tsx
+++ b/frontend/src/__tests__/proxyAndJoiner.test.tsx
@@ -218,8 +218,8 @@ describe("isMidSessionJoiner — issue #80 bonus chip predicate", () => {
     ).toBe(true);
   });
 
-  it("false during SETUP / BRIEFING (handled by JoinIntro waiting variant)", () => {
-    for (const state of ["SETUP", "BRIEFING"]) {
+  it("false during SETUP / READY / BRIEFING (handled by JoinIntro waiting variant)", () => {
+    for (const state of ["SETUP", "READY", "BRIEFING"]) {
       expect(
         isMidSessionJoiner({
           sessionState: state,

--- a/frontend/src/components/SetupChat.tsx
+++ b/frontend/src/components/SetupChat.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { SetupNoteView } from "../api/client";
 import { ChatIndicator } from "./ChatIndicator";
 
@@ -27,6 +28,41 @@ interface Props {
  * buttons that send the option text as the next reply.
  */
 export function SetupChat({ notes, busy, aiTyping, onPickOption }: Props) {
+  // Auto-scroll the chat region to the bottom whenever a new note
+  // arrives or the typing indicator flips on — but only when the
+  // operator is already near the bottom. Without the near-bottom
+  // gate, an operator who scrolls up to re-read a clarifying
+  // question gets yanked back to the bottom on every WS event
+  // (canonical chat anti-pattern). ``scrollHeight`` is read *after*
+  // the current commit so the new note's height is included.
+  //
+  // The gate's threshold (80px) lines up with the standard
+  // "auto-pin if within ~one message of the bottom" pattern used
+  // in Slack / Discord; per-pixel exactness isn't important
+  // because the threshold is checked against the OLD
+  // scrollHeight, not the new one. We capture ``wasNearBottom``
+  // *before* layout has reconciled the new note into the DOM
+  // (the effect runs in the commit phase, after React's
+  // virtual-dom diff but before the browser repaints) so the
+  // measurement reflects whether the user was at the bottom
+  // immediately prior to this update.
+  const NEAR_BOTTOM_PX = 80;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const wasNearBottomRef = useRef(true);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (wasNearBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [notes.length, aiTyping]);
+  const handleScroll = () => {
+    const el = containerRef.current;
+    if (!el) return;
+    wasNearBottomRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX;
+  };
+
   if (notes.length === 0) {
     return (
       <div className="mono rounded-r-3 border border-ink-600 bg-ink-850 p-3 text-[11px] uppercase tracking-[0.06em] text-ink-400">
@@ -39,6 +75,8 @@ export function SetupChat({ notes, busy, aiTyping, onPickOption }: Props) {
 
   return (
     <div
+      ref={containerRef}
+      onScroll={handleScroll}
       className="flex max-h-[60vh] flex-col gap-2 overflow-y-auto rounded-r-3 border border-ink-600 bg-ink-850 p-3"
       role="log"
       aria-live="polite"

--- a/frontend/src/components/SetupChat.tsx
+++ b/frontend/src/components/SetupChat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { SetupNoteView } from "../api/client";
 import { ChatIndicator } from "./ChatIndicator";
 
@@ -33,23 +33,27 @@ export function SetupChat({ notes, busy, aiTyping, onPickOption }: Props) {
   // operator is already near the bottom. Without the near-bottom
   // gate, an operator who scrolls up to re-read a clarifying
   // question gets yanked back to the bottom on every WS event
-  // (canonical chat anti-pattern). ``scrollHeight`` is read *after*
-  // the current commit so the new note's height is included.
+  // (canonical chat anti-pattern).
   //
   // The gate's threshold (80px) lines up with the standard
   // "auto-pin if within ~one message of the bottom" pattern used
-  // in Slack / Discord; per-pixel exactness isn't important
-  // because the threshold is checked against the OLD
-  // scrollHeight, not the new one. We capture ``wasNearBottom``
-  // *before* layout has reconciled the new note into the DOM
-  // (the effect runs in the commit phase, after React's
-  // virtual-dom diff but before the browser repaints) so the
-  // measurement reflects whether the user was at the bottom
-  // immediately prior to this update.
+  // in Slack / Discord. ``wasNearBottomRef`` is updated by the
+  // ``onScroll`` handler so the next layout-effect knows whether
+  // the user was near the bottom *before* the new content was
+  // appended.
+  //
+  // ``useLayoutEffect`` is load-bearing: scroll positioning needs
+  // to happen synchronously *after* React commits the new node and
+  // *before* the browser paints, otherwise the user sees a
+  // one-frame flash where the new note appears below the fold then
+  // jumps to the bottom. (Copilot review on PR #199 flagged the
+  // prior comment claiming "before browser repaints" while using
+  // ``useEffect`` — wrong about the timing; switched to
+  // ``useLayoutEffect`` to make the comment honest.)
   const NEAR_BOTTOM_PX = 80;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const wasNearBottomRef = useRef(true);
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
     if (wasNearBottomRef.current) {

--- a/frontend/src/components/SharedNotepad.tsx
+++ b/frontend/src/components/SharedNotepad.tsx
@@ -172,7 +172,21 @@ export function SharedNotepad({
   // happens inside the provider via ``ws.subscribe`` so callers
   // don't have to pass a stable subscribe function.
   useEffect(() => {
-    if (!editor) return;
+    if (!editor) {
+      // ``useEditor`` returns null on the first render then commits
+      // the editor on the second — emitting a warn here would fire
+      // every page load. Use debug so the breadcrumb is available
+      // for a "notepad never loaded" investigation without crowding
+      // the production console. (Product review feedback; May 2026.)
+      console.debug("[notepad] editor not ready — provider start deferred", {
+        session_id: sessionId,
+      });
+      return;
+    }
+    console.debug("[notepad] mounting provider", {
+      session_id: sessionId,
+      self_role_id: selfRoleId,
+    });
     const provider = new WsYjsProvider(
       ydoc,
       awareness,
@@ -196,8 +210,13 @@ export function SharedNotepad({
       (msg) => setErrorMsg(msg),
     );
     provider.start();
-    return () => provider.stop();
-  }, [editor, ydoc, awareness, ws]);
+    return () => {
+      console.debug("[notepad] unmounting provider", {
+        session_id: sessionId,
+      });
+      provider.stop();
+    };
+  }, [editor, ydoc, awareness, ws, sessionId, selfRoleId]);
 
   // Reflect the lock flag onto the editor's editable state.
   useEffect(() => {

--- a/frontend/src/components/setup/SetupLobbyView.tsx
+++ b/frontend/src/components/setup/SetupLobbyView.tsx
@@ -38,17 +38,23 @@ interface Props {
   onRoleChanged: () => void;
   onError: (msg: string) => void;
   /**
-   * When the launch gates are met (plan finalized + ≥ 2 player
-   * roles), the wizard normally auto-advances to step 6 and renders
-   * ``SetupReviewView`` instead of this lobby. The creator can hop
-   * back here via the "← Back to lobby" button on the review screen
-   * — and once they're back, they need a one-click way to launch
-   * without rail-clicking step 6 (which is a wizard-internals
-   * affordance most users won't notice). When supplied, this prop
-   * triggers a launch directly; the lobby renders a primary CTA in
-   * the sidecar when both gates are met.
+   * Lobby-side launch handler. Step 5 is the natural landing for
+   * the ready phase (we don't auto-advance to step 6) so the lobby
+   * owns the primary launch CTA. The parent supplies this handler
+   * once the launch gates are met (plan finalized + ≥ 2 player
+   * roles); when not supplied, the sidecar's status copy explains
+   * which gate is still pending.
    */
   onLaunchSession?: () => void;
+  /**
+   * Advance to step 6 (Review & launch). Optional secondary
+   * affordance — most creators will launch directly from the lobby
+   * via ``onLaunchSession`` once they've shared invite links, but
+   * the review screen exists for creators who want a final
+   * presence-aware confirmation before pulling the trigger.
+   * Suppressed when the launch gates aren't met.
+   */
+  onAdvanceToReview?: () => void;
 }
 
 export function SetupLobbyView(props: Props) {
@@ -277,6 +283,17 @@ export function SetupLobbyView(props: Props) {
           display: "flex",
           flexDirection: "column",
           gap: 12,
+          // Scroll fallback for tall content on short viewports.
+          // The sticky aside follows the page scroll up to its
+          // content's max height — without an internal scroll, on a
+          // 600px-tall window (or zoom 150%) the secondary "REVIEW &
+          // LAUNCH" CTA can clip below the fold with no recovery.
+          // ``maxHeight`` minus ~32px of outer ``p-5`` / ``lg:p-8``
+          // padding keeps the aside fully reachable; the outer
+          // wizard ``<section>`` still owns the page-level scroll on
+          // shorter content. (UI/UX review HIGH; May 2026.)
+          maxHeight: "calc(100vh - 32px)",
+          overflowY: "auto",
         }}
       >
         <Eyebrow color="var(--signal)">
@@ -319,17 +336,14 @@ export function SetupLobbyView(props: Props) {
             ? "Plan not finalized yet — finish setup in step 04."
             : needPlayers
               ? `Need at least 2 player roles before launch (currently ${props.playerCount}).`
-              : props.onLaunchSession
-                ? "Ready — launch now or share remaining join links first."
-                : "Ready — advance to step 06 to review and launch."}
+              : "Ready — share invite links and launch when the room's set."}
         </div>
-        {/* Primary launch CTA inside the lobby sidecar. Renders only
-            when (a) launch gates are met AND (b) the parent wired
-            the handler — covers the path where the creator hopped
-            back here from the review screen and now wants to launch
-            without round-tripping through the rail (User Agent
-            HIGH#2). The button matches the SetupReviewView CTA so
-            the action feels identical from either entry point. */}
+        {/* Primary launch CTA inside the lobby sidecar. Step 5 is the
+            natural landing for the ready phase, so the lobby owns the
+            launch action — the creator never has to advance to step 6
+            unless they want a presence-aware confirmation screen.
+            Renders only when (a) launch gates are met AND (b) the
+            parent wired the handler. */}
         {!needPlan && !needPlayers && props.onLaunchSession ? (
           <button
             type="button"
@@ -351,6 +365,34 @@ export function SetupLobbyView(props: Props) {
             }}
           >
             {props.busy ? "STARTING…" : "START SESSION →"}
+          </button>
+        ) : null}
+        {/* Secondary affordance: advance to the review screen for a
+            presence-aware confirmation before launch. Subtle styling
+            so it doesn't compete with the primary START SESSION CTA.
+            Renders only when (a) launch gates are met AND (b) the
+            parent wired the handler. */}
+        {!needPlan && !needPlayers && props.onAdvanceToReview ? (
+          <button
+            type="button"
+            onClick={props.onAdvanceToReview}
+            disabled={props.busy}
+            className="mono"
+            aria-label="Advance to Step 6: Review & launch"
+            style={{
+              background: "transparent",
+              color: "var(--ink-300)",
+              border: "1px dashed var(--ink-500)",
+              padding: "8px",
+              borderRadius: 2,
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: "0.16em",
+              cursor: props.busy ? "not-allowed" : "pointer",
+              opacity: props.busy ? 0.5 : 1,
+            }}
+          >
+            REVIEW &amp; LAUNCH →
           </button>
         ) : null}
       </aside>

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -129,17 +129,25 @@ interface Props {
    */
   onAbandonSession?: () => void;
   /**
-   * Lobby-override flag (controlled by ``Facilitator``). When true,
-   * the post-creation step pins to 5 (Invite players) even if the
-   * launch gates are met (plan finalized + ≥ 2 player seats).
-   * Lets the creator manage the lobby after seeing the launch
-   * screen — clicking "← Back to lobby" inside ``SetupReviewView``
-   * sets this; clicking step 6 in the rail clears it.
+   * Whether the creator has explicitly advanced from step 5 (Invite
+   * players) to step 6 (Review & launch). Default is false — after
+   * the plan is finalised the wizard lands on step 5 so the creator
+   * can copy invite links and confirm the lobby BEFORE reviewing.
+   * Flipped to true when they click step 6 in the rail (or when
+   * launch gates are met and they hit a forward affordance), and
+   * back to false when they click step 5 / "← Back to lobby".
+   *
+   * Pre-fix the wizard auto-jumped to step 6 the moment the plan was
+   * approved if there were ≥ 2 seats — bypassing the invite UI
+   * entirely, which left the creator hunting for a way back to copy
+   * the per-role join links. The "Approve & start lobby" button copy
+   * also implied a lobby landing, so the auto-jump contradicted what
+   * the action advertised.
    */
-  lobbyOverride?: boolean;
-  /** Setter for ``lobbyOverride`` so the rail click in step 6
-   *  can clear it without round-tripping through the parent. */
-  setLobbyOverride?: (v: boolean) => void;
+  advancedToReview?: boolean;
+  /** Setter for ``advancedToReview`` so the rail clicks can drive
+   *  step navigation without round-tripping through the parent. */
+  setAdvancedToReview?: (v: boolean) => void;
 }
 
 // Stable React keys for custom-role rows the operator adds. We can't
@@ -157,31 +165,38 @@ export function SetupWizard(props: Props) {
   // and submitting step 3 triggers session creation. Once created
   // (phase != "intro"), the step is derived from backend state.
   const [introStep, setIntroStep] = useState<1 | 2 | 3>(1);
-  // Lobby-override flag is owned by ``Facilitator`` so the
+  // Step 5 → 6 advance flag is owned by ``Facilitator`` so the
   // ``SetupReviewView`` (rendered into the ``postCreationContent``
   // slot below) can request a hop back to step 5 without props
   // round-tripping through this component. Local fallback to
   // ``false`` keeps the component usable in isolation (Storybook,
   // tests).
-  const lobbyOverride = props.lobbyOverride ?? false;
-  const setLobbyOverride = props.setLobbyOverride;
+  const advancedToReview = props.advancedToReview ?? false;
+  const setAdvancedToReview = props.setAdvancedToReview;
 
   const current: WizardStepId = useMemo<WizardStepId>(() => {
     if (props.phase === "intro") return introStep;
     if (props.phase === "setup") return 4;
     if (props.phase === "ready") {
-      // READY with a finalized plan + ≥2 players → review/launch
-      // (step 6). Otherwise we're still gathering joiners → step 5.
-      // ``lobbyOverride`` lets the creator pin step 5 to manage the
-      // lobby even after the gates are met — set when they click
-      // "← Back to lobby" from the review screen.
-      const ready =
+      // After plan finalisation we land on step 5 (Invite players)
+      // so the creator can copy join links and watch the lobby fill
+      // up. Step 6 (Review & launch) is reachable via the rail (or
+      // the "ADVANCE TO REVIEW" affordance in the lobby's sidecar)
+      // once the launch gates are met — but the lobby owns its own
+      // START SESSION CTA, so step 6 is optional, not required.
+      const launchReady =
         props.snapshot?.plan != null && (props.playerCount ?? 0) >= 2;
-      if (lobbyOverride) return 5;
-      return ready ? 6 : 5;
+      if (advancedToReview && launchReady) return 6;
+      return 5;
     }
     return 1;
-  }, [props.phase, introStep, props.snapshot, props.playerCount, lobbyOverride]);
+  }, [
+    props.phase,
+    introStep,
+    props.snapshot,
+    props.playerCount,
+    advancedToReview,
+  ]);
 
   const done = useMemo(() => {
     const s = new Set<WizardStepId>();
@@ -194,34 +209,28 @@ export function SetupWizard(props: Props) {
       s.add(2);
       s.add(3);
       if (props.phase === "ready") s.add(4);
-      // step 5 done when plan is finalized + roster gate met (we're
-      // either in step 6, or pinned back on step 5 via lobbyOverride
-      // but the room is launch-ready). The ``done`` set doubles as
-      // the rail's "clickable" set — see WizardRail's ``isClickable``
-      // calculation — so adding step 5 here is what makes the
-      // "← BACK TO LOBBY" rail link work from step 6.
+      // The ``done`` set doubles as the rail's "clickable" set
+      // (see WizardRail's ``isClickable`` calculation) AND drives
+      // the ✓ glyph next to each step. We only want ✓ on steps the
+      // user has actually moved past — never on the current step.
+      //
+      //  - Step 5 → done when current=6 (back-nav clickability).
+      //  - Step 6 → done when current=5 AND launch gates are met
+      //    (forward-nav clickability). Current step never adds
+      //    itself to ``done`` so it doesn't render a stale ✓.
       const launchReady =
         props.snapshot?.plan != null && (props.playerCount ?? 0) >= 2;
-      if (current === 6 || launchReady) s.add(5);
-      // Step 6 normally only flips to "done" after START SESSION
-      // runs, but in lobbyOverride mode (user clicked "← Back to
-      // lobby" from step 6) we mark it ``done`` so the rail
-      // exposes it as a forward-jump target — otherwise the user
-      // would have to clear the override by some other means
-      // before they could return to the launch screen. Only
-      // applies when the launch gates are met; without that gate
-      // step 6 would render as a half-broken review screen with
-      // no working START SESSION CTA.
-      if (lobbyOverride && launchReady) s.add(6);
+      const current = advancedToReview && launchReady ? 6 : 5;
+      if (props.phase === "ready" && current === 6) s.add(5);
+      if (props.phase === "ready" && current === 5 && launchReady) s.add(6);
     }
     return s;
   }, [
     props.phase,
     introStep,
-    current,
     props.snapshot,
     props.playerCount,
-    lobbyOverride,
+    advancedToReview,
   ]);
 
   // Step navigation. Intro phase: user moves backward through
@@ -239,30 +248,22 @@ export function SetupWizard(props: Props) {
       setIntroStep(id);
       return;
     }
-    if (props.phase === "ready" && setLobbyOverride) {
-      // Ignore clicks on the step that's already current — re-firing
-      // the same handler is at best a no-op and at worst a footgun
-      // (clicking the *current* Step 5 when launch gates aren't yet
-      // met would still flip ``lobbyOverride`` to true, pinning the
-      // wizard to the lobby once gates DO get met and silently
-      // suppressing the auto-advance to Step 6 — Copilot review on
-      // PR #187).
+    if (props.phase === "ready" && setAdvancedToReview) {
       if (id === current) return;
       const launchReady =
         props.snapshot?.plan != null && (props.playerCount ?? 0) >= 2;
       if (id === 5) {
-        // Only honor a jump to Step 5 from Step 6 — i.e. when the
-        // user is actually using the back-nav. From any other step
-        // (e.g. Step 4 while the AI is drafting), Step 5 isn't yet
-        // reachable and the override flag would just be misleading.
-        if (current === 6 && launchReady) setLobbyOverride(true);
+        // Hop back to the lobby. Always allowed in the ready phase
+        // because step 5 is the natural landing for the phase —
+        // clearing the advance flag puts us back there.
+        setAdvancedToReview(false);
         return;
       }
       if (id === 6) {
         // Only allow forward jump to 6 if the launch gates are met,
         // otherwise the user would land on a half-rendered review
         // screen that can't actually launch.
-        if (launchReady) setLobbyOverride(false);
+        if (launchReady) setAdvancedToReview(true);
         return;
       }
       return;
@@ -287,14 +288,13 @@ export function SetupWizard(props: Props) {
         // the rail static — the AI is mid-draft and there's no
         // backward path from "AI is drafting" anyway. The ready-
         // phase wiring also requires the parent to have plumbed
-        // ``setLobbyOverride`` through; without it the rail handler
-        // returns early on every click, so leaving steps clickable
-        // would just produce dead-affordance clicks (Copilot review
-        // on PR #187).
+        // ``setAdvancedToReview`` through; without it the rail
+        // handler returns early on every click, so leaving steps
+        // clickable would just produce dead-affordance clicks.
         onJumpToStep={
           props.phase === "intro"
             ? onJumpToStep
-            : props.phase === "ready" && setLobbyOverride
+            : props.phase === "ready" && setAdvancedToReview
               ? onJumpToStep
               : undefined
         }

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -198,10 +198,13 @@ export function SetupWizard(props: Props) {
     advancedToReview,
   ]);
 
+  // ``done`` strictly means "user has visited and moved past this
+  // step" — drives the ✓ glyph in WizardRail. Step 5 only counts as
+  // done once the user has advanced to step 6; step 6 is never done
+  // until launch (which exits the wizard entirely).
   const done = useMemo(() => {
     const s = new Set<WizardStepId>();
     if (props.phase === "intro") {
-      // Mark earlier intro steps as done as the user advances.
       for (let i = 1; i < introStep; i++) s.add(i as WizardStepId);
     } else {
       // Pre-creation steps are all done once the session is created.
@@ -209,20 +212,16 @@ export function SetupWizard(props: Props) {
       s.add(2);
       s.add(3);
       if (props.phase === "ready") s.add(4);
-      // The ``done`` set doubles as the rail's "clickable" set
-      // (see WizardRail's ``isClickable`` calculation) AND drives
-      // the ✓ glyph next to each step. We only want ✓ on steps the
-      // user has actually moved past — never on the current step.
-      //
-      //  - Step 5 → done when current=6 (back-nav clickability).
-      //  - Step 6 → done when current=5 AND launch gates are met
-      //    (forward-nav clickability). Current step never adds
-      //    itself to ``done`` so it doesn't render a stale ✓.
+      // Step 5 is "done" only after the user has advanced to step 6
+      // (and launch gates are met — otherwise step 6 isn't reachable
+      // and the advance state isn't meaningful). Step 6 is never
+      // marked done from inside the wizard; once START SESSION fires
+      // we leave the wizard for the play view. (Copilot review on
+      // PR #199 caught the prior code marking step 6 as done while
+      // the user was still on step 5.)
       const launchReady =
         props.snapshot?.plan != null && (props.playerCount ?? 0) >= 2;
-      const current = advancedToReview && launchReady ? 6 : 5;
-      if (props.phase === "ready" && current === 6) s.add(5);
-      if (props.phase === "ready" && current === 5 && launchReady) s.add(6);
+      if (props.phase === "ready" && advancedToReview && launchReady) s.add(5);
     }
     return s;
   }, [
@@ -232,6 +231,21 @@ export function SetupWizard(props: Props) {
     props.playerCount,
     advancedToReview,
   ]);
+
+  // ``clickableExtra`` is the "forward-reachable but not visited"
+  // set — adds rail clickability without implying completion. In the
+  // ready phase, step 6 is reachable from step 5 once launch gates
+  // are met. (No ✓ glyph; just a clickable rail entry.)
+  const clickableExtra = useMemo(() => {
+    const s = new Set<WizardStepId>();
+    if (props.phase === "ready") {
+      const launchReady =
+        props.snapshot?.plan != null && (props.playerCount ?? 0) >= 2;
+      const current = advancedToReview && launchReady ? 6 : 5;
+      if (current === 5 && launchReady) s.add(6);
+    }
+    return s;
+  }, [props.phase, props.snapshot, props.playerCount, advancedToReview]);
 
   // Step navigation. Intro phase: user moves backward through
   // completed form steps (state lives in ``introStep``). Post-
@@ -282,6 +296,7 @@ export function SetupWizard(props: Props) {
       <WizardRail
         current={current}
         done={done}
+        clickableExtra={clickableExtra}
         // Wired in two distinct phases: intro (back-nav through
         // the form-state steps 1-3) and ready (hop between
         // lobby step 5 and review step 6). Setup phase 4 keeps

--- a/frontend/src/components/setup/WizardRail.tsx
+++ b/frontend/src/components/setup/WizardRail.tsx
@@ -33,6 +33,15 @@ interface Props {
   /** Set of step ids the user has completed (rendered with a ✓). */
   done: Set<WizardStepId>;
   /**
+   * Optional extra step ids the rail should treat as clickable beyond
+   * ``done`` and the current step. Use this for "forward-reachable"
+   * steps the user can jump to but hasn't visited yet (e.g. step 6 is
+   * reachable from step 5 once launch gates are met, but should NOT
+   * render a ✓ — that would lie about completion). Defaults to empty.
+   * Copilot review on PR #199.
+   */
+  clickableExtra?: Set<WizardStepId>;
+  /**
    * Optional click handler for a step. Only wired by the parent for
    * intro-phase back-nav (steps 1-3 before session creation); always
    * undefined post-creation since the post-creation step is derived
@@ -43,7 +52,13 @@ interface Props {
   onAbandonSession?: () => void;
 }
 
-export function WizardRail({ current, done, onJumpToStep, onAbandonSession }: Props) {
+export function WizardRail({
+  current,
+  done,
+  clickableExtra,
+  onJumpToStep,
+  onAbandonSession,
+}: Props) {
   return (
     <aside
       aria-label="Setup steps"
@@ -118,7 +133,14 @@ export function WizardRail({ current, done, onJumpToStep, onAbandonSession }: Pr
         {WIZARD_STEPS.map((s) => {
           const isCurrent = s.id === current;
           const isDone = done.has(s.id);
-          const isClickable = Boolean(onJumpToStep) && (isDone || isCurrent);
+          // Clickability is "done OR current OR forward-reachable
+          // extras". Completion (✓ glyph) is "done" alone — separating
+          // these lets the parent expose a forward-reachable step
+          // (e.g. step 6 from step 5 when launch gates are met)
+          // without lying about whether the user has visited it.
+          const isExtraClickable = clickableExtra?.has(s.id) ?? false;
+          const isClickable =
+            Boolean(onJumpToStep) && (isDone || isCurrent || isExtraClickable);
           const c = isDone
             ? "var(--ink-300)"
             : isCurrent

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1294,13 +1294,14 @@ export function Facilitator() {
   // 5 vs 6 distinction for the rail highlight; we just have to pick
   // the matching panel content here.
   if (phase === "setup" || phase === "ready") {
-    // Launch gates are met (plan finalized + ≥ 2 player roles), AND
-    // the creator hasn't pinned themselves back to the lobby via
-    // the "← BACK TO LOBBY" button on the review screen. Both
-    // Step 6 (Review & launch) renders only when the creator has
-    // explicitly advanced AND the launch gates are met. On the
-    // natural ready-phase landing we drop into step 5 (the lobby)
-    // so the creator can share join links first.
+    // Step 6 (Review & launch) renders only when the launch gates
+    // are met (plan finalized + ≥ 2 player roles) AND the creator
+    // has explicitly advanced via the rail or the lobby's
+    // "REVIEW & LAUNCH" affordance. On the natural ready-phase
+    // landing we drop into step 5 (the lobby) so the creator can
+    // share join links first; the lobby itself owns the primary
+    // START SESSION CTA so advancing to step 6 is optional, not
+    // required.
     const launchReady =
       phase === "ready" && Boolean(snapshot.plan) && playerCount >= 2;
     const wizardReadyForReview = launchReady && advancedToReview;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -214,17 +214,18 @@ export function Facilitator() {
   const [features, setFeatures] = useState<SessionFeatures>(() => ({
     ...DEFAULT_SESSION_FEATURES,
   }));
-  // Lobby-override toggle for the post-creation wizard. When true,
-  // the wizard pins step 5 (Invite players) even after the launch
-  // gates are met (plan finalized + ≥ 2 player roles). Lets the
-  // creator hop back from the launch screen to share an invite
-  // link without losing the auto-advanced review state. Cleared
-  // automatically when the snapshot leaves READY (because the
-  // override only matters during the lobby — once we're in BRIEFING
-  // / play, the wizard is gone). Lifted out of ``SetupWizard`` so
-  // ``SetupReviewView`` (rendered into the wizard's slot here) can
-  // request the hop without a complex prop chain.
-  const [lobbyOverride, setLobbyOverride] = useState(false);
+  // Step 5 → 6 advance flag for the post-creation wizard. Default
+  // ``false``: after the plan is finalised the wizard lands on step
+  // 5 (Invite players) so the creator can share join links and watch
+  // the lobby fill up before reviewing. Flipped to ``true`` only when
+  // the creator explicitly advances (rail click on step 6, or the
+  // "ADVANCE TO REVIEW" affordance in the lobby's sidecar). Cleared
+  // automatically when the snapshot leaves READY so a "abandon → new
+  // session" flow doesn't carry stale advance state into the next
+  // session. Lifted out of ``SetupWizard`` so ``SetupReviewView``
+  // (rendered into the wizard's slot here) can request a hop back
+  // without a complex prop chain.
+  const [advancedToReview, setAdvancedToReview] = useState(false);
   // Dev-mode toggle on the intro page: prefills a known scenario + creator
   // identity, and on submit auto-skips the AI setup dialogue so testers
   // bypass the 5–30 s setup loop. Use only for local QA.
@@ -443,15 +444,14 @@ export function Facilitator() {
     }
   }, [phase, snapshot]);
 
-  // Drop the lobby-override flag whenever we leave the "ready"
-  // wizard phase. Without this, a creator who hopped back to the
-  // lobby and then started fresh (abandon → new session) would land
-  // back in the lobby step on the new session even after its launch
-  // gates were met. Cheap reset; runs at most once per phase
-  // transition.
+  // Drop the advance flag whenever we leave the "ready" wizard
+  // phase. Without this, a creator who clicked through to step 6
+  // and then started fresh (abandon → new session) would land back
+  // on step 6 of the new session before the next plan was even
+  // drafted. Cheap reset; runs at most once per phase transition.
   useEffect(() => {
-    if (phase !== "ready" && lobbyOverride) setLobbyOverride(false);
-  }, [phase, lobbyOverride]);
+    if (phase !== "ready" && advancedToReview) setAdvancedToReview(false);
+  }, [phase, advancedToReview]);
 
   useEffect(() => {
     if (error) console.warn("[facilitator] error surfaced", error);
@@ -1297,13 +1297,13 @@ export function Facilitator() {
     // Launch gates are met (plan finalized + ≥ 2 player roles), AND
     // the creator hasn't pinned themselves back to the lobby via
     // the "← BACK TO LOBBY" button on the review screen. Both
-    // conditions must hold to render step 6 (Review & launch);
-    // otherwise we drop into step 5 (the lobby).
-    const wizardReadyForReview =
-      phase === "ready" &&
-      Boolean(snapshot.plan) &&
-      playerCount >= 2 &&
-      !lobbyOverride;
+    // Step 6 (Review & launch) renders only when the creator has
+    // explicitly advanced AND the launch gates are met. On the
+    // natural ready-phase landing we drop into step 5 (the lobby)
+    // so the creator can share join links first.
+    const launchReady =
+      phase === "ready" && Boolean(snapshot.plan) && playerCount >= 2;
+    const wizardReadyForReview = launchReady && advancedToReview;
     let postCreationContent;
     if (phase === "setup") {
       postCreationContent = (
@@ -1332,17 +1332,21 @@ export function Facilitator() {
           connectedRoleIds={presence}
           busy={busy}
           onStart={handleStart}
-          onBackToLobby={() => setLobbyOverride(true)}
+          onBackToLobby={() => setAdvancedToReview(false)}
         />
       );
     } else {
-      // Wire the launch handler ONLY when the creator landed back
-      // here via the "← BACK TO LOBBY" affordance (lobbyOverride =
-      // true) — that's the path where they need a one-click way out
-      // of the lobby. On the natural lobby visit (gates not yet met),
-      // the launch CTA inside SetupLobbyView is suppressed (needPlan
-      // / needPlayers branches in the sidecar copy still fire).
-      const lobbyLaunchHandler = lobbyOverride ? handleStart : undefined;
+      // Always wire the launch handler on the lobby once gates are
+      // met — the lobby is the natural launch surface (advancing to
+      // step 6 is optional). When gates aren't met the lobby's own
+      // sidecar copy reads "Plan not finalized" / "Need at least 2
+      // player roles" and the CTA stays suppressed. Also wire the
+      // forward-advance handler so the lobby's sidecar can offer an
+      // explicit "ADVANCE TO REVIEW" affordance once gates clear.
+      const lobbyLaunchHandler = launchReady ? handleStart : undefined;
+      const advanceToReviewHandler = launchReady
+        ? () => setAdvancedToReview(true)
+        : undefined;
       postCreationContent = (
         <SetupLobbyView
           sessionId={state.sessionId}
@@ -1356,6 +1360,7 @@ export function Facilitator() {
           onRoleChanged={refreshSnapshot}
           onError={setError}
           onLaunchSession={lobbyLaunchHandler}
+          onAdvanceToReview={advanceToReviewHandler}
         />
       );
     }
@@ -1402,8 +1407,8 @@ export function Facilitator() {
           playerCount={playerCount}
           postCreationContent={postCreationContent}
           onAbandonSession={handleNewSession}
-          lobbyOverride={lobbyOverride}
-          setLobbyOverride={setLobbyOverride}
+          advancedToReview={advancedToReview}
+          setAdvancedToReview={setAdvancedToReview}
         />
       </>
     );

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -172,11 +172,26 @@ export function Play({ sessionId, token }: Props) {
       const padded = head + "=".repeat((4 - (head.length % 4)) % 4);
       const decoded = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
       const parsed = JSON.parse(decoded);
-      return typeof parsed.role_id === "string" ? parsed.role_id : null;
-    } catch {
+      const value = typeof parsed.role_id === "string" ? parsed.role_id : null;
+      if (!value) {
+        console.warn("[play] token payload missing role_id field", {
+          session_id: sessionId,
+        });
+      }
+      return value;
+    } catch (err) {
+      // Decode failure is load-bearing for several gates (notepad,
+      // highlight popover, mention-self filtering). Without a log
+      // line here a "notepad never mounted" report is opaque — the
+      // gate condition ``wsClient && selfRoleId`` would silently
+      // hold null forever. (Issue #4 in the May 2026 UI sweep.)
+      console.warn("[play] selfRoleId decode failed", {
+        session_id: sessionId,
+        message: err instanceof Error ? err.message : String(err),
+      });
       return null;
     }
-  }, [token]);
+  }, [token, sessionId]);
 
   // Snapshot fetch runs unconditionally so the join-intro page can
   // show the player's role label + scenario context (was: gated on
@@ -223,6 +238,21 @@ export function Play({ sessionId, token }: Props) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [displayName, sessionId, token]);
+
+  // Boundary log for the notepad / highlight-popover mount gate. Both
+  // are gated on ``wsClient && selfRoleId`` — a "notepad never loaded"
+  // bug report needs to distinguish "WS never opened" from "selfRoleId
+  // decode failed" from "both are fine, so the bug is downstream".
+  // Pure debug log; only fires when the gate flips, so it doesn't
+  // crowd the production console. (Issue #4 in the May 2026 UI sweep.)
+  useEffect(() => {
+    console.debug("[play] notepad gate", {
+      session_id: sessionId,
+      ws_connected: Boolean(wsClient),
+      self_role_id_present: Boolean(selfRoleId),
+      will_mount: Boolean(wsClient && selfRoleId),
+    });
+  }, [wsClient, selfRoleId, sessionId]);
 
   // Report this tab's focus / visibility state so the creator's
   // RolesPanel can show this player as engaged (blue) vs tabbed away
@@ -737,14 +767,20 @@ export function Play({ sessionId, token }: Props) {
     wasShowingMidSessionChipRef.current = show;
   }, [snapshot, selfRoleId, sessionId]);
 
-  // Issue #76 transition cue: detect the SETUP/BRIEFING →
+  // Issue #76 transition cue: detect the SETUP/READY/BRIEFING →
   // AWAITING_PLAYERS flip and surface a transient "Session started"
   // banner so the participant has an explicit acknowledgement that
   // their JoinIntro screen was replaced (UI/UX review HIGH: pre-fix
   // the page hard-cut and a screen-reader user had no signal).
+  // READY is included here so a player who joined during the lobby
+  // (waiting on the creator to click Start) gets the same banner as
+  // one who joined during SETUP — without it, the banner would only
+  // fire for the lucky few who arrived before plan finalisation.
   useEffect(() => {
     const isWaitingNow =
-      snapshot?.state === "SETUP" || snapshot?.state === "BRIEFING";
+      snapshot?.state === "SETUP" ||
+      snapshot?.state === "READY" ||
+      snapshot?.state === "BRIEFING";
     const wasWaiting = wasWaitingRef.current;
     // Always update the ref before any conditional return — pre-fix
     // the early `return` left ``wasWaitingRef.current`` stuck at
@@ -819,8 +855,18 @@ export function Play({ sessionId, token }: Props) {
   // instead, with the form swapped for a "Waiting for the facilitator
   // to start" panel + tip carousel. Auto-resolves the moment the
   // session transitions to AWAITING_PLAYERS / AI_PROCESSING / etc.
+  //
+  // READY is included so a player who joins during the lobby phase
+  // (after plan finalisation, before the creator clicks Start) sees
+  // the same waiting variant — pre-fix they fell through to the
+  // empty-transcript chat view, and were then yanked BACK to a
+  // waiting screen the moment the creator hit Start (state went
+  // READY → BRIEFING). Holding them on JoinIntro across the full
+  // SETUP → READY → BRIEFING arc removes that jarring round-trip.
   const isWaitingForSessionStart =
-    snapshot?.state === "SETUP" || snapshot?.state === "BRIEFING";
+    snapshot?.state === "SETUP" ||
+    snapshot?.state === "READY" ||
+    snapshot?.state === "BRIEFING";
 
   // Issue #127: terminal WS close codes must short-circuit BEFORE
   // the JoinIntro guard. Pre-fix a kicked player who reopened the
@@ -1609,7 +1655,10 @@ export function JoinIntro({
   // form variant to the waiting variant inside a single mount.
   const [tipIndex, setTipIndex] = useState(0);
   const isWaitingVariant =
-    hasName && (sessionState === "SETUP" || sessionState === "BRIEFING");
+    hasName &&
+    (sessionState === "SETUP" ||
+      sessionState === "READY" ||
+      sessionState === "BRIEFING");
   // Log the variant so a "stuck on JoinIntro" report has a clear
   // trail. ``console.debug`` (not info) so the breadcrumb doesn't
   // crowd the production console — pair of enter+exit lines keyed
@@ -1913,9 +1962,13 @@ export function JoinIntro({
               >
                 {sessionState === "BRIEFING"
                   ? "The AI is preparing the scenario brief…"
-                  : joinedDisplayName
-                    ? `Welcome, ${joinedDisplayName} — waiting for your facilitator to start the scenario…`
-                    : "Waiting for your facilitator to start the scenario…"}
+                  : sessionState === "READY"
+                    ? joinedDisplayName
+                      ? `Welcome, ${joinedDisplayName} — your facilitator is finalising the lobby and will start shortly…`
+                      : "Your facilitator is finalising the lobby and will start shortly…"
+                    : joinedDisplayName
+                      ? `Welcome, ${joinedDisplayName} — waiting for your facilitator to start the scenario…`
+                      : "Waiting for your facilitator to start the scenario…"}
               </h2>
             </div>
             {roleLabel ? (


### PR DESCRIPTION
## Summary

User-reported UI regressions after recent setup-flow PRs. All four fixed, plus tests and defensive logging.

### 1. Step 04 transcript didn't auto-scroll
Operator's reply pinned to top of the visible region while the AI's response rendered below the fold — they had to manually scroll on every turn. Added a **near-bottom-gated** auto-pin (80px threshold) so the chat follows new content but does NOT clobber scroll position when the user has scrolled up to re-read.

`frontend/src/components/SetupChat.tsx`

### 2. Plan approval skipped step 5 (Invite players) → jumped to step 6 (Review & launch)
The "Approve & start lobby" button advertised a lobby landing but auto-advanced to the review screen the moment plan + ≥ 2 seats existed — leaving the creator hunting for a way to copy invite links.

Renamed `lobbyOverride` → `advancedToReview` with **inverted semantics**:
- Default `false` → ready phase lands on **step 5 by default**
- Step 6 reachable via rail click OR the new **"REVIEW & LAUNCH →"** secondary affordance in the lobby's sidecar
- Lobby always wires `START SESSION` CTA when gates met (was: only after manual back-nav from step 6)

`frontend/src/components/setup/SetupWizard.tsx`, `frontend/src/components/setup/SetupLobbyView.tsx`, `frontend/src/pages/Facilitator.tsx`

### 3. Player jumped to play window instead of lobby waiting
Player who joined during `state=READY` landed on the play view (blank transcript, disabled composer), then got yanked BACK to a waiting screen when the creator hit Start (`state=BRIEFING`).

Added `READY` to both `isWaitingForSessionStart` (Play.tsx) and `isWaitingVariant` (JoinIntro). New heading copy: **"Your facilitator is finalising the lobby and will start shortly…"** Player now stays on JoinIntro across the full `SETUP → READY → BRIEFING` arc.

`frontend/src/pages/Play.tsx`

### 4. Intermittent: notepad / text field broken on player side
Likely caused by the premature mount in (3) — the notepad component mounted into the chat shell during `state=READY` then re-mounted on `READY → BRIEFING`, which is a double mount/unmount cycle for the Yjs editor + WS provider. With the player now held on JoinIntro through `SETUP → READY → BRIEFING`, the notepad mounts once in stable `AWAITING_PLAYERS` state.

Defensive logging added for any recurrence:
- `[play] notepad gate` — debug log when mount conditions flip
- `[play] selfRoleId decode failed` — warn on token-decode failure
- `[notepad] mounting/unmounting provider` — breadcrumbs

`frontend/src/pages/Play.tsx`, `frontend/src/components/SharedNotepad.tsx`

## Sub-agent review findings addressed in this PR

- **UI/UX HIGH**: Lobby aside lacked internal scroll fallback for short viewports → added `maxHeight: calc(100vh - 32px); overflowY: auto` to the sticky aside so secondary CTA stays reachable at 600px-tall windows / 150% zoom.
- **User Agent HIGH**: SetupChat auto-scroll was unconditional pre-fix → added near-bottom gate (canonical Slack/Discord pattern).
- **Product MEDIUM**: `[notepad] editor not ready` warn fired on every render before TipTap mounted (TipTap commits editor on the second render) → downgraded to debug.

Findings deferred (out of scope for "fix the four reported bugs"):
- User Agent suggestion to add presence/invite-share counter near START SESSION (new feature).
- User Agent suggestion to gate START SESSION on at least one invite copied (new feature).
- UI/UX nit on lobby button focus rings (pre-existing inline-style pattern across the codebase).

## Test plan

- [x] `npm test` — 452 passed (+15 new). Coverage added for:
  - `SetupChat.scroll.test.tsx` — auto-scroll fires when near bottom, NOT when user scrolled up, fires on `aiTyping` flip too.
  - `SetupLobbyView.cta.test.tsx` — START SESSION renders/fires/suppressed-on-gate-fail; new REVIEW & LAUNCH affordance renders/fires/suppressed-on-gate-fail; both disabled when busy.
  - `JoinIntro.waiting.test.tsx` — READY-state copy variant ("finalising the lobby").
  - `Play.e2e.test.tsx` — READY-state waiting variant (no chat shell, no composer).
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] Manual smoke: walk through SETUP → READY → BRIEFING with a creator + 2 invitees in separate tabs; verify no premature jumps and notepad mounts correctly on AWAITING_PLAYERS.

https://claude.ai/code/session_018dghW2SPjnxb57EAckWWpQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018dghW2SPjnxb57EAckWWpQ)_