### PR TITLE
frontend: fix typecheck regression on main (PR #204 / #206 merge race)

### DIFF
--- a/frontend/src/__tests__/Facilitator.looksReady.test.tsx
+++ b/frontend/src/__tests__/Facilitator.looksReady.test.tsx
@@ -62,6 +62,16 @@ function fakeSnapshotWithoutPlan(): SessionSnapshot {
       features: { ...DEFAULT_SESSION_FEATURES },
     },
     plan: null,
+    // ``plan_title`` / ``plan_summary`` are required ``string | null``
+    // fields on ``SessionSnapshot`` (added by PR #206
+    // plan-summary-display). PR #204 was rebased off an older main
+    // and merged after #206 without picking up the field addition,
+    // so the fixture shipped without these — main has been failing
+    // typecheck since the merge race. Setting both to null matches
+    // the no-plan-yet semantic this fixture already represents
+    // (``plan: null``).
+    plan_title: null,
+    plan_summary: null,
     roles: [],
     current_turn: null,
     messages: [],


### PR DESCRIPTION
## Summary

Main has been failing `npm run typecheck` since the merge of PR #204. Every open PR that merges with main currently inherits the failure (caught it on PR #205's CI run).

## Root cause

- **PR #206** (plan-summary-display, ebe4f3f) added `plan_title` and `plan_summary` to `SessionSnapshot` as required `string | null` fields.
- **PR #204** (clarify-aar-grading, 416586d) introduced `frontend/src/__tests__/Facilitator.looksReady.test.tsx` with a `fakeSnapshotWithoutPlan` fixture that doesn't set those fields. PR #204 was rebased against an older main and merged after #206 without picking up the field addition.

So the `SessionSnapshot` literal in the fixture is now missing two required properties, and `tsc -b --noEmit` errors out:

```
src/__tests__/Facilitator.looksReady.test.tsx(54,3): error TS2739:
Type '{ … }' is missing the following properties from type
'SessionSnapshot': plan_title, plan_summary
```

Reproduced by `git checkout origin/main && npm run typecheck`.

## Fix

Set both fields to `null` in the fixture, matching the no-plan-yet semantic the fixture already represents (`plan: null`). The in-code comment captures the merge-race history so a future grep finds the context.

## Test plan

- [x] `git checkout origin/main` — typecheck fails
- [x] `git checkout this-branch` — typecheck clean
- [x] `npm run lint` clean
- [ ] CI green

https://claude.ai/code/session_0183Z4G7KnkHeCgduvCyZVQc

---
_Generated by [Claude Code](https://claude.ai/code/session_0183Z4G7KnkHeCgduvCyZVQc)_