### PR TITLE
frontend: surface creator pending state + add NOTHING TO ADD shortcut

### DIFF
--- a/frontend/src/__tests__/Composer.nothingToAdd.test.tsx
+++ b/frontend/src/__tests__/Composer.nothingToAdd.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Composer } from "../components/Composer";
+import type { ImpersonateOption } from "../lib/proxy";
+
+// Coverage for the "READY — NOTHING TO ADD →" shortcut on Composer.
+//
+// The shortcut posts a literal ``Nothing to add.`` with
+// ``intent="ready"`` so a player on the active turn can ready up
+// without typing filler. Visibility rules are conditional, so each
+// case is asserted explicitly — a regression that flips one of these
+// off would silently bring back the "creator never sees a way to
+// finish their turn" complaint that motivated the affordance.
+
+function renderComposer(
+  overrides: Partial<React.ComponentProps<typeof Composer>> = {},
+) {
+  const onSubmit = vi.fn();
+  const utils = render(
+    <Composer
+      enabled={true}
+      placeholder="Type something"
+      label="Your turn"
+      onSubmit={onSubmit}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onSubmit };
+}
+
+const NOTHING_TO_ADD_RE = /ready[\s—-]+nothing to add/i;
+
+describe("Composer NOTHING TO ADD shortcut", () => {
+  it("renders when the role is on an active turn and not yet ready", () => {
+    renderComposer();
+    expect(
+      screen.getByRole("button", { name: NOTHING_TO_ADD_RE }),
+    ).toBeTruthy();
+  });
+
+  it("submits 'Nothing to add.' with intent=ready and no mentions", () => {
+    const { onSubmit } = renderComposer();
+    fireEvent.click(screen.getByRole("button", { name: NOTHING_TO_ADD_RE }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Nothing to add.",
+      "ready",
+      [],
+      undefined,
+    );
+  });
+
+  it("hides once the user starts typing — typed content uses SUBMIT & READY", () => {
+    renderComposer();
+    const textarea = screen.getByPlaceholderText(
+      "Type something",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "actually I have a question" } });
+    expect(
+      screen.queryByRole("button", { name: NOTHING_TO_ADD_RE }),
+    ).toBeNull();
+  });
+
+  it("hides when the role has already marked ready", () => {
+    renderComposer({ isCurrentlyReady: true });
+    expect(
+      screen.queryByRole("button", { name: NOTHING_TO_ADD_RE }),
+    ).toBeNull();
+  });
+
+  it("hides for off-turn / sidebar submissions (hideDiscussButton=true)", () => {
+    renderComposer({ hideDiscussButton: true });
+    expect(
+      screen.queryByRole("button", { name: NOTHING_TO_ADD_RE }),
+    ).toBeNull();
+  });
+
+  it("is disabled when the composer itself is disabled", () => {
+    renderComposer({ enabled: false });
+    const button = screen.queryByRole("button", { name: NOTHING_TO_ADD_RE });
+    // The button still renders so a re-enabled composer doesn't have
+    // its layout shift, but it must not fire onSubmit while disabled.
+    expect(button).toBeTruthy();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // QA review MINOR-1: the visibility predicate also gates on
+  // ``!asRoleId`` and ``!proxyIsOffTurn``. The other tests cover
+  // 3 of the 5 conditions; these two lock the remaining footguns
+  // the inline comment in Composer.tsx calls out — proxying a
+  // "Nothing to add." for another role would re-affirm a ready
+  // signal on someone else's behalf, which is exactly the wrong
+  // shape for this affordance.
+  it("hides while impersonating another role (asRoleId set)", () => {
+    const impersonateOptions: ImpersonateOption[] = [
+      { id: "ciso", label: "CISO", offTurn: false },
+    ];
+    const { container } = renderComposer({ impersonateOptions });
+    const select = container.querySelector(
+      "select",
+    ) as HTMLSelectElement | null;
+    if (!select) throw new Error("expected an impersonate <select>");
+    fireEvent.change(select, { target: { value: "ciso" } });
+    expect(
+      screen.queryByRole("button", { name: NOTHING_TO_ADD_RE }),
+    ).toBeNull();
+  });
+
+  it("hides when impersonating an off-turn role (proxyIsOffTurn)", () => {
+    const impersonateOptions: ImpersonateOption[] = [
+      { id: "soc", label: "SOC", offTurn: true },
+    ];
+    const { container } = renderComposer({ impersonateOptions });
+    const select = container.querySelector(
+      "select",
+    ) as HTMLSelectElement | null;
+    if (!select) throw new Error("expected an impersonate <select>");
+    fireEvent.change(select, { target: { value: "soc" } });
+    expect(
+      screen.queryByRole("button", { name: NOTHING_TO_ADD_RE }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -252,6 +252,33 @@ export function Composer({
   // on initial mount.
   const handledErrorEpochRef = useRef<number | undefined>(submitErrorEpoch);
 
+  // "Nothing to add" shortcut — the operator-voice equivalent of "I'm
+  // good, ship it." Posts a brief ``Nothing to add.`` to the transcript
+  // with ``intent="ready"`` so the role lands in
+  // ``turn.ready_role_ids`` without the user having to type filler.
+  // The transcript line keeps the rest of the team informed (vs. a
+  // silent ready-flag the others can't see), and the message body
+  // satisfies the backend's empty-content guard in
+  // ``submission_pipeline.py`` so this stays a pure client-side
+  // affordance — no new server endpoint, no new gate.
+  function submitNothingToAdd() {
+    // Defense-in-depth (security review MINOR): the visibility guard
+    // ``showNothingToAdd`` already includes ``!isCurrentlyReady``, so
+    // a user who has marked ready can't see the button to click it.
+    // If a future refactor drops that clause from the predicate, this
+    // guard keeps a re-affirmation submit from sneaking through —
+    // the backend's dedupe window would catch the duplicate body, but
+    // we'd rather not rely on it for correctness.
+    if (!enabled || isCurrentlyReady) return;
+    const fallback = "Nothing to add.";
+    onSubmit(fallback, "ready", [], asRoleId || undefined);
+    setText("");
+    setMarks([]);
+    closeMentionPopover();
+    setAsRoleId("");
+    emitTypingStop("submit");
+  }
+
   function submit(intent: SubmissionIntent) {
     if (!enabled || !text.trim()) return;
     const trimmed = text.trim();
@@ -708,6 +735,19 @@ export function Composer({
     : undefined;
   const proxyIsOffTurn = Boolean(proxyOptionSelected?.offTurn);
   const showDiscussButton = !hideDiscussButton && !proxyIsOffTurn;
+  // "Nothing to add" appears only when there's a real ready/discuss
+  // quorum to participate in (so ``hideDiscussButton`` hides it on
+  // sidebar / off-turn submissions), the role hasn't already readied,
+  // the user isn't impersonating someone else (proxying a "Nothing to
+  // add." for another role would be a footgun), and the textarea is
+  // empty — the moment they start typing, the regular SUBMIT & READY
+  // path is the right affordance.
+  const showNothingToAdd =
+    !hideDiscussButton &&
+    !proxyIsOffTurn &&
+    !isCurrentlyReady &&
+    !asRoleId &&
+    !text.trim();
 
   return (
     <form
@@ -861,6 +901,28 @@ export function Composer({
               className="mono rounded-r-1 border border-ink-400 bg-ink-800 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] text-ink-100 hover:border-signal-deep hover:bg-ink-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink-300 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isCurrentlyReady ? "UNREADY ↺" : "STILL DISCUSSING →"}
+            </button>
+          ) : null}
+          {showNothingToAdd ? (
+            // Secondary-styled (matches STILL DISCUSSING) so the
+            // signal-filled SUBMIT & READY → button stays the
+            // unambiguous primary action when text is typed. UI/UX
+            // review MEDIUM: a signal-tinted middle button drew the
+            // eye away from the actual primary CTA.
+            //
+            // Label puts READY first (User Agent HIGH) so the user
+            // can scan the row and immediately tell the button marks
+            // them ready; "NOTHING TO ADD" describes the transcript
+            // line. Arrow glyph matches the rest of the row — no
+            // decorative ``✓`` (HANDOFF.md "no emoji as decoration").
+            <button
+              type="button"
+              onClick={submitNothingToAdd}
+              disabled={!enabled}
+              title="Mark yourself ready without adding to the discussion. Posts a brief 'Nothing to add.' to the transcript so the team sees you're done."
+              className="mono rounded-r-1 border border-ink-400 bg-ink-800 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] text-ink-100 hover:border-signal-deep hover:bg-ink-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink-300 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              READY — NOTHING TO ADD →
             </button>
           ) : null}
           <button

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -271,6 +271,15 @@ export function Composer({
     // we'd rather not rely on it for correctness.
     if (!enabled || isCurrentlyReady) return;
     const fallback = "Nothing to add.";
+    // Clear the rollback ref BEFORE forwarding the submit. The
+    // textarea was empty when the user clicked, so the recovery
+    // contract for this path is "leave it empty on rejection" — the
+    // user re-clicks the button to retry. Without this clear, an
+    // unrelated prior message left in ``lastAttemptedRef.current``
+    // (from a successful earlier ``submit()`` call) would be
+    // restored into the textarea on a Nothing-to-add rejection,
+    // which is worse than a no-op restore.
+    lastAttemptedRef.current = "";
     onSubmit(fallback, "ready", [], asRoleId || undefined);
     setText("");
     setMarks([]);

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1278,7 +1278,22 @@ export function Facilitator() {
   if (!state || !snapshot) return null;
 
   const activeRoleIds = snapshot.current_turn?.active_role_ids ?? [];
-  const isMyTurn = activeRoleIds.includes(state.creatorRoleId);
+  const readyRoleIds = snapshot.current_turn?.ready_role_ids ?? [];
+  const iAmActive = activeRoleIds.includes(state.creatorRoleId);
+  const iAmReady = readyRoleIds.includes(state.creatorRoleId);
+  // ``isMyTurn`` matches the Play.tsx contract: active on the current
+  // turn AND not yet readied. A creator who has marked ready but is
+  // still on the active set is no longer "their turn" — the AI is
+  // waiting on someone else, the WaitingChip should render, and the
+  // composer's secondary button flips to UNREADY ↺ via
+  // ``isCurrentlyReady`` so the creator can walk it back if needed.
+  const isMyTurn = iAmActive && !iAmReady;
+  // Lifted from the composer IIFE so the "Awaiting your response"
+  // banner can include the role-label suffix that ``Play.tsx:1388``
+  // ships. Without the suffix the creator-as-impersonator can't tell
+  // which of their hats the AI is waiting on (UI/UX + User Agent
+  // review HIGH).
+  const selfRole = snapshot.roles.find((r) => r.id === state.creatorRoleId);
   const playerCount = snapshot.roles.filter((r) => r.kind === "player").length;
 
   // Issue #113: keep the wizard chrome up through setup/ready so the
@@ -1674,15 +1689,29 @@ export function Facilitator() {
                   the "is the AI thinking or stuck?" signal sits where
                   the operator's eye already is during a turn. */}
               <BusyChip busy={busy} message={busyMessage} />
-              {!isMyTurn && snapshot.current_turn?.active_role_ids?.length ? (
+              {/* Mirror of the player-side chip on Play.tsx so the
+                  creator-as-player gets the same at-a-glance "you are
+                  on the hook" cue. Without this, a creator who is on
+                  the active set but never typed anything has no visual
+                  signal — only the small composer label changes —
+                  and the user-agent review flagged this as a real
+                  "did the AI freeze on me?" mystery during solo runs. */}
+              {snapshot.state !== "ENDED" && isMyTurn ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="mb-2 rounded border border-warn bg-warn-bg px-3 py-1.5 text-center text-xs font-semibold leading-tight text-warn break-words"
+                >
+                  ⚠ Awaiting your response — {selfRole?.label ?? "you"}
+                </div>
+              ) : null}
+              {!isMyTurn && activeRoleIds.length ? (
                 <WaitingChip
                   activeRoleIds={activeRoleIds}
                   submittedRoleIds={
                     snapshot.current_turn?.submitted_role_ids ?? []
                   }
-                  readyRoleIds={
-                    snapshot.current_turn?.ready_role_ids ?? []
-                  }
+                  readyRoleIds={readyRoleIds}
                   roles={snapshot.roles}
                 />
               ) : null}
@@ -1699,9 +1728,9 @@ export function Facilitator() {
                   submittedRoleIds:
                     snapshot.current_turn?.submitted_role_ids ?? [],
                 });
-                const selfRole = snapshot.roles.find(
-                  (r) => r.id === state.creatorRoleId,
-                );
+                // ``selfRole`` is computed at the top of the render
+                // so the "Awaiting your response" banner can use it;
+                // the composer label below reads the same value.
                 // Wave 2: roster the @-popover offers. Excludes the
                 // creator's own role and spectators. Synthetic
                 // facilitator entry is rendered by the popover itself.
@@ -1782,6 +1811,20 @@ export function Facilitator() {
                       impersonateOptions={impersonateOptions}
                       selfLabel={selfRole?.label}
                       mentionRoster={mentionRoster}
+                      // Mirror Play.tsx: surface the creator's own ready
+                      // signal so the secondary button flips to
+                      // ``UNREADY ↺`` after they mark ready, the
+                      // ``You're marked ready`` hint shows, and the
+                      // ``NOTHING TO ADD →`` shortcut hides (no point
+                      // when the role is already in ``ready_role_ids``).
+                      isCurrentlyReady={iAmReady}
+                      // The creator can post out-of-turn sidebar
+                      // comments at any time (issue #78). Hide the
+                      // discuss/ready buttons when they're not on the
+                      // active turn so the affordances only show where
+                      // they're load-bearing — same rule the player
+                      // path uses on Play.tsx.
+                      hideDiscussButton={!iAmActive}
                     />
                   </>
                 );

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1289,10 +1289,10 @@ export function Facilitator() {
   // ``isCurrentlyReady`` so the creator can walk it back if needed.
   const isMyTurn = iAmActive && !iAmReady;
   // Lifted from the composer IIFE so the "Awaiting your response"
-  // banner can include the role-label suffix that ``Play.tsx:1388``
-  // ships. Without the suffix the creator-as-impersonator can't tell
-  // which of their hats the AI is waiting on (UI/UX + User Agent
-  // review HIGH).
+  // banner can include the role-label suffix the player-side
+  // awaiting-response banner in ``Play.tsx`` ships. Without the
+  // suffix the creator-as-impersonator can't tell which of their
+  // hats the AI is waiting on (UI/UX + User Agent review HIGH).
   const selfRole = snapshot.roles.find((r) => r.id === state.creatorRoleId);
   const playerCount = snapshot.roles.filter((r) => r.kind === "player").length;
 

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -1563,6 +1563,7 @@ const WAITING_TIPS: readonly string[] = [
   "Disagree with a teammate? Say so. The AI tracks decisions and dissents in the AAR.",
   "Out of your lane? \"Loop in Legal\" or \"hand off to Comms\" — the AI will pivot the conversation.",
   "Focus on your reasoning — the AAR captures decisions and rationale, not right-vs-wrong scoring.",
+  "Nothing to add on a turn? Hit READY — NOTHING TO ADD instead of typing filler — keeps the team's pace up.",
 ];
 const WAITING_TIP_ROTATE_MS = 7000;
 
@@ -1875,6 +1876,24 @@ export function JoinIntro({
                 </span>{" "}
                 chip appears. The most recent AI message is also
                 outlined so you can spot what to react to.
+              </li>
+              <li>
+                <span className="font-semibold text-ink-100">Submit, discuss, or pass.</span>{" "}
+                <span className="mono rounded-r-1 border border-signal-deep bg-ink-800 px-1.5 py-0.5 text-[10px] font-bold uppercase text-signal">
+                  SUBMIT &amp; READY →
+                </span>{" "}
+                posts your reply AND marks you ready — the AI advances
+                once everyone is ready.{" "}
+                <span className="mono rounded-r-1 border border-ink-400 bg-ink-800 px-1.5 py-0.5 text-[10px] font-bold uppercase text-ink-100">
+                  STILL DISCUSSING →
+                </span>{" "}
+                posts but keeps your seat open for follow-ups. Nothing
+                to add this turn?{" "}
+                <span className="mono rounded-r-1 border border-ink-400 bg-ink-800 px-1.5 py-0.5 text-[10px] font-bold uppercase text-ink-100">
+                  READY — NOTHING TO ADD →
+                </span>{" "}
+                marks you ready without forcing filler — useful when a
+                teammate already covered your angle.
               </li>
             </ul>
           )}


### PR DESCRIPTION
## Summary

The creator-as-player path was missing two affordances the player path already had:

1. The **"⚠ Awaiting your response"** banner only rendered on `Play.tsx` — a creator on the active turn had to infer it from the small composer label. Solo runs hit the "did the AI freeze on me?" mystery.
2. There was **no path to mark ready without typing filler**. A role with nothing to add either typed `ok` / `pass` or left the turn dangling while the team waited on them.

This PR adds both, plus updates the player-side lobby copy so a participant in the join-intro waiting room sees the new affordance before they hit their first turn.

## Changes

- **`Facilitator.tsx`** — add the missing banner above the composer; tighten `isMyTurn = iAmActive && !iAmReady` to match `Play.tsx`; pass `isCurrentlyReady` + `hideDiscussButton` through so the existing `UNREADY ↺` flip and "you're marked ready" hint work for the creator. Lift `selfRole` to the top of the render so the banner can include the `— {role.label}` suffix that ships on `Play.tsx`.
- **`Composer.tsx`** — add the `READY — NOTHING TO ADD →` button + `submitNothingToAdd()` helper. Posts a literal `Nothing to add.` with `intent="ready"` through the existing `onSubmit → submit_response` WS flow — no new backend gate. Visible only when `!hideDiscussButton && !proxyIsOffTurn && !isCurrentlyReady && !asRoleId && !text.trim()`. Defense-in-depth `isCurrentlyReady` guard inside the helper too.
- **`Play.tsx`** — extend `HOW TO PLAY` to introduce the three controls and append a matching tip to `WAITING_TIPS`.
- **`Composer.nothingToAdd.test.tsx`** (new) — 8 tests locking the visibility matrix.

No backend / LLM / scenario-replay changes — pure frontend; submission flows through the existing pipeline unchanged.

## Sub-agent reviews (six, run in parallel per CLAUDE.md)

| Agent | Verdict | Resolved this commit | Deferred |
|---|---|---|---|
| QA | pass | MINOR-1: added `asRoleId` / off-turn proxy tests | MEDIUM (label-cascade reads "Respond as / sidebar" after creator marks ready — pre-existing parity with Play.tsx) |
| Security | APPROVE | MINOR: added defense-in-depth `isCurrentlyReady` guard in `submitNothingToAdd` | i18n consideration when localization lands |
| UI/UX | pass | HIGH: appended role-label suffix to banner; HIGH: replaced decorative `✓` with `→` per HANDOFF.md; MEDIUM: de-emphasized button to neutral styling so `SUBMIT & READY` stays the primary CTA | LOW (test default-prop, banner mono-tracking) |
| Product / App-Owner | pass | — | — (both asks satisfied, no scope drift) |
| User Agent (creator persona) | pass | HIGH: banner reads `⚠ Awaiting your response — {role.label}`; HIGH: button now leads with `READY` so readiness intent is scannable | MEDIUM (transcript styling for `Nothing to add.` entries; three-button crowding partly mitigated by the visual de-emphasis above) |
| Prompt Expert | no concerns | — | — (guardrail rubric in `prompts.py` explicitly classifies casual / short reactions as `on_topic`; AAR scorer handles "Nothing to add." entries gracefully) |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test -- --run` — 442/442 pass (was 434, +8 new in `Composer.nothingToAdd.test.tsx`)
- [ ] Manual smoke: creator on active turn sees `⚠ Awaiting your response — {role}` banner above composer
- [ ] Manual smoke: creator with empty composer + active turn sees `READY — NOTHING TO ADD →` button; clicking it posts `Nothing to add.` to transcript and advances the turn when everyone else is ready
- [ ] Manual smoke: button hides when textarea is non-empty, when role has marked ready, when impersonating another role, and on off-turn / sidebar submissions
- [ ] Manual smoke: `HOW TO PLAY` lobby card now shows the three button labels; `WAITING_TIPS` carousel mentions `READY — NOTHING TO ADD`

https://claude.ai/code/session_01LiJSXbVtwz3MWt278KY9DK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiJSXbVtwz3MWt278KY9DK)_