### PR TITLE
frontend: stop auto-finalizing the scenario plan after LOOKS READY

### DIFF
--- a/frontend/src/__tests__/Facilitator.looksReady.test.tsx
+++ b/frontend/src/__tests__/Facilitator.looksReady.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+
+// Stub the WS module BEFORE importing Facilitator so the connect()
+// effect doesn't try to open a real socket. Returns a no-op client
+// that swallows every send/close call.
+vi.mock("../lib/ws", () => {
+  return {
+    WsClient: class {
+      connect() {
+        /* no-op */
+      }
+      close() {
+        /* no-op */
+      }
+      send() {
+        /* no-op */
+      }
+    },
+  };
+});
+
+import {
+  api,
+  type ScenarioPlan,
+  type SessionSnapshot,
+  DEFAULT_SESSION_FEATURES,
+} from "../api/client";
+import { Facilitator } from "../pages/Facilitator";
+
+function fakePlan(): ScenarioPlan {
+  return {
+    title: "Operation Test Echo",
+    executive_summary: "Ransomware drill in a regional hospital.",
+    key_objectives: ["Identify patient zero by beat 3"],
+    guardrails: ["No real exploit code"],
+    success_criteria: ["Containment decision documented"],
+    out_of_scope: ["Insurance specifics"],
+    narrative_arc: [
+      { beat: 1, label: "Detection", expected_actors: ["IR Lead"] },
+    ],
+    injects: [{ trigger: "T+10", type: "info", summary: "ping" }],
+  };
+}
+
+function fakeSnapshotWithoutPlan(): SessionSnapshot {
+  return {
+    id: "session_test",
+    state: "SETUP",
+    created_at: "2026-05-07T00:00:00Z",
+    scenario_prompt: "test scenario",
+    settings: {
+      difficulty: "standard",
+      duration_minutes: 60,
+      features: { ...DEFAULT_SESSION_FEATURES },
+    },
+    plan: null,
+    roles: [],
+    current_turn: null,
+    messages: [],
+    setup_notes: [
+      {
+        ts: "2026-05-07T00:00:01Z",
+        speaker: "ai",
+        content: "What's your industry?",
+        topic: null,
+        options: null,
+      },
+    ],
+    cost: null,
+    workstreams: [],
+  };
+}
+
+function fakeSnapshotWithPlan(): SessionSnapshot {
+  return { ...fakeSnapshotWithoutPlan(), plan: fakePlan() };
+}
+
+/**
+ * Regression net for the bug fixed in this PR: clicking LOOKS READY —
+ * PROPOSE THE PLAN previously called ``api.setupFinalize`` immediately
+ * after the AI returned a plan, which transitioned the session
+ * SETUP → READY and bumped the wizard from step 4 to step 5 without
+ * the operator ever seeing the plan. The fix removes the auto-call;
+ * finalize now only runs from the explicit APPROVE & START LOBBY click
+ * in PlanPanel (which routes through ``handleApprovePlan``).
+ *
+ * The test drives the Facilitator from the intro form through
+ * ROLL SESSION, fakes a SETUP-state session with a single AI question,
+ * clicks LOOKS READY, and asserts:
+ *   1. ``api.setupReply`` IS called (with the ``NUDGE_PROPOSE`` string).
+ *   2. ``api.setupFinalize`` is NEVER called as part of that flow —
+ *      the only legitimate call site is the operator's APPROVE click.
+ *   3. The drafted plan title renders in the PlanPanel after the
+ *      reply resolves, proving step 4 is the rendering surface.
+ *
+ * The WS module is mocked at the top of this file so the connect()
+ * effect doesn't dial a real socket.
+ */
+describe("Facilitator — handleLooksReady doesn't auto-finalize (regression)", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT call api.setupFinalize after LOOKS READY returns a plan", async () => {
+    const createSpy = vi.spyOn(api, "createSession").mockResolvedValue({
+      session_id: "session_test",
+      creator_role_id: "role_creator",
+      creator_token: "tok_creator",
+      creator_join_url: "http://localhost/play/session_test/tok_creator",
+      failed_invitees: [],
+    });
+
+    // First getSession (right after createSession) returns the no-plan
+    // snapshot; the second one (right after setupReply) returns the
+    // plan-bearing snapshot. Sequenced via mockImplementation so the
+    // counter increments per call.
+    let getSessionCalls = 0;
+    const getSpy = vi
+      .spyOn(api, "getSession")
+      .mockImplementation(async () => {
+        getSessionCalls += 1;
+        if (getSessionCalls === 1) return fakeSnapshotWithoutPlan();
+        return fakeSnapshotWithPlan();
+      });
+
+    const replySpy = vi.spyOn(api, "setupReply").mockResolvedValue({
+      ok: true,
+      plan_proposed: true,
+      diagnostics: [],
+    });
+    const finalizeSpy = vi.spyOn(api, "setupFinalize");
+
+    render(<Facilitator />);
+
+    // Walk the intro wizard: scenario textarea (Step 1) → next →
+    // next → ROLL SESSION. The creator label pre-fills to "CISO".
+    const scenarioBox = screen.getByPlaceholderText(
+      /What happened, when, at what severity/i,
+    );
+    fireEvent.change(scenarioBox, {
+      target: { value: "ransomware in a hospital" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /NEXT · ENVIRONMENT/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /NEXT · ROLES/i }));
+    // Submit via form.requestSubmit-equivalent: jsdom's button-click
+    // → form-submit chain has known races, so trigger the form's
+    // onSubmit directly by dispatching a submit event from the
+    // ROLL SESSION button's enclosing form.
+    const rollBtn = screen.getByRole("button", { name: /ROLL SESSION/i });
+    const form = rollBtn.closest("form");
+    if (!form) throw new Error("ROLL SESSION button not inside a form");
+    fireEvent.submit(form);
+
+    // Wait for the session to be created and the SetupView to mount
+    // (the LOOKS READY button is the marker — it only renders inside
+    // SetupView during the setup phase with no plan yet).
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    await screen.findByRole("button", {
+      name: /LOOKS READY — PROPOSE THE PLAN/i,
+    });
+
+    // Click LOOKS READY. The handler should call setupReply, then
+    // getSession (which returns a plan-bearing snapshot), then STOP.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /LOOKS READY — PROPOSE THE PLAN/i,
+      }),
+    );
+
+    // Wait for the plan to render in the PlanPanel header. The header
+    // starts with "● PROPOSED PLAN — <title>" and is the load-bearing
+    // signal that step 4 stayed mounted (vs. jumping to step 5).
+    await screen.findByText(/PROPOSED PLAN — Operation Test Echo/i);
+
+    // The actual regression assertions.
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(replySpy).toHaveBeenCalledWith(
+      "session_test",
+      "tok_creator",
+      expect.stringMatching(/draft the scenario plan now/i),
+    );
+    expect(finalizeSpy).not.toHaveBeenCalled();
+    expect(getSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/SetupLobbyView.cta.test.tsx
+++ b/frontend/src/__tests__/SetupLobbyView.cta.test.tsx
@@ -235,4 +235,51 @@ describe("SetupLobbyView — CTAs (lobby-as-launch-surface)", () => {
       screen.getByText(/share invite links and launch/i),
     ).toBeInTheDocument();
   });
