### PR TITLE
ui: replace truncated scenario brief with plan title + summary on Join page

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -530,6 +530,15 @@ def register_api_routes(app: FastAPI) -> None:
             "id": session.id,
             "state": session.state.value,
             "scenario_prompt": session.scenario_prompt,
+            # Player-safe headline + 1-liner pulled off the AI-generated
+            # plan. The full ``plan`` (injects, narrative_arc, success
+            # criteria) stays creator-only — those would spoil the
+            # exercise. ``title`` and ``executive_summary`` are by
+            # design high-level descriptors of *what the scenario is
+            # about*, not what's going to happen, so they're safe to
+            # ship to every participant.
+            "plan_title": session.plan.title if session.plan else None,
+            "plan_summary": session.plan.executive_summary if session.plan else None,
             # Creator-selected scenario tuning. ``difficulty`` and
             # ``duration_minutes`` are benign — every participant sees a
             # difficulty pill / target-duration HUD. ``features`` is

--- a/backend/app/llm/prompts.py
+++ b/backend/app/llm/prompts.py
@@ -478,6 +478,15 @@ _SETUP_SYSTEM = (
     "Iterate freely with the creator. When they approve, call `finalize_setup` "
     "with the final plan. After `finalize_setup`, end your turn — the play "
     "phase begins.\n\n"
+    "**`title` and `executive_summary` are shown to every participant on "
+    "the join page — keep them spoiler-free.** State the scenario *type "
+    "and stakes* (e.g. 'Ransomware response under regulator scrutiny'), "
+    "not the *plot*: do not name the antagonist, attribute the root "
+    "cause, reveal which inject fires when, or pre-state the twist. "
+    "Inject details, antagonist identity, and beat-specific surprises "
+    "belong in `injects[]` and `narrative_arc[]`, which stay creator-only. "
+    "The rest of the plan is creator-only and the disclosure rules in "
+    "Block 4 still apply to it.\n\n"
     "**Plan completeness — non-negotiable.** Your `propose_scenario_plan` "
     "and `finalize_setup` calls MUST include:\n"
     "  * `narrative_arc`: at least 3 beats. Each beat needs `beat` "
@@ -504,8 +513,9 @@ _SETUP_SYSTEM = (
     "the same content as JSON, do not retry the XML form.\n"
     "<example>\n"
     "{\n"
-    '  "title": "Phishing-led ransomware",\n'
-    '  "executive_summary": "Finance team breach via vendor token.",\n'
+    '  "title": "Ransomware response under regulator scrutiny",\n'
+    '  "executive_summary": "Multi-team incident with legal, comms, '
+    'and technical decisions under time pressure.",\n'
     '  "key_objectives": [\n'
     '    "Containment decision documented before beat 3",\n'
     '    "Comms drafted and reviewed by Legal",\n'

--- a/backend/app/llm/tools.py
+++ b/backend/app/llm/tools.py
@@ -513,7 +513,10 @@ SETUP_TOOLS: list[dict[str, Any]] = [
             "facilitate against. Iterate via repeated calls until "
             "approved, then call finalize_setup. Emit ``input`` as a "
             "JSON object matching this input_schema; legacy XML "
-            "function-call markup is not accepted."
+            "function-call markup is not accepted. **`title` and "
+            "`executive_summary` are shown to every participant on the "
+            "join page — keep them spoiler-free (scenario type/stakes, "
+            "not antagonist/root-cause/twist).**"
         ),
         "input_schema": {
             "type": "object",
@@ -554,7 +557,10 @@ SETUP_TOOLS: list[dict[str, Any]] = [
             "Transitions session to READY. Same array invariants as "
             "propose_scenario_plan: narrative_arc / key_objectives / "
             "injects MUST each contain at least one entry. Emit ``input`` "
-            "as a JSON object matching this input_schema."
+            "as a JSON object matching this input_schema. **`title` and "
+            "`executive_summary` are shown to every participant on the "
+            "join page — keep them spoiler-free (scenario type/stakes, "
+            "not antagonist/root-cause/twist).**"
         ),
         "input_schema": {
             "type": "object",

--- a/backend/tests/test_api_routes_gaps.py
+++ b/backend/tests/test_api_routes_gaps.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 
 from app.config import reset_settings_cache
 from app.main import create_app
-from app.sessions.models import SessionState
+from app.sessions.models import ScenarioBeat, ScenarioInject, ScenarioPlan, SessionState
 from tests.conftest import default_settings_body
 from tests.mock_anthropic import MockAnthropic
 
@@ -393,3 +393,80 @@ def test_proxy_submit_pending_409_when_no_open_turn(client: TestClient) -> None:
         json={"content": "stand-in"},
     )
     assert r.status_code == 409
+
+
+# ---------------------------------------------------------------- get_session: plan_title / plan_summary
+
+
+def test_get_session_omits_plan_title_summary_when_plan_is_none(
+    client: TestClient,
+) -> None:
+    """Pre-finalize, ``session.plan`` is None — both fields must be null
+    so the JoinIntro hides the brief panel cleanly."""
+
+    seats = _seat(client)
+    r = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['ptok']}"
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["plan_title"] is None
+    assert body["plan_summary"] is None
+    # Full plan stays creator-only too.
+    assert body["plan"] is None
+
+
+def test_get_session_exposes_plan_title_summary_to_non_creator(
+    client: TestClient,
+) -> None:
+    """Once the plan is set, every participant — including non-creator
+    players — sees ``plan_title`` and ``plan_summary``. The full
+    ``plan`` object stays creator-only."""
+
+    seats = _seat(client)
+    sid = seats["sid"]
+    manager = client.app.state.manager
+
+    plan = ScenarioPlan(
+        title="Ransomware response under regulator scrutiny",
+        executive_summary=(
+            "Multi-team incident with legal, comms, and technical "
+            "decisions under time pressure."
+        ),
+        key_objectives=["Containment decision documented before beat 3"],
+        narrative_arc=[
+            ScenarioBeat(beat=1, label="Detection", expected_actors=["SOC"]),
+        ],
+        injects=[
+            ScenarioInject(trigger="after beat 1", type="event", summary="x"),
+        ],
+    )
+
+    import asyncio
+
+    async def _seed_plan() -> None:
+        async with await manager._lock_for(sid):
+            sess = await manager._repo.get(sid)
+            sess.plan = plan
+            await manager._repo.save(sess)
+
+    asyncio.run(_seed_plan())
+
+    # Non-creator player token sees the title + summary.
+    rp = client.get(f"/api/sessions/{sid}?token={seats['ptok']}")
+    assert rp.status_code == 200, rp.text
+    pbody = rp.json()
+    assert pbody["plan_title"] == plan.title
+    assert pbody["plan_summary"] == plan.executive_summary
+    # ...but not the full plan (still creator-only).
+    assert pbody["plan"] is None
+
+    # Creator sees the full plan AND the convenience fields.
+    rc = client.get(f"/api/sessions/{sid}?token={seats['ctok']}")
+    assert rc.status_code == 200, rc.text
+    cbody = rc.json()
+    assert cbody["plan_title"] == plan.title
+    assert cbody["plan_summary"] == plan.executive_summary
+    assert cbody["plan"] is not None
+    assert cbody["plan"]["title"] == plan.title
+

--- a/frontend/src/__tests__/JoinIntro.waiting.test.tsx
+++ b/frontend/src/__tests__/JoinIntro.waiting.test.tsx
@@ -13,6 +13,8 @@ const COMMON_PROPS = {
   roleLabel: "SOC Analyst",
   roleKind: "player" as const,
   roleExistingDisplayName: null,
+  planTitle: null,
+  planSummary: null,
   snapshotLoaded: true,
   snapshotError: null,
   onRetry: () => undefined,

--- a/frontend/src/__tests__/JoinIntro.waiting.test.tsx
+++ b/frontend/src/__tests__/JoinIntro.waiting.test.tsx
@@ -280,3 +280,113 @@ describe("JoinIntro — issue #76 (joined, waiting for session start)", () => {
     expect(tipPanel.textContent).toMatch(/1\s*\/\s*\d+/);
   });
 });
+
+describe("JoinIntro — SCENARIO BRIEF panel (plan_title / plan_summary)", () => {
+  it("plan present → renders title + summary, no preparing placeholder", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="READY"
+        planTitle="Ransomware response under regulator scrutiny"
+        planSummary="Multi-team incident with legal, comms, and technical decisions under time pressure."
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: /SCENARIO BRIEF/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Ransomware response under regulator scrutiny"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Multi-team incident/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/still preparing the scenario brief/i),
+    ).toBeNull();
+  });
+
+  it("plan absent + pre-play → renders 'preparing' placeholder under SCENARIO BRIEF", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="SETUP"
+        planTitle={null}
+        planSummary={null}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: /SCENARIO BRIEF/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/still preparing the scenario brief/i),
+    ).toBeInTheDocument();
+  });
+
+  it("plan absent + ENDED → no SCENARIO BRIEF panel at all", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="ENDED"
+        planTitle={null}
+        planSummary={null}
+      />,
+    );
+    expect(
+      screen.queryByRole("heading", { name: /SCENARIO BRIEF/i, level: 2 }),
+    ).toBeNull();
+  });
+
+  it("empty-string title/summary collapse the panel cleanly (truthy gating)", () => {
+    // ``ScenarioPlan.executive_summary`` defaults to ``""`` per Pydantic
+    // and the model can emit ``""``; the panel must not render an empty
+    // chrome with no content underneath.
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="READY"
+        planTitle=""
+        planSummary=""
+      />,
+    );
+    // Both empty → falls through to the pending placeholder (state is
+    // not ENDED), which is fine — gives the user *something*.
+    expect(
+      screen.getByText(/still preparing the scenario brief/i),
+    ).toBeInTheDocument();
+  });
+
+  it("only planTitle set → renders title without an empty summary p", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        sessionState="READY"
+        planTitle="Office CPU spike investigation"
+        planSummary={null}
+      />,
+    );
+    expect(
+      screen.getByText("Office CPU spike investigation"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/still preparing the scenario brief/i),
+    ).toBeNull();
+  });
+
+  it("spectator role still sees the brief", () => {
+    render(
+      <JoinIntro
+        {...COMMON_PROPS}
+        roleKind="spectator"
+        sessionState="READY"
+        planTitle="Office CPU spike investigation"
+        planSummary="Investigation under time pressure."
+      />,
+    );
+    expect(
+      screen.getByText("Office CPU spike investigation"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Investigation under time pressure."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Play.e2e.test.tsx
+++ b/frontend/src/__tests__/Play.e2e.test.tsx
@@ -70,6 +70,8 @@ function _baseSnapshot(): SessionSnapshot {
     state: "AWAITING_PLAYERS",
     created_at: "2026-05-03T00:00:00Z",
     scenario_prompt: "Ransomware via vendor portal",
+    plan_title: "Ransomware",
+    plan_summary: "Detection at 03:14 on three finance laptops.",
     settings: {
       difficulty: "standard",
       duration_minutes: 60,

--- a/frontend/src/__tests__/SetupView.planPanel.test.tsx
+++ b/frontend/src/__tests__/SetupView.planPanel.test.tsx
@@ -28,6 +28,8 @@ function fakeSnapshot(plan: ScenarioPlan | null): SessionSnapshot {
     state: plan ? "SETUP" : "SETUP",
     created_at: "2026-05-05T00:00:00Z",
     scenario_prompt: "test scenario",
+    plan_title: plan?.title ?? null,
+    plan_summary: plan?.executive_summary ?? null,
     settings: {
       difficulty: "standard",
       duration_minutes: 60,

--- a/frontend/src/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/__tests__/SetupWizard.test.tsx
@@ -35,6 +35,8 @@ function fakeSnapshot(overrides: {
     state: overrides.state,
     created_at: "2026-05-05T00:00:00Z",
     scenario_prompt: "test scenario",
+    plan_title: overrides.plan?.title ?? null,
+    plan_summary: overrides.plan?.executive_summary ?? null,
     settings: {
       difficulty: "standard",
       duration_minutes: 60,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,13 @@ export interface SessionSnapshot {
   /** Session-start timestamp (ISO 8601, UTC) — used for ``T+MM:SS`` relative timestamps in the shared notepad. */
   created_at: string;
   scenario_prompt: string;
+  /** Player-safe AI-generated headline + 1-liner pulled off
+   *  ``plan.title`` and ``plan.executive_summary``. Visible to every
+   *  participant — high-level descriptors that don't spoil injects,
+   *  unlike the full ``plan`` which stays creator-only. ``null`` until
+   *  the plan exists (early CONFIGURING states). */
+  plan_title: string | null;
+  plan_summary: string | null;
   /** Creator-selected scenario tuning (frozen at creation). The HUD
    *  renders a difficulty pill + target-duration off this; the
    *  ``features`` subfield is creator-only and arrives ``null`` on

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -1754,13 +1754,22 @@ export function JoinIntro({
     }
   }
 
-  // Hide the brief panel entirely when the AI-generated plan hasn't
-  // landed yet (early CONFIGURING). ``plan.title`` and
-  // ``plan.executive_summary`` are the only plan fields safe to show
-  // every participant — the rest stays creator-only.
-  const briefVisible = planTitle !== null || planSummary !== null;
-
+  // Render strategy for the SCENARIO BRIEF panel:
+  //   * brief data present → show title + summary
+  //   * brief absent + still pre-play → show "being prepared" placeholder
+  //     so the join-page doesn't read as "did I get the wrong link?"
+  //   * brief absent + ENDED → hide
+  // Truthy check (not ``!== null``) so empty strings — which Pydantic
+  // defaults ``executive_summary`` to and the model can emit — collapse
+  // the panel cleanly instead of rendering an empty SCENARIO BRIEF
+  // chrome. ``plan.title`` and ``plan.executive_summary`` are the only
+  // plan fields safe to show every participant; the rest stays
+  // creator-only.
+  const briefHasContent = Boolean(planTitle) || Boolean(planSummary);
   const sessionEnded = sessionState === "ENDED";
+  const briefPending = !briefHasContent && !sessionEnded;
+  const briefVisible = briefHasContent || briefPending;
+
   const isSpectator = roleKind === "spectator";
 
   // Snapshot-error branch: the snapshot fetch failed (network blip,
@@ -1860,19 +1869,36 @@ export function JoinIntro({
               : "Join the tabletop exercise"}
           </h1>
           {briefVisible ? (
-            <div className="mt-2 rounded-r-2 border-l-2 border-signal bg-ink-800 p-3 text-sm leading-relaxed text-ink-100">
-              <span className="block mono text-[10px] font-bold uppercase tracking-[0.20em] text-signal mb-1">
+            <section
+              aria-labelledby="brief-heading"
+              className="mt-2 rounded-r-2 border-l-2 border-signal bg-ink-800 p-3 leading-relaxed"
+            >
+              <h2
+                id="brief-heading"
+                className="mono text-[10px] font-bold uppercase tracking-[0.20em] text-signal mb-1"
+              >
                 SCENARIO BRIEF
-              </span>
+              </h2>
+              {briefPending ? (
+                <p className="text-[13px] italic text-ink-300">
+                  The facilitator is still preparing the scenario brief.
+                </p>
+              ) : null}
               {planTitle ? (
-                <p className="font-semibold text-ink-050">{planTitle}</p>
+                <p className="text-base font-semibold text-ink-050">{planTitle}</p>
               ) : null}
               {planSummary ? (
-                <p className={planTitle ? "mt-1 text-ink-100" : "text-ink-100"}>
+                <p
+                  className={
+                    planTitle
+                      ? "mt-1 text-[13px] text-ink-200"
+                      : "text-[13px] text-ink-200"
+                  }
+                >
                   {planSummary}
                 </p>
               ) : null}
-            </div>
+            </section>
           ) : null}
         </header>
 

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -938,7 +938,8 @@ export function Play({ sessionId, token }: Props) {
         roleLabel={myRoleFromSnapshot?.label}
         roleKind={myRoleFromSnapshot?.kind}
         roleExistingDisplayName={serverDisplayName}
-        scenarioPrompt={snapshot?.scenario_prompt}
+        planTitle={snapshot?.plan_title ?? null}
+        planSummary={snapshot?.plan_summary ?? null}
         sessionState={snapshot?.state}
         snapshotLoaded={snapshot !== null}
         snapshotError={snapshot === null ? error : null}
@@ -1566,7 +1567,12 @@ interface JoinIntroProps {
    *  participation-style interaction and confused them. */
   roleKind?: "player" | "spectator";
   roleExistingDisplayName: string | null;
-  scenarioPrompt?: string;
+  /** AI-generated scenario name (``plan.title``) — short headline like
+   *  "Phishing-led ransomware". ``null`` before the plan exists. */
+  planTitle: string | null;
+  /** AI-generated 1-2 sentence executive summary. ``null`` before the
+   *  plan exists. */
+  planSummary: string | null;
   sessionState?: string;
   /** ``true`` once the snapshot fetch has resolved. Pre-fix the page
    *  rendered a generic header until the fetch completed, which let
@@ -1637,7 +1643,8 @@ export function JoinIntro({
   roleLabel,
   roleKind,
   roleExistingDisplayName,
-  scenarioPrompt,
+  planTitle,
+  planSummary,
   sessionState,
   snapshotLoaded,
   snapshotError,
@@ -1747,13 +1754,11 @@ export function JoinIntro({
     }
   }
 
-  // The scenario prompt is creator-authored seed text that's part of
-  // the public session — it's not the AI-generated plan (that stays
-  // hidden from non-creators). A short trimmed preview is fine for
-  // setting the room expectation without spoiling injects.
-  const scenarioPreview = scenarioPrompt
-    ? scenarioPrompt.slice(0, 240).trim() + (scenarioPrompt.length > 240 ? "…" : "")
-    : null;
+  // Hide the brief panel entirely when the AI-generated plan hasn't
+  // landed yet (early CONFIGURING). ``plan.title`` and
+  // ``plan.executive_summary`` are the only plan fields safe to show
+  // every participant — the rest stays creator-only.
+  const briefVisible = planTitle !== null || planSummary !== null;
 
   const sessionEnded = sessionState === "ENDED";
   const isSpectator = roleKind === "spectator";
@@ -1854,13 +1859,20 @@ export function JoinIntro({
                 : `You're invited as ${roleLabel}`
               : "Join the tabletop exercise"}
           </h1>
-          {scenarioPreview ? (
-            <p className="mt-2 rounded-r-2 border-l-2 border-signal bg-ink-800 p-3 text-sm leading-relaxed text-ink-100">
+          {briefVisible ? (
+            <div className="mt-2 rounded-r-2 border-l-2 border-signal bg-ink-800 p-3 text-sm leading-relaxed text-ink-100">
               <span className="block mono text-[10px] font-bold uppercase tracking-[0.20em] text-signal mb-1">
                 SCENARIO BRIEF
               </span>
-              {scenarioPreview}
-            </p>
+              {planTitle ? (
+                <p className="font-semibold text-ink-050">{planTitle}</p>
+              ) : null}
+              {planSummary ? (
+                <p className={planTitle ? "mt-1 text-ink-100" : "text-ink-100"}>
+                  {planSummary}
+                </p>
+              ) : null}
+            </div>
           ) : null}
         </header>
 


### PR DESCRIPTION
## Summary

The player Join page rendered the creator's raw `scenario_prompt`
sliced to 240 chars + "…". The prompt is the creator's section-headered
seed text ("SCENARIO BRIEF / TEAM / ENVIRONMENT / CONSTRAINTS"), so the
visible preview leaked the section header into the rendered text *and*
the trailing ellipsis read as a clickable "expand" — players reported
trying to click it.

Replace with the AI-generated `plan.title` and `plan.executive_summary`
exposed on the snapshot for every participant. The full plan stays
creator-only — only these two fields ship to players.

## Changes

- **Backend**: `GET /api/sessions/{id}` now emits `plan_title` and
  `plan_summary` to all participants. Full `plan` object remains
  creator-only.
- **Frontend**: JoinIntro renders the title as a bold sub-headline and
  the summary as body text below, with no truncation. When the plan
  isn't ready yet (early CONFIGURING), shows "The facilitator is still
  preparing the scenario brief." in the SCENARIO BRIEF slot. SCENARIO
  BRIEF promoted to an `<h2>` inside an `aria-labelledby` section for
  screen-reader navigation.
- **Prompt hardening**: `_SETUP_SYSTEM` and the `propose_scenario_plan`
  / `finalize_setup` tool descriptions tell the model that
  `title`/`executive_summary` are player-visible — no antagonist
  identity, root cause, or beat-specific spoilers. The example in
  `prompts.py` was sanitised (the prior "Finance team breach via
  vendor token" leaked the entry vector).

## Sub-agent reviews

Six-agent review pipeline was run; all HIGH findings landed in the
follow-up commit:

- **Security/Prompt**: prompt directive for spoiler-safe
  title/executive_summary
- **QA/Product**: truthy gate for empty-string title/summary
- **QA**: 6 new frontend tests + 2 new backend tests covering all
  render branches
- **UI/UX**: visual hierarchy bump + a11y heading promotion
- **User**: "preparing the brief" placeholder when plan absent

Deferred (MEDIUM/LOW): brand-voice directive for AI plan copy,
"re-read the brief in-game" affordance, gating `scenario_prompt` on
`is_creator`. All tracked as follow-ups.

## Test plan

- [x] Frontend: 465 tests pass (was 459; +6 new SCENARIO BRIEF tests)
- [x] Frontend: typecheck + lint clean
- [x] Backend: 902 non-live tests pass (1 pre-existing skipped)
- [x] Backend: ruff clean
- [x] Live: `test_workstreams_setup_routing.py` 1 passed / 1 xfail
  (~$0.06) — confirms prompt directive doesn't regress setup
  tool routing
- [ ] Manual smoke: open join URL during CONFIGURING (placeholder)
  and after READY (title+summary)

https://claude.ai/code/session_01RQd2A8rPDGtEFqmdRv4cXb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQd2A8rPDGtEFqmdRv4cXb)_