### PR TITLE
frontend: pin RightSidebar tablist so participants can switch tabs

### DIFF
--- a/frontend/src/__tests__/RightSidebar.tabs.test.tsx
+++ b/frontend/src/__tests__/RightSidebar.tabs.test.tsx
@@ -97,6 +97,23 @@ describe("RightSidebar — 3-tab system (chat-declutter polish)", () => {
     expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("desktop tablist is sticky-pinned to the top of the page-level scroll", () => {
+    // Regression test for the participant "stuck on Action items"
+    // bug — the page-level <aside> on Play.tsx / Facilitator.tsx
+    // is ``lg:overflow-y-auto``; without ``sticky top-0`` on the
+    // tablist a tall HUD + expanded notepad scrolls the tabs off
+    // the top of the viewport and the user can't reach the other
+    // tabs. The mobile (``mrail``) tablist lives inside a
+    // <details> block and doesn't need this — collapsing the
+    // <details> hides the entire surface.
+    render(<RightSidebar messages={[]} roles={ROLES} workstreams={WORKSTREAMS} />);
+    const desktopTablist = document.querySelector(
+      "[role='tablist'][aria-label='Right sidebar']",
+    );
+    expect(desktopTablist?.className).toContain("sticky");
+    expect(desktopTablist?.className).toContain("top-0");
+  });
+
   it("Action items tab surfaces address_role asks with status", () => {
     const messages: MessageView[] = [
       msg({

--- a/frontend/src/__tests__/RightSidebar.tabs.test.tsx
+++ b/frontend/src/__tests__/RightSidebar.tabs.test.tsx
@@ -107,11 +107,8 @@ describe("RightSidebar — 3-tab system (chat-declutter polish)", () => {
     // <details> block and doesn't need this — collapsing the
     // <details> hides the entire surface.
     render(<RightSidebar messages={[]} roles={ROLES} workstreams={WORKSTREAMS} />);
-    const desktopTablist = document.querySelector(
-      "[role='tablist'][aria-label='Right sidebar']",
-    );
-    expect(desktopTablist?.className).toContain("sticky");
-    expect(desktopTablist?.className).toContain("top-0");
+    const desktopTablist = screen.getByRole("tablist", { name: "Right sidebar" });
+    expect(desktopTablist).toHaveClass("sticky", "top-0");
   });
 
   it("Action items tab surfaces address_role asks with status", () => {

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -153,11 +153,24 @@ export function RightSidebar({
       */}
       <aside className="hidden flex-col gap-4 lg:flex lg:min-h-0 lg:flex-1 lg:pr-1">
         <section className="flex min-h-0 flex-1 flex-col rounded-r-3 border border-ink-600 bg-ink-850">
+          {/*
+            ``sticky top-0`` keeps the tablist visible when the
+            page-level <aside> scrolls (a tall HUD + expanded notepad
+            can push the section's top above the visible viewport).
+            Pre-fix, participants reported being "stuck on Action
+            items" because the tabs scrolled out of view with the
+            outer aside and they couldn't reach Artifacts / Timeline.
+            Safe to combine with the tabpanel's internal
+            ``overflow-y-auto`` below — the H2 regression that caused
+            this to be reverted (PR #158 follow-up) only happened when
+            the tabpanel had no internal scroll, which let a tall
+            body push the notepad off screen.
+          */}
           <div
             role="tablist"
             aria-label="Right sidebar"
             onKeyDown={(e) => onTablistKey(e, "rail")}
-            className="flex rounded-t-3 border-b border-ink-600 bg-ink-850 text-[11px]"
+            className="sticky top-0 z-10 flex rounded-t-3 border-b border-ink-600 bg-ink-850 text-[11px]"
           >
             {TABS.map((tab) => (
               <RailTabButton


### PR DESCRIPTION
## Summary

- Participants reported being "stuck on Action items" — they could see the Action items panel content but couldn't click over to **Artifacts** / **Timeline**.
- Re-pinned the right-rail tablist with `sticky top-0 z-10` so it stays visible when the page-level `<aside>` scrolls.
- Added a regression test so a future revert lands red in CI.

## Root cause

The page-level rail `<aside>` on `Play.tsx` and `Facilitator.tsx` is `lg:overflow-y-auto`. When the rail content (collapsible HUD + tab section + expanded `SharedNotepad`) exceeds the viewport, the outer aside scrolls. The tablist sat inside the section without sticky positioning, so it scrolled away with the rest of the rail. The user was "stuck on Action items" because the buttons to switch tabs were no longer in the visible scroll area — the only thing they could see was the *content* of whichever tab was active in localStorage.

## Why this is safe now

`sticky top-0` was on the tablist before; it was reverted in `985afc6` as the H2 regression — back then the tabpanel had no internal scroll, so a tall tab body grew the section and pushed the notepad below the viewport. The current layout (`flex min-h-0 flex-1 flex-col overflow-y-auto` on the tabpanel) bounds the tab body to internal scroll, so re-adding sticky doesn't re-introduce that regression.

The mobile (`mrail`) tablist lives inside a `<details>` block — collapsing hides the entire surface, so it doesn't need sticky.

## Test plan

- [x] `npm test -- --run RightSidebar` (6/6 passing, including the new regression test)
- [x] `npm test -- --run` (460/460 passing — no other behavior changes)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Manual smoke as a participant: scroll the rail, confirm tabs stay pinned at top of the visible scroll area, confirm clicks on **Artifacts** and **Timeline** switch panels as expected.

https://claude.ai/code/session_01RZLBp1HjKDEDkBorzCP7ck

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZLBp1HjKDEDkBorzCP7ck)_