+
+  // Per docs/PLAN.md line 215 ("the finalized plan is … surfaced to
+  // the creator … as a collapsible reference panel"): once the plan
+  // is finalized, the lobby has to expose the full content (not just
+  // the SidecarStat counts), otherwise an operator who needs to re-
+  // read an objective or inject during invite-link sharing has no
+  // way back. The wizard rail explicitly blocks step-5 → step-4
+  // back-nav (SetupWizard.tsx:259-262, "step 4 is AI work they can't
+  // rewind"), so the lobby is the reachable surface for re-read.
+  // Implemented as a <details> disclosure so it doesn't dominate the
+  // role-list view.
+  it("renders a collapsible plan recap on the role-list column when plan exists", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    const ic = role({ id: "r-ic", label: "IC" });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso, ic]}
+        plan={fakePlan()}
+        playerCount={2}
+        onLaunchSession={vi.fn()}
+      />,
+    );
+    const recap = screen.getByTestId("lobby-plan-recap");
+    expect(recap).toBeInTheDocument();
+    // Plan title shows in the summary so the operator can identify
+    // the right section without expanding it.
+    expect(recap.textContent).toMatch(/Test plan/i);
+    // Default-collapsed: PlanView's body content (e.g. "Key
+    // objectives" header) is in the DOM under the <details> but
+    // hidden until expanded. We assert it exists, which is what
+    // the operator needs (one click to reveal).
+    expect(recap.querySelector("h4")).toBeTruthy();
+  });
+
+  it("does NOT render the plan recap when plan is null", () => {
+    const ciso = role({ id: "r-ciso", label: "CISO", is_creator: true });
+    render(
+      <SetupLobbyView
+        {...COMMON_PROPS}
+        roles={[ciso]}
+        plan={null}
+        playerCount={1}
+      />,
+    );
+    expect(screen.queryByTestId("lobby-plan-recap")).toBeNull();
+  });
 });

