### PR TITLE
frontend: show debounced "AI is thinking" banner during pre-plan setup replies

### DIFF
--- a/frontend/src/__tests__/SetupView.planPanel.test.tsx
+++ b/frontend/src/__tests__/SetupView.planPanel.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SetupView } from "../pages/Facilitator";
 import {
   DEFAULT_SESSION_FEATURES,
@@ -195,9 +195,24 @@ describe("SetupView — with-plan branch", () => {
 /**
  * The plan-drafting wait is 5–30 s of non-streaming LLM work; pre-fix,
  * the operator only saw the small typing dots inside the chat
- * transcript and the LOOKS READY button reading as "stuck." The
- * ``draftingPlan`` prop renders a prominent in-chat banner with the
- * brand DieLoader so the wait reads as an explicit, named step.
+ * transcript and the LOOKS READY button reading as "stuck." A
+ * prominent in-chat banner with the brand DieLoader names the wait
+ * as an explicit step.
+ *
+ * Two banner variants share one ``data-testid="drafting-plan-banner"``
+ * element; ``data-banner-variant`` distinguishes them:
+ *
+ *  - ``looks-ready`` — driven by the ``draftingPlan`` prop
+ *    (Facilitator's ``handleLooksReady`` click). Mounts immediately,
+ *    label "Drafting scenario plan · typically 10–30 sec". A plan IS
+ *    the documented next step here.
+ *  - ``implicit-thinking`` — internal SetupView state. Mounts after
+ *    a 1.5 s debounce when ``busy && !hasPlan && !draftingPlan``.
+ *    Label "AI is thinking · typically 5–30 sec" — neutral because
+ *    the AI may end up drafting another question or the plan, and we
+ *    can't tell mid-call (the setup tier is non-streaming). Quick
+ *    chip-pick turns under the threshold keep the small typing dots
+ *    only — no heavy banner mount/unmount thrash.
  *
  * The banner intentionally relies on ``<DieLoader>``'s own
  * ``role="status" aria-live="polite"`` rather than wrapping in a
@@ -206,12 +221,12 @@ describe("SetupView — with-plan branch", () => {
  * expectation so a single announcement covers both pieces.
  */
 describe("SetupView — draftingPlan banner", () => {
-  it("does NOT render the banner when draftingPlan is false", () => {
+  it("does NOT render the banner when not busy and no draftingPlan", () => {
     render(<SetupView snapshot={fakeSnapshot(null)} {...baseProps()} />);
     expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
   });
 
-  it("renders the prominent banner when draftingPlan is true and no plan yet", () => {
+  it("renders the LOOKS-READY banner immediately (no debounce) with the plan-specific label", () => {
     render(
       <SetupView
         snapshot={fakeSnapshot(null)}
@@ -223,6 +238,9 @@ describe("SetupView — draftingPlan banner", () => {
     );
     const banner = screen.getByTestId("drafting-plan-banner");
     expect(banner).toBeInTheDocument();
+    // The plan-specific variant is honest only when LOOKS READY was
+    // explicitly clicked — that's what ``draftingPlan`` represents.
+    expect(banner).toHaveAttribute("data-banner-variant", "looks-ready");
     // The DieLoader label is the load-bearing copy — names the step
     // ("Drafting scenario plan") and sets a timing expectation
     // ("typically 10–30 sec"). The operator's complaint was "feels
@@ -308,5 +326,173 @@ describe("SetupView — draftingPlan banner", () => {
     );
     expect(screen.getByRole("button", { name: "Option A" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Option B" })).toBeDisabled();
+  });
+});
+
+/**
+ * The implicit-thinking variant covers the case the user reported in
+ * the bug fix that introduced this code: when the AI is processing a
+ * regular setup reply (not LOOKS READY) and may decide to draft the
+ * plan on its own, the operator was previously left with only the
+ * small typing dots — feels stuck.
+ *
+ * Two design rules these tests pin (both came directly from review):
+ *  - **Debounce.** Quick turns (chip pick → 5 s question response)
+ *    keep the small typing dots; only slow turns (≳1.5 s) escalate
+ *    to the banner. Without the debounce, fast Q&A round-trips cause
+ *    the heavy banner to mount/unmount on every reply, training the
+ *    operator to ignore it (banner-fatigue) and undermining its
+ *    signal value when LOOKS-READY actually runs.
+ *  - **Neutral label.** "AI is thinking · typically 5–30 sec"
+ *    rather than "Drafting scenario plan". The setup tier is
+ *    non-streaming so we can't tell mid-call whether the AI is
+ *    producing another question or the actual plan; a neutral label
+ *    is honest in either case. The plan-specific label is reserved
+ *    for ``draftingPlan`` (LOOKS-READY click) where a plan IS the
+ *    documented next step.
+ */
+describe("SetupView — implicit-thinking banner (debounced)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does NOT render under the 1500 ms debounce threshold", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        busyMessage="AI is thinking — drafting the next setup question…"
+      />,
+    );
+    // Banner is absent at t=0.
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+    // Still absent just before the threshold — fast turns shouldn't
+    // mount the heavy banner.
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders with the neutral label after the 1500 ms debounce", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        busyMessage="AI is thinking — drafting the next setup question…"
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    const banner = screen.getByTestId("drafting-plan-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute("data-banner-variant", "implicit-thinking");
+    // Neutral label is honest whether the AI ends up drafting another
+    // question or the plan.
+    expect(within(banner).getByText(/AI is thinking/i)).toBeInTheDocument();
+    expect(within(banner).getByText(/5–30 sec/i)).toBeInTheDocument();
+    // The plan-specific label MUST NOT appear in the implicit branch
+    // — it would lie when the AI is just drafting another question.
+    expect(
+      within(banner).queryByText(/Drafting scenario plan/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears immediately when busy goes false (request finished)", () => {
+    const { rerender } = render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        busyMessage="AI is thinking…"
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByTestId("drafting-plan-banner")).toBeInTheDocument();
+    rerender(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy={false}
+      />,
+    );
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+  });
+
+  it("does not arm the implicit banner when LOOKS-READY is already showing", () => {
+    // Concurrency invariant: when ``draftingPlan`` is true, the
+    // LOOKS-READY variant takes priority — the implicit timer must
+    // not also arm and swap labels mid-wait.
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        draftingPlan
+        busyMessage="Drafting the scenario plan…"
+      />,
+    );
+    // LOOKS-READY variant shows immediately.
+    const banner = screen.getByTestId("drafting-plan-banner");
+    expect(banner).toHaveAttribute("data-banner-variant", "looks-ready");
+    // Even after the implicit-debounce window passes, the variant
+    // must stay LOOKS-READY (priority guard).
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(banner).toHaveAttribute("data-banner-variant", "looks-ready");
+  });
+
+  it("does not arm when a plan already exists (revision case)", () => {
+    // The revision case (``hasPlan=true`` + ``busy=true``) is owned
+    // by the BusyChip's "revising the plan" message. The prominent
+    // banner would compete with the plan card itself.
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(fakePlan())}
+        {...baseProps()}
+        busy
+        busyMessage="AI is thinking — revising the plan…"
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the small BusyChip once the implicit banner is up", () => {
+    // Same indicator-hierarchy invariant as the LOOKS-READY case:
+    // banner + chip + dots together read as duplicate UI.
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        busy
+        busyMessage="AI is thinking — drafting the next setup question…"
+      />,
+    );
+    // Pre-debounce: chip is visible (small indicator) and banner is
+    // absent.
+    expect(
+      screen.getByText(/AI is thinking — drafting the next setup question…/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("drafting-plan-banner")).not.toBeInTheDocument();
+    // Post-debounce: banner is up, chip text is suppressed.
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByTestId("drafting-plan-banner")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/AI is thinking — drafting the next setup question…/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/SetupView.planPanel.test.tsx
+++ b/frontend/src/__tests__/SetupView.planPanel.test.tsx
@@ -404,7 +404,15 @@ describe("SetupView — implicit-thinking banner (debounced)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("clears immediately when busy goes false (request finished)", () => {
+  it("clears in the same render commit when busy goes false (no flicker)", () => {
+    // Copilot PR #201 review flagged a one-frame flicker risk: the
+    // latched ``showImplicitThinkingBanner`` state would still be
+    // true on the render where ``busy`` flipped false, until the
+    // ``useEffect`` cleanup committed the reset. The fix is to gate
+    // ``showThinkingBanner`` on ``busy`` directly. This test pins
+    // that — the banner must be absent on the very first render
+    // after ``busy=false`` is passed in, BEFORE any subsequent
+    // effect tick.
     const { rerender } = render(
       <SetupView
         snapshot={fakeSnapshot(null)}
@@ -417,6 +425,9 @@ describe("SetupView — implicit-thinking banner (debounced)", () => {
       vi.advanceTimersByTime(1500);
     });
     expect(screen.getByTestId("drafting-plan-banner")).toBeInTheDocument();
+    // Re-render with busy=false but DON'T wrap in act — we want to
+    // observe the synchronous render commit. (act wraps state +
+    // effect flushes; the gate must work without that.)
     rerender(
       <SetupView
         snapshot={fakeSnapshot(null)}

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -2390,10 +2390,17 @@ export function SetupView({
 
   // The prominent banner is shown when EITHER explicit signal
   // (``draftingPlan``) or the debounced implicit signal is true and
-  // no plan exists yet.
+  // no plan exists yet. The implicit branch is also gated on
+  // ``busy`` directly (not just on the latched
+  // ``showImplicitThinkingBanner`` state) so a render commit where
+  // ``busy`` has just flipped false but the effect cleanup hasn't
+  // run yet doesn't paint a stale banner for one frame (Copilot
+  // PR #201 review). The state still drives the *delay* (banner only
+  // appears after the 1500 ms timer); the ``busy`` gate just makes
+  // the unmount synchronous with the request finishing.
   const showLooksReadyBanner = draftingPlan && !hasPlan;
   const showThinkingBanner =
-    showImplicitThinkingBanner && !hasPlan && !draftingPlan;
+    showImplicitThinkingBanner && busy && !hasPlan && !draftingPlan;
   const bannerVisible = showLooksReadyBanner || showThinkingBanner;
 
   // Layout intent (across both branches):

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -269,22 +269,17 @@ export function Facilitator() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
-  // Prominent in-chat indicator for the LOOKS-READY → propose-plan path.
-  // Distinct from ``busy`` because the chat-region DieLoader needs to
-  // be visible *only* during the plan-drafting wait — not during the
-  // dozen other things that flip ``busy`` (regular Q&A reply,
-  // finalize, skip-setup-dev, etc.). The setup tier is non-streaming
-  // so we can't detect mid-call whether the model chose
-  // ``ask_setup_question`` vs ``propose_scenario_plan``; the explicit
-  // button click is the one moment we *know* what's coming, so we
-  // light the banner client-side there.
-  //
-  // Implicit-nudge gap (tracked follow-up): when the AI decides to
-  // propose during a regular reply turn (not LOOKS READY), the
-  // operator still sees only the small typing dots until the plan
-  // lands. Closing that gap requires either streaming the setup tier
-  // (so the model's tool choice is observable mid-call) or a
-  // mid-call "now drafting" WS event. Out of scope for this PR.
+  // Prominent in-chat indicator with the LOOKS-READY-specific label
+  // ("Drafting scenario plan · typically 10–30 sec"). True from the
+  // moment the operator clicks LOOKS READY → propose-the-plan until
+  // the plan lands or an error surfaces. Distinct from ``busy``
+  // because the chat-region DieLoader's *plan-specific* label is
+  // honest only when we know a plan is imminent — i.e. the operator
+  // explicitly asked for one. The implicit "AI is thinking" indicator
+  // for regular pre-plan replies is owned by SetupView itself
+  // (debounced; soft label) so quick chip-pick turns under ~1.5 s
+  // never mount the heavy banner. See SetupView's
+  // ``showImplicitThinkingBanner`` state for that branch.
   const [draftingPlan, setDraftingPlan] = useState(false);
   const [wsStatus, setWsStatus] = useState<"connecting" | "open" | "closed" | "error" | "kicked" | "rejected" | "session-gone">("connecting");
 
@@ -912,6 +907,12 @@ export function Facilitator() {
     setError(null);
     setBusy(true);
     setBusyMessage(busyText);
+    // Note: this path does NOT set ``draftingPlan`` — that flag is
+    // reserved for the LOOKS READY click where we know a plan is
+    // imminent. The implicit-thinking banner (debounced, with a
+    // softer "AI is thinking" label) is owned by SetupView itself
+    // based on ``busy && !hasPlan && !draftingPlan``. See
+    // ``SetupView``'s ``showImplicitThinkingBanner`` state.
     try {
       await api.setupReply(state.sessionId, state.token, content.trim());
       await refreshSnapshot();
@@ -953,6 +954,7 @@ export function Facilitator() {
     }
     setBusy(true);
     setDraftingPlan(true);
+    console.debug("[facilitator] draftingPlan", { value: true, source: "looks-ready" });
     setBusyMessage("Drafting the scenario plan… typically 10–30 seconds.");
     try {
       const reply = await api.setupReply(state.sessionId, state.token, NUDGE_PROPOSE);
@@ -963,6 +965,7 @@ export function Facilitator() {
         // operator's eye moves to the plan card; the smaller BusyChip
         // continues to communicate the fast finalize step.
         setDraftingPlan(false);
+        console.debug("[facilitator] draftingPlan", { value: false, source: "looks-ready-plan-landed" });
         setBusyMessage("Plan drafted — finalizing…");
         await api.setupFinalize(state.sessionId, state.token);
         const after = await api.getSession(state.sessionId, state.token);
@@ -995,6 +998,7 @@ export function Facilitator() {
       setBusy(false);
       setBusyMessage(null);
       setDraftingPlan(false);
+      console.debug("[facilitator] draftingPlan", { value: false, source: "looks-ready-finally" });
     }
   }
 
@@ -2321,17 +2325,76 @@ export function SetupView({
   onPickOption: (option: string) => void;
   busy: boolean;
   busyMessage: string | null;
-  /** True from the moment the operator clicks LOOKS READY → PROPOSE THE
-   *  PLAN until either the plan arrives or an error surfaces. Drives a
-   *  prominent in-chat banner so the operator has unambiguous feedback
-   *  during the 5–30 s plan-drafting wait (otherwise the small typing
-   *  dots in the chat read as "stuck"). Required, not optional —
-   *  every call site already passes it explicitly and a default would
-   *  silently hide the indicator if a future site forgets. */
+  /** True from the moment the operator clicks LOOKS READY → PROPOSE
+   *  THE PLAN until either the plan arrives or an error surfaces.
+   *  Drives a prominent in-chat banner with the plan-specific label
+   *  "Drafting scenario plan · typically 10–30 sec" so the operator
+   *  has unambiguous feedback during the 10–30 s wait. The implicit
+   *  branch — AI is thinking during a regular reply / option pick —
+   *  is owned by SetupView's internal ``showImplicitThinkingBanner``
+   *  state (debounced, neutral label) so quick turns don't mount the
+   *  heavy banner. Required, not optional — every call site already
+   *  passes it explicitly and a default would silently hide the
+   *  indicator if a future site forgets. */
   draftingPlan: boolean;
 }) {
   const hasPlan = Boolean(snapshot.plan);
   const notes = snapshot.setup_notes ?? [];
+
+  // Implicit-thinking banner: shown during a regular reply / option
+  // pick (not LOOKS READY) when the AI is processing pre-plan and the
+  // wait crosses ~1.5 s. Two design choices, both from
+  // user-persona + UI/UX review:
+  //   1. **Debounce** — fast turns (chip pick → 5 s question) keep
+  //      the small typing dots; only slow turns (≳1.5 s) escalate to
+  //      the banner. Without this the banner would mount/unmount on
+  //      every routine Q&A round, training the operator to ignore it
+  //      and undermining its signal value when LOOKS-READY actually
+  //      runs.
+  //   2. **Neutral label** — "AI is thinking · typically 5–30 sec"
+  //      rather than the LOOKS-READY-specific "Drafting scenario
+  //      plan". The setup tier is non-streaming so we can't tell
+  //      mid-call whether the AI is producing another question or
+  //      the actual plan; a neutral label is honest in either case.
+  //      The plan-specific label is reserved for ``draftingPlan``
+  //      (the explicit operator-clicked-LOOKS-READY path) where a
+  //      plan IS the documented next step.
+  // The 1500 ms threshold matches the perceptual "barely noticed"
+  // → "definitely waiting" boundary; tune if user feedback diverges.
+  const [showImplicitThinkingBanner, setShowImplicitThinkingBanner] =
+    useState(false);
+  useEffect(() => {
+    // The implicit banner only applies pre-plan and only when the
+    // explicit LOOKS-READY banner isn't already up.
+    if (busy && !hasPlan && !draftingPlan) {
+      const timer = window.setTimeout(() => {
+        setShowImplicitThinkingBanner(true);
+        console.debug("[facilitator] implicit-thinking banner mounted");
+      }, 1500);
+      return () => {
+        window.clearTimeout(timer);
+        // The cleanup runs both on unmount and on dep change. If the
+        // banner had mounted, ensure it clears so a transition from
+        // "busy without plan" → "plan exists" / "LOOKS-READY took
+        // over" / "request finished" doesn't leave a stale banner.
+        setShowImplicitThinkingBanner(false);
+      };
+    }
+    // Defensive reset for the ``busy=false`` / ``hasPlan=true`` /
+    // ``draftingPlan=true`` branches — the cleanup above only fires
+    // on dep change *from the previous truthy branch*, so a
+    // first-render with the banner already false has no effect here.
+    setShowImplicitThinkingBanner(false);
+    return undefined;
+  }, [busy, hasPlan, draftingPlan]);
+
+  // The prominent banner is shown when EITHER explicit signal
+  // (``draftingPlan``) or the debounced implicit signal is true and
+  // no plan exists yet.
+  const showLooksReadyBanner = draftingPlan && !hasPlan;
+  const showThinkingBanner =
+    showImplicitThinkingBanner && !hasPlan && !draftingPlan;
+  const bannerVisible = showLooksReadyBanner || showThinkingBanner;
 
   // Layout intent (across both branches):
   //   - No plan: single column — chat → reply form, top to bottom.
@@ -2369,15 +2432,16 @@ export function SetupView({
           can't dispatch a second ``api.setupReply()`` while a
           LOOKS-READY draft is mid-air (PR #186 review block).
           ``aiTyping`` is the indicator-only flag: suppress the
-          small bouncing dots while the prominent drafting-plan
-          banner below is the dominant signal, otherwise mirror
-          ``busy``. The two flags are deliberately split — combining
-          them would silently re-enable chip clicks during the
-          draft. */}
+          small bouncing dots once a prominent banner takes over,
+          otherwise mirror ``busy``. Sub-debounce regular replies
+          (``busy=true``, banner not yet mounted) keep the dots so
+          quick turns get a light indicator. The two flags are
+          deliberately split — combining them would silently
+          re-enable chip clicks during the draft. */}
       <SetupChat
         notes={notes}
         busy={busy}
-        aiTyping={busy && !draftingPlan}
+        aiTyping={busy && !bannerVisible}
         onPickOption={onPickOption}
       />
 
@@ -2389,31 +2453,46 @@ export function SetupView({
           expectation inline so screen readers announce the full
           message in one pass.
 
-          ``!hasPlan`` race guard: the Facilitator clears
-          ``draftingPlan`` as soon as the plan lands, but a
-          render-cycle race could leave both true for a frame. Hiding
-          the banner once a plan exists makes that race a no-op
-          rather than a "drafting" caption flashing over the new plan
-          card. */}
-      {draftingPlan && !hasPlan ? (
+          Two label branches share one banner element (single
+          ``data-testid`` so existing tests / observers find it):
+          ``draftingPlan`` (operator clicked LOOKS READY) → the
+          plan-specific label with the 10–30 s window we know
+          applies; the implicit/debounced branch → a neutral "AI is
+          thinking" label that's honest whether the AI ends up
+          drafting another question or the plan.
+
+          ``!hasPlan`` race guard on both branches: the Facilitator
+          clears ``draftingPlan`` as soon as the plan lands, but a
+          render-cycle race could leave both true for a frame.
+          Hiding the banner once a plan exists makes that race a
+          no-op rather than a "drafting" caption flashing over the
+          new plan card. */}
+      {bannerVisible ? (
         <div
           data-testid="drafting-plan-banner"
+          data-banner-variant={
+            showLooksReadyBanner ? "looks-ready" : "implicit-thinking"
+          }
           className="flex flex-col items-center gap-3 rounded-r-3 border border-signal-deep bg-signal-tint p-6"
         >
           <DieLoader
-            label="Drafting scenario plan · typically 10–30 sec"
+            label={
+              showLooksReadyBanner
+                ? "Drafting scenario plan · typically 10–30 sec"
+                : "AI is thinking · typically 5–30 sec"
+            }
             size={64}
           />
         </div>
       ) : null}
 
-      {/* Suppress the small chip while the prominent banner above is
-          claiming the operator's attention (UI/UX review: three
-          parallel indicators read as duplicate UI). The chip continues
-          to communicate the fast post-plan finalize step
+      {/* Suppress the small chip while a prominent banner is
+          claiming the operator's attention (UI/UX review: parallel
+          indicators read as duplicate UI). The chip continues to
+          communicate the fast post-plan finalize step
           (``busyMessage = "Plan drafted — finalizing…"``) and every
           other ``busy`` state. */}
-      <BusyChip busy={busy && !draftingPlan} message={busyMessage} />
+      <BusyChip busy={busy && !bannerVisible} message={busyMessage} />
     </div>
   );
 


### PR DESCRIPTION
## Summary

The prominent setup-tier loading banner only mounted when the operator clicked **LOOKS READY**. When the AI decided to draft the plan on its own after a regular reply or option-chip pick, the operator was left with only the small typing dots during a 5–30 s wait — reads as "stuck."

This adds a second, debounced banner variant owned by `SetupView` that mounts during a regular pre-plan reply once `busy` has been true for ~1.5 s. Quick chip-pick turns under that threshold keep the small typing dots only — no heavy banner mount/unmount thrash.

The two banner variants share one `data-testid` and use distinct `data-banner-variant` values:

| Variant | Trigger | Label | Timing |
| --- | --- | --- | --- |
| `looks-ready` | `draftingPlan` prop (operator clicked LOOKS READY) | `Drafting scenario plan · typically 10–30 sec` | Immediate (no debounce) |
| `implicit-thinking` | SetupView internal state (debounced 1500 ms; `busy && !hasPlan && !draftingPlan`) | `AI is thinking · typically 5–30 sec` | Mounts after debounce |

The setup tier is non-streaming, so we can't tell mid-call whether the AI is producing another question or the actual plan. The neutral "AI is thinking" label is honest in either case; the plan-specific label is reserved for the LOOKS-READY click where a plan IS the documented next step.

Both banners are suppressed once a plan exists (panel becomes the focal artifact, BusyChip resumes for revising/finalize). Chip + typing-dots are suppressed whenever a banner is up — preserves the indicator-hierarchy invariant from PR #186.

## Sub-agent review summary

- **QA**: clean, no CRITICAL/BLOCK/HIGH.
- **Security**: no input/secret/auth surface touched (pure UI state-management change).
- **Product**: APPROVE; suggested follow-up if user feedback shows label confusion — addressed proactively here via the variant split.
- **UI/UX**: HIGH on label fidelity ("'Drafting scenario plan' lies during routine Q&A") + LOW on logging. **Both addressed** (variant split + `console.debug("[facilitator] draftingPlan", { ... })` state-transition logging).
- **User-persona**: HIGH on label fidelity AND HIGH on banner thrash during rapid chip picks. **Both addressed** (variant split + 1.5 s debounce).
- **Prompt expert**: N/A (no prompt changes).

## Lifecycle scenario carve-out

Per CLAUDE.md scenario commit rule: this is a UI loading-indicator change. No `SessionState` transition, no turn-pump path, no input gate, no `MessageKind`/tool-name change. No scenario update required.

## Test plan

- [x] `npm test` — 465/465 pass (6 new `vi.useFakeTimers()`-driven cases pin the debounce threshold, LOOKS-READY-priority guard, plan-exists suppression, and chip-suppression).
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [ ] Manual smoke at 1080p / 1440p / mobile viewports: verify banner reachability and reflow.
- [ ] Manual smoke: regular reply with a slow AI response (≥1.5 s) — neutral banner appears.
- [ ] Manual smoke: chip pick with a fast AI response (<1.5 s) — only dots, no banner mount.
- [ ] Manual smoke: LOOKS READY click — plan-specific banner mounts immediately.
- [ ] Manual smoke: revising the plan after approve — chip + "Plan drafted — finalizing…" message; no prominent banner.

https://claude.ai/code/session_01H5Yj2kCMFgvzwzWWFt5XS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5Yj2kCMFgvzwzWWFt5XS7)_