### PR TITLE
frontend: clarify AAR grading with per-role breakdown + grade legend

### DIFF
--- a/frontend/src/__tests__/AarReport.test.tsx
+++ b/frontend/src/__tests__/AarReport.test.tsx
@@ -437,6 +437,91 @@ describe("AarReportView", () => {
     expect(ariaLabel).toMatch(/toggle breakdown/i);
   });
 
+  it("a 0 sub-score (no-score sentinel) does not drag the headline letter — counted only as '—' in the cell, skipped in the average", async () => {
+    // Regression: PR #204 review caught that `(0 + 5 + 5) / 3 = 3.33`
+    // would round to a "C" headline letter while the expanded panel
+    // already renders "—" for the 0 sub-score (per
+    // `gradeForScore`'s rubric, 0 means "no score", not F-equivalent).
+    // The fix filters 0 / non-finite values in `avg()` and reuses
+    // it for the per-role overall — so 0/5/5 grades as A on the
+    // surviving sub-scores.
+    _mockFetch(
+      200,
+      _report([
+        {
+          role_id: "role-partial",
+          decision_quality: 0, // not scored
+          communication: 5,
+          speed: 5,
+          decisions: 2,
+          rationale: "Strong on comms and speed; decision data missing.",
+          label: "PARTIAL",
+          display_name: "Riley",
+        },
+      ]),
+    );
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("PARTIAL")).toBeInTheDocument(),
+    );
+    const toggle = screen.getByText("PARTIAL").closest("button")!;
+    const row = within(toggle.closest("li")!);
+    // Headline grade: avg of {5, 5} = 5 → "A". Pre-fix: avg of
+    // {0, 5, 5} = 3.33 → "C". The aria-label echoes the same
+    // headline letter so we can read it without expanding.
+    expect(toggle.getAttribute("aria-label")).toMatch(/overall A/);
+    fireEvent.click(toggle);
+    // Expanded: DECISION cell renders "—" (the 0 sub-score), the
+    // other two render their numeric values. Use a regex over the
+    // cell's mono span so a stray "5" elsewhere in the panel
+    // doesn't satisfy the assertion.
+    expect(row.getByText("DECISION")).toBeInTheDocument();
+    expect(row.getByText("COMMS")).toBeInTheDocument();
+    expect(row.getByText("SPEED")).toBeInTheDocument();
+    expect(row.getByText("—")).toBeInTheDocument();
+  });
+
+  it("a role with all sub-scores at 0 renders '—' as the headline grade (no valid data)", async () => {
+    _mockFetch(
+      200,
+      _report([
+        {
+          role_id: "role-empty",
+          decision_quality: 0,
+          communication: 0,
+          speed: 0,
+          decisions: 0,
+          rationale: undefined,
+          label: "ABSENT",
+          display_name: null,
+        },
+      ]),
+    );
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("ABSENT")).toBeInTheDocument(),
+    );
+    // The headline-letter span lives in the toggle button. With
+    // all sub-scores at 0 the avg() filter leaves nothing; overall
+    // falls back to 0; gradeForScore renders "—" in neutral ink.
+    const toggle = screen.getByText("ABSENT").closest("button")!;
+    expect(toggle.getAttribute("aria-label")).toMatch(/overall —/);
+  });
+
   it("expanded row without a rationale falls back to a placeholder line", async () => {
     _mockFetch(
       200,

--- a/frontend/src/__tests__/AarReport.test.tsx
+++ b/frontend/src/__tests__/AarReport.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 
 import { AarReportView } from "../components/AarReport";
 
@@ -269,6 +275,198 @@ describe("AarReportView", () => {
     const pdfBtn = screen.getByText(/PDF REPORT/i).closest("button")!;
     expect(pdfBtn).toBeDisabled();
     expect(pdfBtn.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("does not render the OVERALL · N / 5 block (the three top score cards already carry the team grade)", async () => {
+    _mockFetch(200, _report());
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("CISO")).toBeInTheDocument(),
+    );
+    // The legacy "OVERALL · 4 / 5" eyebrow and the overall_rationale
+    // prose used to render here. Both are gone; the three score cards
+    // (CONTAINMENT / COMMS / DECISION SPEED) at the top already convey
+    // the team's grade in the same letter scheme as the per-role rows.
+    expect(screen.queryByText(/OVERALL\s*·\s*\d+\s*\/\s*5/)).toBeNull();
+    expect(
+      screen.queryByText(/Solid exercise with one notable gap\./),
+    ).toBeNull();
+  });
+
+  it("per-role rows start collapsed and expand on click to show sub-scores + rationale", async () => {
+    _mockFetch(200, _report());
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("CISO")).toBeInTheDocument());
+
+    // Sub-score labels and rationale are hidden until the row is
+    // toggled open. "DECISION" is unique to the per-role panel (the
+    // top card is "DECISION SPEED"); "COMMS" + "SPEED" appear in
+    // both the team-aggregate cards and the per-role panel, so the
+    // expansion-driven assertions below scope queries to the row.
+    expect(screen.queryByText("DECISION")).toBeNull();
+    expect(
+      screen.queryByText(/Decisive on isolation, kept comms cadence\./),
+    ).toBeNull();
+
+    // The row is a real <button type="button"> (not a div with role).
+    // Lock the element so a future refactor to a non-button can't
+    // silently regress keyboard activation.
+    const cisoToggle = screen.getByText("CISO").closest("button")!;
+    const cisoRow = within(cisoToggle.closest("li")!);
+    expect(cisoToggle.tagName).toBe("BUTTON");
+    expect(cisoToggle.getAttribute("type")).toBe("button");
+    expect(cisoToggle.getAttribute("aria-expanded")).toBe("false");
+
+    // aria-controls must reference a real DOM id once the panel
+    // renders (i.e. on expansion). Pre-expand we just verify the
+    // attribute is present and non-empty; the linkage is checked
+    // after click.
+    const controlsId = cisoToggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+
+    // Chevron is the visual analog of aria-expanded — locked so a
+    // regression to a static glyph or an inverted toggle is caught.
+    expect(within(cisoToggle).getByText("▶")).toBeInTheDocument();
+
+    fireEvent.click(cisoToggle);
+
+    // After click: aria-expanded flips, chevron flips, the three
+    // sub-score cells appear with their numeric values, the model's
+    // rationale renders inline (not as a tooltip), and aria-controls
+    // resolves to the panel that just appeared. Scope to the row's
+    // <li> so "COMMS" / "SPEED" don't ambiguously match the top
+    // score cards.
+    expect(cisoToggle.getAttribute("aria-expanded")).toBe("true");
+    expect(within(cisoToggle).getByText("▼")).toBeInTheDocument();
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+    expect(cisoRow.getByText("DECISION")).toBeInTheDocument();
+    expect(cisoRow.getByText("COMMS")).toBeInTheDocument();
+    expect(cisoRow.getByText("SPEED")).toBeInTheDocument();
+    expect(
+      cisoRow.getByText(/Decisive on isolation, kept comms cadence\./),
+    ).toBeInTheDocument();
+
+    // Click again → collapses back.
+    fireEvent.click(cisoToggle);
+    expect(cisoToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(within(cisoToggle).getByText("▶")).toBeInTheDocument();
+    expect(cisoRow.queryByText("DECISION")).toBeNull();
+  });
+
+  it("multiple per-role rows can be expanded simultaneously (side-by-side comparison)", async () => {
+    _mockFetch(200, _report());
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("CISO")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("CISO").closest("button")!);
+    fireEvent.click(screen.getByText("SOC").closest("button")!);
+
+    // Both rationales should be visible — neither click closed the
+    // other panel.
+    expect(
+      screen.getByText(/Decisive on isolation, kept comms cadence\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Provided telemetry on request\./),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the discoverability + grade-legend caption above the per-role list", async () => {
+    _mockFetch(200, _report());
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("CISO")).toBeInTheDocument(),
+    );
+    // The legend tells a first-time creator (a) the rows are
+    // tappable and (b) what each letter actually means. Without it
+    // the bare "B" carries no anchoring.
+    expect(
+      screen.getByText(
+        /Tap a row for the breakdown.*A exemplary.*B above bar.*C at bar.*D below bar.*F critical/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("each per-role toggle button has an accessible label describing the action", async () => {
+    _mockFetch(200, _report());
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("CISO")).toBeInTheDocument());
+    // CISO row: label="CISO", display_name="Alex", decisions=3,
+    // computed grade from (5+4+4)/3≈4.33→B (rounds to 4 → "B").
+    const cisoBtn = screen.getByText("CISO").closest("button")!;
+    const ariaLabel = cisoBtn.getAttribute("aria-label") ?? "";
+    expect(ariaLabel).toMatch(/CISO/);
+    expect(ariaLabel).toMatch(/Alex/);
+    expect(ariaLabel).toMatch(/B/);
+    expect(ariaLabel).toMatch(/3 decisions/);
+    expect(ariaLabel).toMatch(/toggle breakdown/i);
+  });
+
+  it("expanded row without a rationale falls back to a placeholder line", async () => {
+    _mockFetch(
+      200,
+      _report([
+        {
+          role_id: "role-x",
+          decision_quality: 2,
+          communication: 2,
+          speed: 2,
+          decisions: 1,
+          rationale: undefined,
+          label: "ANALYST",
+          display_name: "Casey",
+        },
+      ]),
+    );
+    render(
+      <AarReportView
+        sessionId="s1"
+        token="tok"
+        downloadMdHref="/x.md"
+        downloadJsonHref="/x.json"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("ANALYST")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText("ANALYST").closest("button")!);
+    expect(screen.getByText(/no rationale recorded/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/AarReport.tsx
+++ b/frontend/src/components/AarReport.tsx
@@ -313,17 +313,6 @@ function LeftColumn({ report }: { report: AarReport }) {
           ) : null}
         </section>
       ) : null}
-
-      {report.overall_rationale ? (
-        <section className="rounded-r-2 border border-signal-deep bg-signal-tint p-4">
-          <p className="mono mb-2 text-[10px] font-bold uppercase tracking-[0.20em] text-signal">
-            OVERALL · {report.overall_score} / 5
-          </p>
-          <p className="whitespace-pre-wrap text-sm leading-relaxed text-ink-100">
-            {report.overall_rationale}
-          </p>
-        </section>
-      ) : null}
     </section>
   );
 }
@@ -364,11 +353,36 @@ function RightColumn({
 }) {
   const { meta, per_role_scores } = report;
   const labelById = new Map(meta.roles.map((r) => [r.id, r] as const));
+  // Per-role expansion state. Set, not boolean, so multiple rows can
+  // be open at once for side-by-side comparison ("why did CISO get B
+  // when SOC also got B?"). Resets to empty whenever the dialog
+  // re-mounts; the report is meant to be read in one sitting.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (roleId: string): void => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(roleId)) next.delete(roleId);
+      else next.add(roleId);
+      return next;
+    });
+  };
+
   return (
     <section className="flex max-h-full flex-col gap-4 overflow-y-auto rounded-r-3 border border-ink-600 bg-ink-850 p-4">
-      <p className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-ink-300">
-        PER-ROLE SCORING
-      </p>
+      <div className="flex flex-col gap-1">
+        <p className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-ink-300">
+          PER-ROLE SCORING
+        </p>
+        {/* Discoverability + grade-legend caption. The bare letter
+            grade carries no anchoring without a key (a CISO seeing
+            "B" can't tell if it's "fine" or "we need a postmortem"),
+            and the chevron alone reads as ornament — calling out the
+            tap affordance turns a static-looking row into a clearly
+            interactive one. */}
+        <p className="mono text-[9px] uppercase tracking-[0.14em] text-ink-400">
+          Tap a row for the breakdown · A exemplary · B above bar · C at bar · D below bar · F critical
+        </p>
+      </div>
       <ul className="flex flex-col gap-2">
         {per_role_scores.map((s) => {
           // Prefer the backend-resolved label/display_name (which
@@ -385,31 +399,76 @@ function RightColumn({
           const tone = toneForScore(overall);
           const tc = toneClass(tone);
           const gradeColor = isEmpty ? "text-ink-500" : tc.text;
+          const isOpen = expanded.has(s.role_id);
+          const detailId = `aar-role-detail-${s.role_id}`;
           return (
             <li
               key={`${s.role_id}-${label}`}
-              className="flex items-center gap-3 rounded-r-1 border border-ink-600 bg-ink-800 px-3 py-2"
-              title={s.rationale ?? undefined}
+              className="rounded-r-1 border border-ink-600 bg-ink-800"
             >
-              <span
-                className="mono shrink-0 truncate text-[11px] font-bold uppercase tracking-[0.10em] text-ink-100"
-                style={{ minWidth: 56, maxWidth: 96 }}
+              <button
+                type="button"
+                onClick={() => toggle(s.role_id)}
+                aria-expanded={isOpen}
+                aria-controls={detailId}
+                aria-label={`${label}${
+                  displayName ? `, ${displayName}` : ""
+                }: overall ${grade}, ${s.decisions} ${
+                  s.decisions === 1 ? "decision" : "decisions"
+                }. Toggle breakdown.`}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-ink-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-signal"
               >
-                {label}
-              </span>
-              <span className="sans flex-1 truncate text-[13px] text-ink-200">
-                {displayName ?? (
-                  <span className="text-ink-500">— not joined —</span>
-                )}
-              </span>
-              <span className="mono text-[10px] uppercase tracking-[0.10em] text-ink-400 tabular-nums">
-                {s.decisions} {s.decisions === 1 ? "DECISION" : "DECISIONS"}
-              </span>
-              <span
-                className={`mono w-7 text-right text-[16px] font-bold tabular-nums ${gradeColor}`}
-              >
-                {grade}
-              </span>
+                <span
+                  aria-hidden="true"
+                  className="mono shrink-0 text-[9px] leading-none text-ink-200"
+                  style={{ width: 8 }}
+                >
+                  {isOpen ? "▼" : "▶"}
+                </span>
+                <span
+                  className="mono shrink-0 truncate text-[11px] font-bold uppercase tracking-[0.10em] text-ink-100"
+                  style={{ minWidth: 56, maxWidth: 96 }}
+                >
+                  {label}
+                </span>
+                <span className="sans flex-1 truncate text-[13px] text-ink-200">
+                  {displayName ?? (
+                    <span className="text-ink-500">— not joined —</span>
+                  )}
+                </span>
+                <span className="mono text-[10px] uppercase tracking-[0.10em] text-ink-400 tabular-nums">
+                  {s.decisions} {s.decisions === 1 ? "DECISION" : "DECISIONS"}
+                </span>
+                <span
+                  className={`mono w-7 text-right text-[16px] font-bold tabular-nums ${gradeColor}`}
+                >
+                  {grade}
+                </span>
+              </button>
+              {isOpen ? (
+                <div
+                  id={detailId}
+                  className="flex flex-col gap-2 border-t border-ink-700 bg-ink-850 px-3 py-3"
+                >
+                  <div className="grid grid-cols-3 gap-2">
+                    <SubScoreCell
+                      label="DECISION"
+                      value={s.decision_quality}
+                    />
+                    <SubScoreCell label="COMMS" value={s.communication} />
+                    <SubScoreCell label="SPEED" value={s.speed} />
+                  </div>
+                  {s.rationale ? (
+                    <p className="text-[12px] leading-relaxed text-ink-200">
+                      {s.rationale}
+                    </p>
+                  ) : (
+                    <p className="mono text-[10px] uppercase tracking-[0.16em] text-ink-500">
+                      No rationale recorded.
+                    </p>
+                  )}
+                </div>
+              ) : null}
             </li>
           );
         })}
@@ -446,6 +505,36 @@ function RightColumn({
           no need to repeat it inline; we just take the spare height
           so the column doesn't visually trail off. */}
     </section>
+  );
+}
+
+/**
+ * One labeled sub-score (DECISION / COMMS / SPEED) shown inside the
+ * expanded per-role panel. Surfaces the raw 0-5 rubric value so two
+ * roles that both round to "B" overall still tell a different story
+ * (e.g. 5/5/3 reads very differently from 4/4/4). Uses the same
+ * tone bands as the headline letter — color carries severity, the
+ * number carries precision.
+ */
+function SubScoreCell({ label, value }: { label: string; value: number }) {
+  const isEmpty = !Number.isFinite(value) || value <= 0;
+  const tone = toneForScore(value);
+  const tc = toneClass(tone);
+  const valueColor = isEmpty ? "text-ink-500" : tc.text;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="mono text-[9px] font-bold uppercase tracking-[0.16em] text-ink-400">
+        {label}
+      </span>
+      <span
+        className={`mono text-[14px] font-bold tabular-nums ${valueColor}`}
+      >
+        {isEmpty ? "—" : value}
+        {isEmpty ? null : (
+          <span className="text-ink-500"> / 5</span>
+        )}
+      </span>
+    </div>
   );
 }
 

--- a/frontend/src/components/AarReport.tsx
+++ b/frontend/src/components/AarReport.tsx
@@ -241,9 +241,26 @@ function formatGenerated(iso: string | null): string {
   return `${yyyy}-${mm}-${dd} ${hh}:${mi} UTC`;
 }
 
+/**
+ * Mean of ``nums``, treating ``0`` and non-finite values as
+ * "no score" rather than as F-equivalents. Per ``gradeForScore``
+ * the rubric is 1–5; 0 is the documented "no-score" sentinel
+ * (a sub-score the model didn't emit, or one the backend
+ * extractor coerced down to 0). Including those zeros in a
+ * straight mean drags an otherwise solid role into the wrong
+ * grade band — e.g. ``[0, 5, 5]`` would average to 3.33 → "C"
+ * while the expanded breakdown row already renders "—" for the
+ * missing cell. Filtering them out keeps the headline letter
+ * honest and consistent with the cell-level rendering.
+ *
+ * Returns 0 when no scores survive the filter — call sites pass
+ * that through to ``gradeForScore`` which renders "—" + neutral
+ * ink. Caught by Copilot review on PR #204.
+ */
 function avg(nums: number[]): number {
-  if (nums.length === 0) return 0;
-  return nums.reduce((a, b) => a + b, 0) / nums.length;
+  const valid = nums.filter((n) => Number.isFinite(n) && n > 0);
+  if (valid.length === 0) return 0;
+  return valid.reduce((a, b) => a + b, 0) / valid.length;
 }
 
 function LeftColumn({ report }: { report: AarReport }) {
@@ -357,7 +374,7 @@ function RightColumn({
   // be open at once for side-by-side comparison ("why did CISO get B
   // when SOC also got B?"). Resets to empty whenever the dialog
   // re-mounts; the report is meant to be read in one sitting.
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const toggle = (roleId: string): void => {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -393,7 +410,16 @@ function RightColumn({
           const label = s.label ?? fromMeta?.label ?? "—";
           const displayName =
             (s.display_name ?? fromMeta?.display_name) ?? null;
-          const overall = (s.decision_quality + s.communication + s.speed) / 3;
+          // ``avg`` skips 0 / non-finite sub-scores — see its
+          // docstring. A role with one missing sub-score is graded
+          // on the others, not penalised by the zero. The expanded
+          // panel still renders "—" for the missing cell so the
+          // user can see what was vs. wasn't scored.
+          const overall = avg([
+            s.decision_quality,
+            s.communication,
+            s.speed,
+          ]);
           const grade = gradeForScore(overall);
           const isEmpty = grade === "—";
           const tone = toneForScore(overall);


### PR DESCRIPTION
## Summary

A creator reading the AAR popup hit two confusions:

1. **Mixed scoring scales.** The top score cards (CONTAINMENT / COMMS / DECISION SPEED) and the per-role rows showed letter grades A–F, but a trailing `OVERALL · 4 / 5` block used the raw 0–5 rubric value. The two coexisting scales read as different rating systems.
2. **All four roles got "B" with no breakdown.** The model already emits three sub-scores per role (`decision_quality` / `communication` / `speed`) plus a one-sentence rationale citing a turn — but the frontend stuffed the rationale into a hover `title` (mouse-only, invisible to keyboard / mobile / SR) and averaged the three sub-scores into a single letter. So two B's that came from 5/5/3 vs. 4/4/4 were indistinguishable, and there was no "show your work" affordance.

## Changes

Frontend-only — backend export shape unchanged. The data was already shipping; the UI just wasn't surfacing it.

- **Drop the `OVERALL · {score} / 5` block** from `LeftColumn`. Per the user's explicit direction: the three top score cards already convey the team grade in the same letter scheme. The numeric `overall_score` and `overall_rationale` still ship in the JSON + markdown exports.
- **Per-role rows are now collapsible buttons.** Each row uses a brand-canonical `▶` / `▼` chevron (matches `CollapsibleRailPanel.tsx`) with `aria-expanded` / `aria-controls`. Clicking expands a panel showing three `SubScoreCell` boxes (DECISION / COMMS / SPEED with `N / 5` numerics colored by the existing tone rubric) and the model's rationale text rendered inline. Multiple rows can be expanded simultaneously for comparison.
- **Discoverability + grade-legend caption** above the per-role list: "Tap a row for the breakdown · A exemplary · B above bar · C at bar · D below bar · F critical." Without this, a first-time CISO sees four greyed rows with letters and may read them as a static summary table.
- **`aria-label` on each toggle button** so screen-reader users get the role, display name, grade, decision count, and the toggle action in one announcement.

## Test plan

- [x] `npm test -- --run AarReport` — 13/13 pass (added 6 new tests: OVERALL block absence, collapsed-by-default + click-to-expand, multi-row expand, no-rationale fallback, legend caption, aria-label content; also tightened the expand test with chevron-flip / aria-controls→panel-id linkage / button-tag/type assertions per QA review).
- [x] `npm test -- --run` — full frontend suite 465/465 pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [ ] Manual smoke in the browser (see "Manual verification" below).

## Manual verification

1. Open a finished session's AAR popup as the creator.
2. Verify the trailing "OVERALL · 4 / 5" block is gone.
3. Scroll the right column; per-role rows show a small `▶` at the start.
4. Click a row → chevron flips to `▼`, panel below shows DECISION / COMMS / SPEED numerics + rationale text.
5. Click another row → both stay open.
6. Click the open row → collapses; chevron back to `▶`.
7. Tab through with the keyboard — focus ring visible on each row, Space/Enter toggles.
8. Confirm the "Tap a row for the breakdown · A exemplary..." caption is visible above the role list.

## Sub-agent reviews

Six reviews ran in parallel per CLAUDE.md.

| Agent | Result |
|---|---|
| QA | 4 MEDIUM/LOW coverage gaps — **all addressed inline** (chevron flip, aria-controls linkage, button tag/type, scoping) |
| Security | Clean — no `dangerouslySetInnerHTML`, no new network paths, trust-boundary respected |
| UI/UX | 2 MEDIUM — `aria-label` **addressed**; `<dl>` semantic markup for SubScoreCell **deferred** (a11y polish, not interaction-blocking) |
| Product / App-Owner | Clean — change matches the user's two clarifications verbatim |
| User Persona | 3 HIGH — chevron discoverability **addressed** (caption + brighter chevron); grade legend **addressed** (caption); team-level synthesis **deferred** per explicit user direction |
| Prompt Expert | Clean — no prompts touched; AAR prompt already mandates rationale + sub-scores |

### Deferred findings (none interaction-blocking)

- `SubScoreCell` could use `<dl>` / `<dt>` / `<dd>` markup with `sr-only "out of 5"` instead of inline `/ 5` for cleaner SR pair-association.
- Sub-score "dot" indicators on collapsed rows so two B's read differently without expansion.
- Sticky EXPORT pill footer when many rows are expanded.
- Clickable turn references inside the rationale text (would need the JSON timeline integration).

The "team-level synthesis" gap (User Persona HIGH #3) is deferred deliberately: the user explicitly asked for the OVERALL block to be removed and said the three top score cards already serve that role. If a one-number team verdict is desired later, it can land as a separate change.

https://claude.ai/code/session_01RjigPWyEpp4S5Jd3ubAC25

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjigPWyEpp4S5Jd3ubAC25)_