--- a/frontend/src/components/setup/PlanView.tsx
+++ b/frontend/src/components/setup/PlanView.tsx
@@ -63,6 +63,29 @@ export function PlanView({
               ),
               strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
               em: ({ children }) => <em className="italic">{children}</em>,
+              // AI-emitted prose may contain markdown links. Mirror
+              // ``Transcript.tsx``'s safe-link pattern so the operator's
+              // session isn't lost to a same-tab navigation, and reject
+              // any non-http(s) scheme defensively (react-markdown v10
+              // sanitises ``javascript:`` already; the guard is
+              // defence-in-depth against a future dep bump regression).
+              a: ({ href, children }) => {
+                const safe =
+                  typeof href === "string" &&
+                  /^https?:\/\//i.test(href) ? href : undefined;
+                return safe ? (
+                  <a
+                    href={safe}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-signal underline hover:text-signal-bright"
+                  >
+                    {children}
+                  </a>
+                ) : (
+                  <span className="text-ink-300">{children}</span>
+                );
+              },
             }}
           >
             {plan.executive_summary}

--- a/frontend/src/components/setup/PlanView.tsx
+++ b/frontend/src/components/setup/PlanView.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { ScenarioPlan } from "../../api/client";
+
+/**
+ * Readable structured plan view with optional spoiler-hide.
+ *
+ * Default: title, executive_summary, key_objectives, guardrails,
+ * success_criteria, and out_of_scope are visible. ``narrative_arc`` and
+ * ``injects`` are spoiler-hidden behind a Reveal toggle whose state is
+ * persisted in localStorage so it carries across reloads. Per-session
+ * scoping (via ``sessionId``) makes each new exercise reset to the safe
+ * (hidden) default while still respecting the user's choice within the
+ * current session — without it, a creator screen-sharing with their
+ * team after a previous solo test would silently spoil the next plan.
+ */
+export function PlanView({
+  plan,
+  sessionId,
+}: {
+  plan: ScenarioPlan;
+  sessionId?: string;
+}) {
+  const storageKey = sessionId
+    ? `atf-plan-reveal:${sessionId}`
+    : "atf-plan-reveal";
+  const [reveal, setReveal] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(storageKey) === "1";
+    } catch {
+      return false;
+    }
+  });
+  function toggleReveal() {
+    setReveal((cur) => {
+      const next = !cur;
+      try {
+        window.localStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        /* localStorage may be disabled; preference is best-effort. */
+      }
+      return next;
+    });
+  }
+  return (
+    <article className="flex flex-col gap-4 text-sm text-ink-100">
+      <header>
+        <h3 className="text-lg font-semibold text-signal-100">{plan.title}</h3>
+      </header>
+
+      {plan.executive_summary ? (
+        <section className="flex flex-col gap-1">
+          <h4 className="text-xs uppercase tracking-widest text-ink-400">
+            Executive summary
+          </h4>
+          <ReactMarkdown
+            skipHtml
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ children }) => (
+                <p className="whitespace-pre-wrap leading-relaxed">{children}</p>
+              ),
+              strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+              em: ({ children }) => <em className="italic">{children}</em>,
+            }}
+          >
+            {plan.executive_summary}
+          </ReactMarkdown>
+        </section>
+      ) : null}
+
+      {plan.key_objectives.length > 0 ? (
+        <section className="flex flex-col gap-1">
+          <h4 className="text-xs uppercase tracking-widest text-ink-400">Key objectives</h4>
+          <ul className="ml-4 list-disc space-y-0.5">
+            {plan.key_objectives.map((o, i) => (
+              <li key={i}>{o}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.guardrails.length > 0 ? (
+        <section className="flex flex-col gap-1">
+          <h4 className="text-xs uppercase tracking-widest text-ink-400">Guardrails</h4>
+          <ul className="ml-4 list-disc space-y-0.5">
+            {plan.guardrails.map((o, i) => (
+              <li key={i}>{o}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.success_criteria.length > 0 ? (
+        <section className="flex flex-col gap-1">
+          <h4 className="text-xs uppercase tracking-widest text-ink-400">
+            Success criteria
+          </h4>
+          <ul className="ml-4 list-disc space-y-0.5">
+            {plan.success_criteria.map((o, i) => (
+              <li key={i}>{o}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.out_of_scope.length > 0 ? (
+        <section className="flex flex-col gap-1">
+          <h4 className="text-xs uppercase tracking-widest text-ink-400">Out of scope</h4>
+          <ul className="ml-4 list-disc space-y-0.5">
+            {plan.out_of_scope.map((o, i) => (
+              <li key={i}>{o}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.narrative_arc.length > 0 || plan.injects.length > 0 ? (
+        <section className="flex flex-col gap-2 rounded border border-warn bg-warn-bg p-2">
+          <header className="flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-xs uppercase tracking-widest text-warn">
+              Narrative arc &amp; injects
+            </h4>
+            <button
+              type="button"
+              onClick={toggleReveal}
+              className="rounded border border-warn px-2 py-0.5 text-xs font-semibold text-warn hover:bg-warn-bg"
+              aria-pressed={reveal}
+              title={
+                reveal
+                  ? "Switch to participant mode — hide upcoming injects so you can play fresh."
+                  : "Switch to facilitator mode — show upcoming injects so you can pace the meeting."
+              }
+            >
+              {reveal ? "Switch to participant mode" : "Switch to facilitator mode"}
+            </button>
+          </header>
+          {!reveal ? (
+            <p className="text-xs text-warn">
+              <span className="font-semibold">Participant mode.</span>{" "}
+              Hidden so you can play through fresh. {plan.narrative_arc.length}{" "}
+              beat{plan.narrative_arc.length === 1 ? "" : "s"}, {plan.injects.length}{" "}
+              inject{plan.injects.length === 1 ? "" : "s"} planned. Switch to
+              facilitator mode if you need to pace the meeting block.
+            </p>
+          ) : (
+            <>
+              {plan.narrative_arc.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                  <p className="text-[11px] uppercase tracking-widest text-warn">
+                    Narrative arc
+                  </p>
+                  <ol className="ml-4 list-decimal space-y-1">
+                    {plan.narrative_arc.map((b) => (
+                      <li key={b.beat}>
+                        <span className="font-semibold">{b.label}</span>
+                        {b.expected_actors.length > 0 ? (
+                          <span className="ml-1 text-ink-400">
+                            — {b.expected_actors.join(", ")}
+                          </span>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              ) : null}
+              {plan.injects.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                  <p className="text-[11px] uppercase tracking-widest text-warn">
+                    Injects
+                  </p>
+                  <ul className="ml-4 list-disc space-y-1">
+                    {plan.injects.map((inj, i) => (
+                      <li key={i}>
+                        <span className="text-ink-400">[{inj.trigger}]</span>{" "}
+                        <span className="text-ink-400">({inj.type})</span>{" "}
+                        {inj.summary}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </>
+          )}
+        </section>
+      ) : null}
+    </article>
+  );
+}

--- a/frontend/src/components/setup/SetupLobbyView.tsx
+++ b/frontend/src/components/setup/SetupLobbyView.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, ReactNode, useState } from "react";
 import { RoleView, ScenarioPlan, api } from "../../api/client";
 import { Eyebrow } from "../brand/Eyebrow";
+import { PlanView } from "./PlanView";
 
 /**
  * Step 5 (Invite players) panel for the setup wizard. Brand mock
@@ -193,6 +194,19 @@ export function SetupLobbyView(props: Props) {
           briefing — they don't pick a seat from a list. Add or remove
           seats here too; the change is live for everyone in the lobby.
         </p>
+        {props.plan ? (
+          <details
+            className="rounded-r-3 border border-signal-deep bg-signal-tint"
+            data-testid="lobby-plan-recap"
+          >
+            <summary className="mono cursor-pointer px-3 py-2 text-[11px] font-bold uppercase tracking-[0.16em] text-signal hover:bg-signal/10">
+              ● VIEW APPROVED PLAN — {props.plan.title}
+            </summary>
+            <div className="border-t border-signal-deep/50 px-4 py-3">
+              <PlanView plan={props.plan} sessionId={props.sessionId} />
+            </div>
+          </details>
+        ) : null}
         <h2
           className="sans"
           style={{

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1,6 +1,4 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import {
   api,
   CostSnapshot,
@@ -39,6 +37,7 @@ import { TurnStateRail } from "../components/brand/TurnStateRail";
 import { SetupWizard, type SetupRoleSlot } from "../components/setup/SetupWizard";
 import { SetupLobbyView } from "../components/setup/SetupLobbyView";
 import { SetupReviewView } from "../components/setup/SetupReviewView";
+import { PlanView } from "../components/setup/PlanView";
 import {
   buildImpersonateOptions,
   countUnjoinedImpersonateOptions,
@@ -940,13 +939,21 @@ export function Facilitator() {
   }
 
   /**
-   * "Looks ready" button: force progress toward a finalized plan.
-   * - If a draft plan already exists → finalize directly (skip the AI loop).
-   * - Otherwise → nudge the AI to propose, then auto-finalize if it does.
+   * "Looks ready — propose the plan" button: nudge the AI to draft a
+   * plan so the operator can review it in the PlanPanel. Does NOT
+   * finalize — the operator commits the plan by clicking APPROVE &
+   * START LOBBY in the PlanPanel, which routes through
+   * ``handleApprovePlan`` → ``api.setupFinalize``. Auto-finalizing
+   * here would skip the panel render and dump the operator on step 5
+   * (the lobby) without ever seeing the plan, with no rail back-
+   * navigation to recover.
    */
   async function handleLooksReady() {
     if (!state || !snapshot) return;
     setError(null);
+    // Tab-background race: ``hasPlan`` hides the button in render, but
+    // a plan that lands between paint and click leaves a stale button
+    // reachable for one frame. Route to APPROVE in that case.
     if (snapshot.plan) {
       await handleApprovePlan();
       return;
@@ -954,19 +961,14 @@ export function Facilitator() {
     setBusy(true);
     setDraftingPlan(true);
     setBusyMessage("Drafting the scenario plan… typically 10–30 seconds.");
+    console.info("[facilitator] looks_ready_clicked nudging plan");
     try {
       const reply = await api.setupReply(state.sessionId, state.token, NUDGE_PROPOSE);
       const snap = await api.getSession(state.sessionId, state.token);
       setSnapshot(snap);
       if (snap.plan) {
-        // Plan landed — drop the prominent drafting banner so the
-        // operator's eye moves to the plan card; the smaller BusyChip
-        // continues to communicate the fast finalize step.
+        console.info("[facilitator] plan_proposed awaiting_approve");
         setDraftingPlan(false);
-        setBusyMessage("Plan drafted — finalizing…");
-        await api.setupFinalize(state.sessionId, state.token);
-        const after = await api.getSession(state.sessionId, state.token);
-        setSnapshot(after);
       } else {
         // Disambiguate the failure mode using server-side diagnostics
         // so the operator knows whether to raise max_tokens, share more
@@ -990,7 +992,9 @@ export function Facilitator() {
         setError(message);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[facilitator] looks_ready_failed", msg, err);
+      setError(msg);
     } finally {
       setBusy(false);
       setBusyMessage(null);
@@ -1004,12 +1008,15 @@ export function Facilitator() {
     setError(null);
     setBusy(true);
     setBusyMessage("Finalizing plan and moving to the lobby…");
+    console.info("[facilitator] approve_plan_clicked finalizing");
     try {
       await api.setupFinalize(state.sessionId, state.token);
       const snap = await api.getSession(state.sessionId, state.token);
       setSnapshot(snap);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[facilitator] approve_plan_failed", msg, err);
+      setError(msg);
     } finally {
       setBusy(false);
       setBusyMessage(null);
@@ -2451,7 +2458,7 @@ export function SetupView({
             onClick={onLooksReady}
             disabled={busy}
             className="mono rounded-r-1 border border-signal-deep px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-signal hover:bg-signal-tint focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal disabled:opacity-50"
-            title="Asks the AI to draft a plan; auto-finalizes it if one comes back."
+            title="Asks the AI to draft a plan you can review and approve."
           >
             LOOKS READY — PROPOSE THE PLAN
           </button>
@@ -2609,202 +2616,6 @@ function PlanPanel({
         </button>
       </div>
     </section>
-  );
-}
-
-/**
- * Readable structured plan view with optional spoiler-hide.
- *
- * The plan was previously dumped as ``JSON.stringify`` which (a) clipped on
- * narrow viewports and (b) spoiled every upcoming inject for the creator.
- * The creator is the only one who sees the plan in any case (it's
- * creator-only by ``visible_messages`` filtering), but as the operator
- * they may still want to play "fresh" alongside the team.
- *
- * Default: title, executive_summary, key_objectives, guardrails,
- * success_criteria, and out_of_scope are visible. ``narrative_arc`` and
- * ``injects`` are spoiler-hidden behind a Reveal toggle whose state is
- * persisted in localStorage so it carries across reloads.
- */
-function PlanView({
-  plan,
-  sessionId,
-}: {
-  plan: ScenarioPlan;
-  /**
-   * Optional session id used to scope the spoiler-reveal preference.
-   * Without this the preference would persist across sessions and a
-   * creator who screen-shares with their team after a previous solo
-   * test would silently spoil the next plan. Per-session scoping makes
-   * each new exercise reset to the safe (hidden) default while still
-   * respecting the user's choice within the current session.
-   */
-  sessionId?: string;
-}) {
-  const storageKey = sessionId
-    ? `atf-plan-reveal:${sessionId}`
-    : "atf-plan-reveal";
-  const [reveal, setReveal] = useState<boolean>(() => {
-    try {
-      return window.localStorage.getItem(storageKey) === "1";
-    } catch {
-      return false;
-    }
-  });
-  function toggleReveal() {
-    setReveal((cur) => {
-      const next = !cur;
-      try {
-        window.localStorage.setItem(storageKey, next ? "1" : "0");
-      } catch {
-        /* localStorage may be disabled; preference is best-effort. */
-      }
-      return next;
-    });
-  }
-  return (
-    <article className="flex flex-col gap-4 text-sm text-ink-100">
-      <header>
-        <h3 className="text-lg font-semibold text-signal-100">{plan.title}</h3>
-      </header>
-
-      {plan.executive_summary ? (
-        <section className="flex flex-col gap-1">
-          <h4 className="text-xs uppercase tracking-widest text-ink-400">
-            Executive summary
-          </h4>
-          <ReactMarkdown
-            skipHtml
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => (
-                <p className="whitespace-pre-wrap leading-relaxed">{children}</p>
-              ),
-              strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-              em: ({ children }) => <em className="italic">{children}</em>,
-            }}
-          >
-            {plan.executive_summary}
-          </ReactMarkdown>
-        </section>
-      ) : null}
-
-      {plan.key_objectives.length > 0 ? (
-        <section className="flex flex-col gap-1">
-          <h4 className="text-xs uppercase tracking-widest text-ink-400">Key objectives</h4>
-          <ul className="ml-4 list-disc space-y-0.5">
-            {plan.key_objectives.map((o, i) => (
-              <li key={i}>{o}</li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
-
-      {plan.guardrails.length > 0 ? (
-        <section className="flex flex-col gap-1">
-          <h4 className="text-xs uppercase tracking-widest text-ink-400">Guardrails</h4>
-          <ul className="ml-4 list-disc space-y-0.5">
-            {plan.guardrails.map((o, i) => (
-              <li key={i}>{o}</li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
-
-      {plan.success_criteria.length > 0 ? (
-        <section className="flex flex-col gap-1">
-          <h4 className="text-xs uppercase tracking-widest text-ink-400">
-            Success criteria
-          </h4>
-          <ul className="ml-4 list-disc space-y-0.5">
-            {plan.success_criteria.map((o, i) => (
-              <li key={i}>{o}</li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
-
-      {plan.out_of_scope.length > 0 ? (
-        <section className="flex flex-col gap-1">
-          <h4 className="text-xs uppercase tracking-widest text-ink-400">Out of scope</h4>
-          <ul className="ml-4 list-disc space-y-0.5">
-            {plan.out_of_scope.map((o, i) => (
-              <li key={i}>{o}</li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
-
-      {plan.narrative_arc.length > 0 || plan.injects.length > 0 ? (
-        <section className="flex flex-col gap-2 rounded border border-warn bg-warn-bg p-2">
-          <header className="flex flex-wrap items-center justify-between gap-2">
-            <h4 className="text-xs uppercase tracking-widest text-warn">
-              Narrative arc &amp; injects
-            </h4>
-            <button
-              type="button"
-              onClick={toggleReveal}
-              className="rounded border border-warn px-2 py-0.5 text-xs font-semibold text-warn hover:bg-warn-bg"
-              aria-pressed={reveal}
-              title={
-                reveal
-                  ? "Switch to participant mode — hide upcoming injects so you can play fresh."
-                  : "Switch to facilitator mode — show upcoming injects so you can pace the meeting."
-              }
-            >
-              {reveal ? "Switch to participant mode" : "Switch to facilitator mode"}
-            </button>
-          </header>
-          {!reveal ? (
-            <p className="text-xs text-warn">
-              <span className="font-semibold">Participant mode.</span>{" "}
-              Hidden so you can play through fresh. {plan.narrative_arc.length}{" "}
-              beat{plan.narrative_arc.length === 1 ? "" : "s"}, {plan.injects.length}{" "}
-              inject{plan.injects.length === 1 ? "" : "s"} planned. Switch to
-              facilitator mode if you need to pace the meeting block.
-            </p>
-          ) : (
-            <>
-              {plan.narrative_arc.length > 0 ? (
-                <div className="flex flex-col gap-1">
-                  <p className="text-[11px] uppercase tracking-widest text-warn">
-                    Narrative arc
-                  </p>
-                  <ol className="ml-4 list-decimal space-y-1">
-                    {plan.narrative_arc.map((b) => (
-                      <li key={b.beat}>
-                        <span className="font-semibold">{b.label}</span>
-                        {b.expected_actors.length > 0 ? (
-                          <span className="ml-1 text-ink-400">
-                            — {b.expected_actors.join(", ")}
-                          </span>
-                        ) : null}
-                      </li>
-                    ))}
-                  </ol>
-                </div>
-              ) : null}
-              {plan.injects.length > 0 ? (
-                <div className="flex flex-col gap-1">
-                  <p className="text-[11px] uppercase tracking-widest text-warn">
-                    Injects
-                  </p>
-                  <ul className="ml-4 list-disc space-y-1">
-                    {plan.injects.map((inj, i) => (
-                      <li key={i}>
-                        <span className="text-ink-400">[{inj.trigger}]</span>{" "}
-                        <span className="text-ink-400">({inj.type})</span>{" "}
-                        {inj.summary}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
-            </>
-          )}
-        </section>
-      ) : null}
-    </article>
   );
 }
 


### PR DESCRIPTION
## Summary

User report: *"When you click 'create plan' in the AI question mode it sometimes skips to the invite players and you can't see the plan. And then once there you can't click back to see the plan."*

`handleLooksReady()` in `frontend/src/pages/Facilitator.tsx` was calling `api.setupReply(NUDGE_PROPOSE)` and then **immediately** calling `api.setupFinalize()` the moment the AI returned a plan. That transitioned the session SETUP → READY before the PlanPanel could render, the wizard jumped from step 4 to step 5 (Invite players) without the plan being shown, and the wizard rail explicitly blocks back-nav from step 5 to step 4. Net effect: the operator never saw the plan they were "approving," and could not retrieve it from the lobby (sidecar showed only stats, not full content).

The button label was always `LOOKS READY — PROPOSE THE PLAN` (proposal-only), the helper text always said *"Read it through, then click 'Approve & start lobby' on the proposed-plan panel to commit"*, and the LLM prompt at `backend/app/llm/prompts.py:478` always said *"Iterate freely. **When they approve**, call `finalize_setup`"*. The frontend was the only piece racing ahead of the documented flow.

## Changes

- **`Facilitator.tsx::handleLooksReady`** — stops at the draft. Finalization only runs from the explicit APPROVE & START LOBBY click in PlanPanel (`handleApprovePlan` → `api.setupFinalize`).
- **`SetupLobbyView`** — adds a collapsible plan recap (`<details>` "● VIEW APPROVED PLAN — <title>") on the role-list column. Per `docs/PLAN.md` line 215, the finalized plan must remain a creator-visible reference panel.
- **`PlanView` extracted** to `frontend/src/components/setup/PlanView.tsx` so both `PlanPanel` (in SetupView) and the lobby recap consume the same component.
- **Boundary logging** on every state-shifting click + `setError` site: `console.info` on LOOKS READY click, plan-proposed success, and APPROVE click; paired `console.warn` on the two `setError` sites in `handleLooksReady` / `handleApprovePlan` (CLAUDE.md Browser-logging rule).
- **Tooltip** on the LOOKS READY button: `"…auto-finalizes it if one comes back."` → `"Asks the AI to draft a plan you can review and approve."`

## Test plan

- [x] `frontend/src/__tests__/Facilitator.looksReady.test.tsx` (new) — drives the Facilitator through ROLL SESSION, clicks LOOKS READY, asserts `api.setupReply` IS called and `api.setupFinalize` is NOT called, plan title renders. WS module mocked.
- [x] `frontend/src/__tests__/SetupLobbyView.cta.test.tsx` — adds two tests for the lobby plan recap (renders when plan exists; absent when plan is null).
- [x] `npm test -- --run` — 462/462 pass.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [ ] Manual smoke: dev server, walk through ROLL SESSION → AI question → LOOKS READY → verify PlanPanel renders with full plan + APPROVE button → click APPROVE → land on lobby → expand "VIEW APPROVED PLAN" → verify full plan content visible.

## Sub-agent reviews

All 6 sub-agent reviews returned. Triage:

| Agent | Severity | Finding | Status |
|---|---|---|---|
| Security | — | Clean (auth model unchanged, fewer requests, no log/secret/CSP changes) | — |
| Prompt | — | Clean (frontend-only diff; `backend/app/llm/prompts.py:478` already separates propose/approve) | — |
| UI/UX | LOW | Missing `console.warn` companions on `setError` | Fixed in this commit |
| UI/UX | MEDIUM | Tablet plan-visibility scroll cost | Deferred (polish) |
| UI/UX | MEDIUM | Drafting-banner dismount transition | Deferred (polish) |
| QA | HIGH | Missing handler-level test that `setupFinalize` is not auto-called | Fixed (`Facilitator.looksReady.test.tsx`) |
| QA | LOW | Missing `console.info` boundary log | Fixed |
| Product | HIGH | Lobby (step 5) lacks full plan view; violates `docs/PLAN.md` line 215 | Fixed (collapsible plan recap in SetupLobbyView) |
| User-Persona | HIGH-H1 | Same as Product HIGH (re-readable plan) | Fixed |
| User-Persona | HIGH-H2 | "REQUEST CHANGES" affordance in PlanPanel | Deferred — helper text + reply form already cover this; adding a button is debatable scope |
| User-Persona | MEDIUM | Button label "PROPOSE" reads as "ship" to some operators | Deferred (copy polish) |

## Scenario replay rule

Frontend-only orchestration change. No new `SessionState` transition, `MessageKind`, tool name, or player-input gate. Existing scenarios already cover SETUP → READY through `api.setupFinalize` via the explicit approve path, which is now the only path. No scenario JSON edit required.

https://claude.ai/code/session_01AzfXfppjYXQE3ppmvpoykM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzfXfppjYXQE3ppmvpoykM)_