### PR TITLE
frontend: drop "Responding as" label, creator-gate Force-Advance, clarify off-turn Mark Ready

### DIFF
--- a/frontend/src/__tests__/MarkReadyButton.test.tsx
+++ b/frontend/src/__tests__/MarkReadyButton.test.tsx
@@ -313,4 +313,83 @@ describe("<MarkReadyButton/>", () => {
       ).toBe("self");
     });
   });
+
+  describe("disabledLabel override", () => {
+    it("disabled + disabledLabel shows the override on the button face instead of MARK READY", () => {
+      render(
+        <MarkReadyButton
+          isReady={false}
+          enabled={false}
+          onToggle={vi.fn()}
+          variant="self"
+          disabledLabel="NOT YOUR TURN"
+          disabledReason="You aren't on the active turn — Mark Ready isn't your call this beat."
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready");
+      expect(btn.textContent).toMatch(/NOT YOUR TURN/);
+      expect(btn.textContent).not.toMatch(/MARK READY/);
+      expect(btn.getAttribute("title")).toMatch(/active turn/i);
+    });
+
+    it("enabled + disabledLabel keeps the default MARK READY face — override only applies while disabled", () => {
+      render(
+        <MarkReadyButton
+          isReady={false}
+          enabled={true}
+          onToggle={vi.fn()}
+          variant="self"
+          disabledLabel="NOT YOUR TURN"
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready");
+      expect(btn.textContent).toMatch(/MARK READY/);
+      expect(btn.textContent).not.toMatch(/NOT YOUR TURN/);
+    });
+
+    it("disabled without disabledLabel falls back to MARK READY (legacy callers unchanged)", () => {
+      render(
+        <MarkReadyButton
+          isReady={false}
+          enabled={false}
+          onToggle={vi.fn()}
+          variant="self"
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready");
+      expect(btn.textContent).toMatch(/MARK READY/);
+    });
+  });
+
+  describe("undo hint gating on enabled", () => {
+    // ``showUndoHint`` was previously gated on ``variant === "self" && isReady``.
+    // The hint suggested "tap to undo" — but if the button was disabled
+    // the user couldn't actually undo, so the hint lied. Tighten the
+    // gate to also require ``enabled``.
+    it("disabled + isReady=true does NOT render the 'tap to undo' hint", () => {
+      render(
+        <MarkReadyButton
+          isReady={true}
+          enabled={false}
+          onToggle={vi.fn()}
+          variant="self"
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready");
+      expect(btn.textContent).not.toMatch(/tap to undo/i);
+    });
+
+    it("enabled + isReady=true still renders the 'tap to undo' hint (regression net)", () => {
+      render(
+        <MarkReadyButton
+          isReady={true}
+          enabled={true}
+          onToggle={vi.fn()}
+          variant="self"
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready");
+      expect(btn.textContent).toMatch(/tap to undo/i);
+    });
+  });
 });

--- a/frontend/src/__tests__/Play.e2e.test.tsx
+++ b/frontend/src/__tests__/Play.e2e.test.tsx
@@ -251,6 +251,14 @@ describe("Play page e2e — state transitions", () => {
     expect(
       screen.getByText(/what does the alert queue actually show/i),
     ).toBeInTheDocument();
+    // ESCAPE HATCHES panel must NOT render for a non-creator player.
+    // The whole panel (including the heading) is creator-gated; a
+    // regression that re-shows force-advance / pause AI / end session
+    // to a non-creator gets caught here.
+    expect(screen.queryByText(/escape hatches/i)).toBeNull();
+    expect(screen.queryByText(/force-advance/i)).toBeNull();
+    expect(screen.queryByText(/pause ai/i)).toBeNull();
+    expect(screen.queryByText(/end session/i)).toBeNull();
   });
 
   it("AI_PROCESSING: composer stays enabled so a player can drop a sidebar / interjection", async () => {

--- a/frontend/src/__tests__/RoleRoster.test.tsx
+++ b/frontend/src/__tests__/RoleRoster.test.tsx
@@ -166,4 +166,26 @@ describe("<RoleRoster/>", () => {
     // The other role's row carries the inline READY ✓ chip.
     expect(screen.getByText(/READY ✓/i)).toBeInTheDocument();
   });
+
+  it("shows NOT YOUR TURN on the disabled button when self isn't on the active set", () => {
+    // Pre-fix the off-active-set viewer saw a greyed-out
+    // "MARK READY →" face that read as broken. The plain-English
+    // override label tells them at a glance that the affordance
+    // isn't theirs to act on this beat — the tooltip still names
+    // the why, but touch users who can't hover get the signal too.
+    render(
+      <RoleRoster
+        roles={ROLES}
+        activeRoleIds={["role-other"]}
+        selfRoleId="role-self"
+        readyRoleIds={new Set()}
+        onSelfMarkReady={vi.fn()}
+        selfMarkReadyEnabled={false}
+      />,
+    );
+    const btn = screen.getByTestId("mark-ready");
+    expect(btn).toBeDisabled();
+    expect(btn.textContent).toMatch(/NOT YOUR TURN/);
+    expect(btn.textContent).not.toMatch(/MARK READY/);
+  });
 });

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -44,10 +44,13 @@ export interface MentionMark {
 interface Props {
   enabled: boolean;
   placeholder: string;
-  /** Visible label above the textarea. Issue #78: parents render
-   * "Your turn" when ``isMyTurn`` and "Add a comment" / "Your message"
-   * otherwise so the at-a-glance signal isn't lost when the composer
-   * stays enabled for out-of-turn sidebar comments. */
+  /** Accessible-name suffix for the textarea. Parents pass
+   * "Your turn" / "Add a comment" / "Your message" so screen-reader
+   * users still get the at-a-glance turn signal. The visible
+   * "RESPONDING AS · X" label that previously consumed this prop was
+   * dropped — the at-a-glance signal lives in the rail (active row,
+   * Mark Ready button) and the textarea placeholder, not above the
+   * composer. */
   label?: string;
   /**
    * ``asRoleId`` is omitted for normal submissions (use the local
@@ -672,14 +675,8 @@ export function Composer({
       onSubmit={handle}
       className="flex flex-col gap-2 rounded-r-3 border-t border-ink-600 bg-ink-850 p-3"
     >
-      <div className="flex items-center justify-between gap-2">
-        <label
-          className="mono text-[10px] font-bold uppercase tracking-[0.20em] text-signal"
-          htmlFor="composer"
-        >
-          {label ? `RESPONDING AS · ${label.toUpperCase()}` : "RESPONDING AS · YOU"}
-        </label>
-        {hasImpersonate ? (
+      {hasImpersonate ? (
+        <div className="flex items-center justify-end gap-2">
           <label className="mono flex items-center gap-1 text-[10px] uppercase tracking-[0.10em] text-ink-300">
             Respond as
             <select
@@ -698,8 +695,8 @@ export function Composer({
               ))}
             </select>
           </label>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
       {asRoleId ? (() => {
         const selected = (impersonateOptions ?? []).find(
           (o) => o.id === asRoleId,
@@ -755,6 +752,7 @@ export function Composer({
               : undefined
           }
           aria-autocomplete="list"
+          aria-label={label ? `Composer, ${label}` : "Composer"}
           className={`w-full rounded-r-1 border bg-ink-900 p-3 text-sm text-ink-100 sans focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal-deep disabled:opacity-50 ${
             asRoleId ? "border-warn" : "border-signal-deep"
           }`}

--- a/frontend/src/components/RoleRoster.tsx
+++ b/frontend/src/components/RoleRoster.tsx
@@ -190,6 +190,7 @@ export function RoleRoster({
                 ? "You aren't on the active turn — Mark Ready isn't your call this beat."
                 : undefined)
             }
+            disabledLabel={!selfIsActive ? "NOT YOUR TURN" : undefined}
           />
           {/* User-persona MEDIUM M2: "quorum" is operator-jargon for
               a first-time CISO. Plain copy reads sensibly and matches

--- a/frontend/src/components/brand/BottomActionBar.tsx
+++ b/frontend/src/components/brand/BottomActionBar.tsx
@@ -161,14 +161,23 @@ export function BottomActionBar(props: Props) {
       )}
       {props.phase === "play" && (
         <>
+          {/* The FORCE-ADVANCE button used to be ``border-ink-500
+              text-ink-200 font-semibold`` — a gray-on-gray chip that
+              blended into the surrounding telemetry row. Now warn-
+              tinted (orange) outline + bold text + arrow affordance
+              so the operator's eye lands on it during a stuck turn.
+              Outline-only (no fill) on purpose: the END SESSION
+              button alongside is also outline (crit), and filling
+              FORCE-ADVANCE would invert the destructive-action
+              hierarchy. UI/UX review M1. */}
           <button
             type="button"
             onClick={props.onForceAdvance}
             disabled={props.busy}
-            className="mono rounded-r-1 border border-ink-500 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-ink-200 hover:border-signal hover:text-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal disabled:opacity-50"
+            className="mono rounded-r-1 border border-warn px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-warn hover:bg-warn-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-warn disabled:opacity-50"
             title="Hand the turn to the AI now."
           >
-            FORCE-ADVANCE
+            FORCE-ADVANCE TURN →
           </button>
           <button
             type="button"

--- a/frontend/src/components/brand/MarkReadyButton.tsx
+++ b/frontend/src/components/brand/MarkReadyButton.tsx
@@ -84,6 +84,16 @@ interface Props {
   /** Optional reason shown as a tooltip when ``enabled=false`` —
    *  e.g. "Not on the active turn", "WebSocket reconnecting". */
   disabledReason?: string;
+  /** Optional short label that replaces the default state label
+   *  ("MARK READY →" / "READY ✓") while the button is disabled.
+   *  e.g. ``"NOT YOUR TURN"`` when the viewer isn't on the active
+   *  turn — a greyed-out "MARK READY" reads as broken; a state label
+   *  that matches the actual situation reads as "this isn't your
+   *  beat, hold." Visible on the button face; the full reason still
+   *  surfaces in the tooltip via ``disabledReason`` and is mirrored
+   *  into ``aria-label`` for screen-reader users (touch users
+   *  can't hover, so the tooltip alone isn't enough). */
+  disabledLabel?: string;
 }
 
 export function MarkReadyButton({
@@ -93,6 +103,7 @@ export function MarkReadyButton({
   variant = "self",
   subjectLabel,
   disabledReason,
+  disabledLabel,
   inFlight = false,
 }: Props) {
   // Truncate long role labels with an ellipsis so the button face
@@ -110,6 +121,12 @@ export function MarkReadyButton({
   // wasn't sure whether it was confirming their ready or undoing it.
   // User-persona review HIGH H1: separate concerns visually.
   const stateLabel = (() => {
+    // ``disabledLabel`` overrides the default state copy whenever the
+    // button isn't interactive AND the parent supplied one. Lets the
+    // rail say "STAND BY" while the viewer is off-turn instead of a
+    // greyed "MARK READY →" that reads as broken. The default still
+    // wins when the parent hasn't opted in (legacy call sites).
+    if (!enabled && disabledLabel) return disabledLabel;
     if (variant === "impersonate") {
       const target = trunc((subjectLabel ?? "role").toUpperCase());
       return isReady ? `${target} READY ✓` : `MARK ${target} READY →`;
@@ -117,10 +134,12 @@ export function MarkReadyButton({
     return isReady ? "READY ✓" : "MARK READY →";
   })();
   // Secondary "tap to undo" hint — only rendered for the SELF variant
-  // when already ready. The impersonation variant uses the row label
-  // as its lead-in ("CISO READY ✓"), so an undo hint there would be
-  // ambiguous (whose ready are we undoing?).
-  const showUndoHint = variant === "self" && isReady;
+  // when already ready AND interactive. The impersonation variant uses
+  // the row label as its lead-in ("CISO READY ✓"), so an undo hint
+  // there would be ambiguous (whose ready are we undoing?). We also
+  // skip it when ``enabled=false`` because the button can't actually
+  // undo right now — the hint would lie.
+  const showUndoHint = variant === "self" && isReady && enabled;
   // ``aria-pressed`` is only meaningful on the self variant — it
   // describes the LOCAL participant's ready state. On the
   // impersonation variant the toggle reflects another role's state,
@@ -182,15 +201,26 @@ export function MarkReadyButton({
       disabled={!enabled}
       aria-pressed={ariaPressed}
       aria-busy={inFlight || undefined}
-      aria-label={
-        variant === "self"
-          ? isReady
-            ? "Walk back your ready signal"
-            : "Mark yourself ready"
-          : isReady
-            ? `Walk back ${subjectLabel ?? "this role"}'s ready signal`
-            : `Mark ${subjectLabel ?? "this role"} ready`
-      }
+      aria-label={(() => {
+        // When the parent has supplied a ``disabledLabel`` AND the
+        // button isn't interactive, mirror the disabled state into
+        // the accessible name. Touch users can't hover for the
+        // ``disabledReason`` tooltip and screen-reader users hearing
+        // only "Mark yourself ready, dimmed" miss the "this isn't
+        // your beat" signal sighted users get from the visible
+        // override label. UI/UX review LOW L1.
+        if (!enabled && disabledLabel) {
+          return disabledReason
+            ? `${disabledLabel} — ${disabledReason}`
+            : `${disabledLabel} — Mark Ready unavailable`;
+        }
+        if (variant === "self") {
+          return isReady ? "Walk back your ready signal" : "Mark yourself ready";
+        }
+        return isReady
+          ? `Walk back ${subjectLabel ?? "this role"}'s ready signal`
+          : `Mark ${subjectLabel ?? "this role"} ready`;
+      })()}
       title={title}
       data-tone={tone}
       data-variant={variant}

--- a/frontend/src/components/brand/MarkReadyButton.tsx
+++ b/frontend/src/components/brand/MarkReadyButton.tsx
@@ -123,9 +123,9 @@ export function MarkReadyButton({
   const stateLabel = (() => {
     // ``disabledLabel`` overrides the default state copy whenever the
     // button isn't interactive AND the parent supplied one. Lets the
-    // rail say "STAND BY" while the viewer is off-turn instead of a
-    // greyed "MARK READY →" that reads as broken. The default still
-    // wins when the parent hasn't opted in (legacy call sites).
+    // rail say "NOT YOUR TURN" while the viewer is off-turn instead
+    // of a greyed "MARK READY →" that reads as broken. The default
+    // still wins when the parent hasn't opted in (legacy call sites).
     if (!enabled && disabledLabel) return disabledLabel;
     if (variant === "impersonate") {
       const target = trunc((subjectLabel ?? "role").toUpperCase());

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -102,10 +102,6 @@ export function Play({ sessionId, token }: Props) {
     recovery?: string | null;
     forRoleId?: string | null;
   } | null>(null);
-  // 3-second client-side cooldown on force-advance — paired with the
-  // backend in-flight gate. Prevents the triple-banner cascade from a
-  // double/triple click (issue #63).
-  const [forceAdvanceCooldown, setForceAdvanceCooldown] = useState(false);
   // Wave 3 (issue #69) AI-pause toggle round-trip flag. Disables the
   // creator's "Pause AI / Resume AI" button while the POST is in
   // flight so a rapid double-click doesn't fire two contradictory
@@ -206,7 +202,6 @@ export function Play({ sessionId, token }: Props) {
     x: number;
     y: number;
   } | null>(null);
-  const forceAdvanceTimerRef = useRef<number | null>(null);
 
   // Determine self by inspecting snapshot.roles and matching the role with the
   // missing display_name (server doesn't echo our token; we use the snapshot
@@ -562,17 +557,6 @@ export function Play({ sessionId, token }: Props) {
     [messageCount],
   );
 
-  // Clean up the force-advance cooldown timer on unmount so a tab
-  // close mid-cooldown doesn't fire setState on an unmounted component.
-  useEffect(() => {
-    return () => {
-      if (forceAdvanceTimerRef.current !== null) {
-        window.clearTimeout(forceAdvanceTimerRef.current);
-        forceAdvanceTimerRef.current = null;
-      }
-    };
-  }, []);
-
   // Expire stale typing entries.
   useEffect(() => {
     const id = setInterval(() => {
@@ -761,31 +745,6 @@ export function Play({ sessionId, token }: Props) {
   // are React refs (stable identity across renders) — accessing ``.current``
   // inside the callback reads the latest value without needing them as deps.
   }, []);
-
-  function handleForceAdvance() {
-    if (forceAdvanceCooldown) {
-      console.warn("[play] force-advance suppressed (cooldown)");
-      return;
-    }
-    setForceAdvanceCooldown(true);
-    // Tracked in a ref so a tab-close mid-cooldown doesn't try to
-    // setState on an unmounted component.
-    forceAdvanceTimerRef.current = window.setTimeout(() => {
-      setForceAdvanceCooldown(false);
-      forceAdvanceTimerRef.current = null;
-    }, 3000);
-    // Pin the chat to the bottom so the participant sees the AI's next
-    // beat land. Mirrors Facilitator.tsx's force-advance behavior so
-    // the "consistent for the creator and the user" half of issue #79
-    // covers force-advance, not just submit.
-    forceScrollToBottom();
-    try {
-      wsRef.current?.send({ type: "request_force_advance" });
-    } catch (err) {
-      console.warn("[play] force-advance send failed", err);
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  }
 
   function handleEnd() {
     // Issue #81: button is rendered only when the local participant is
@@ -1586,21 +1545,11 @@ export function Play({ sessionId, token }: Props) {
               {readyRejectionNotice}
             </div>
           ) : null}
-          <div className="flex flex-col gap-2 rounded-r-3 border border-ink-600 bg-ink-850 p-3">
-            <span className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-ink-300">
-              ESCAPE HATCHES
-            </span>
-            <button
-              onClick={handleForceAdvance}
-              disabled={forceAdvanceCooldown}
-              aria-disabled={forceAdvanceCooldown}
-              className="mono rounded-r-1 border border-warn px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-warn hover:bg-warn-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-warn disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {forceAdvanceCooldown
-                ? "Force-advance (cooling)"
-                : "Force-advance turn"}
-            </button>
-            {isSelfCreator ? (
+          {isSelfCreator ? (
+            <div className="flex flex-col gap-2 rounded-r-3 border border-ink-600 bg-ink-850 p-3">
+              <span className="mono text-[10px] font-bold uppercase tracking-[0.22em] text-ink-300">
+                ESCAPE HATCHES
+              </span>
               <button
                 onClick={() => handlePauseToggle(snapshot.ai_paused === true)}
                 disabled={pauseInFlight}
@@ -1610,16 +1559,14 @@ export function Play({ sessionId, token }: Props) {
               >
                 {snapshot.ai_paused === true ? "Resume AI" : "Pause AI"}
               </button>
-            ) : null}
-            {isSelfCreator ? (
               <button
                 onClick={handleEnd}
                 className="mono rounded-r-1 border border-crit px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-crit hover:bg-crit-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-crit"
               >
                 End session
               </button>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
         </aside>
         <section className="flex min-w-0 flex-col gap-2 lg:min-h-0 lg:overflow-hidden">
           {/*


### PR DESCRIPTION
## Summary

User report (screenshots): three rough edges in the play surface.

- **Drop the "RESPONDING AS · YOUR TURN" label** above the composer. It was redundant with the rail's active-row highlight, the global "● YOUR TURN" banner, and the textarea placeholder. `aria-label` on the textarea preserves the screen-reader name.
- **Remove Force-Advance from the player's "ESCAPE HATCHES" panel.** Recovery is a creator admin action — not a player escape hatch. Wraps the entire panel in `{isSelfCreator ? ... : null}` (Pause AI / End session were already creator-gated). Also deletes ~80 lines of dead `forceAdvanceCooldown` state / ref / effect / handler that supported the removed button.
- **Make the creator-side Force-Advance more visible.** Was a gray-on-gray chip that disappeared into the BottomActionBar telemetry. Now warn-tinted outline + bold + arrow ("FORCE-ADVANCE TURN →"). Outline-only on purpose so it doesn't dominate the more destructive END SESSION alongside it.
- **Clarify Mark Ready when off-turn.** Greyed-out "MARK READY →" reads as broken. New optional `disabledLabel` prop on `<MarkReadyButton>` overrides the state copy while disabled; the rail passes `"NOT YOUR TURN"` when the viewer isn't on the active set. The `disabledLabel + disabledReason` mirrors into `aria-label` for touch / screen-reader users who can't hover for the tooltip. `showUndoHint` is also tightened to require `enabled=true` (the hint would lie when the button can't actually undo).

## Sub-agent review

Six reviews ran in parallel; the diff was iterated to address every BLOCK / CRITICAL / HIGH:
- **QA M1–M3 (HIGH):** added 5 new tests for `disabledLabel` override, `showUndoHint` gating, RoleRoster `"NOT YOUR TURN"` rendering, and `Play.e2e` ESCAPE HATCHES hidden for non-creator. Test count: 532 (was 526).
- **UI/UX H2:** `STAND BY` → `NOT YOUR TURN` (plain English, can't be misread as "the system is busy").
- **UI/UX M1:** Force-Advance restored to outline-only + bold so hierarchy with END SESSION holds.
- **UI/UX M2:** `aria-label` em-dash → comma (natural AT pause).
- **UI/UX L1:** `aria-label` on disabled MarkReady mirrors `disabledLabel + disabledReason`.
- **UI/UX L2:** `hover:bg-warn/30` → `hover:bg-warn-bg` for consistency.
- **Prompt expert:** NO-OP (no LLM-facing strings touched).

## Deferred (tracked separately, see issue #63 closing keywords intentionally omitted)

- **Security HIGH (pre-existing).** `request_force_advance` is gated by `require_participant` server-side, not `require_creator`. Hiding the button is UX, not the security boundary — a player can still re-craft the WS frame. Not introduced here; should land as its own backend gate change.
- **User-persona C1.** Without the player-side Force-Advance, a player whose creator stepped away has no in-app recourse for a stuck AI. Deliberately removed per the user's ask; should land as a stuck-session "ask your facilitator" hint after N seconds of `AI_PROCESSING` with no token churn.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test -- --run` — 532 / 532 frontend tests pass
- [ ] Manual smoke: player view at 1080p — composer header is gone, ESCAPE HATCHES not rendered, "NOT YOUR TURN" shows on disabled rail button when off-active-set
- [ ] Manual smoke: creator view at 1080p — BottomActionBar "FORCE-ADVANCE TURN →" stands out next to the gray telemetry, hierarchy with red END SESSION holds
- [ ] Manual smoke: VoiceOver / NVDA — composer announces "Composer, Your turn" / "Composer, Add a comment"; disabled MarkReady announces "NOT YOUR TURN — You aren't on the active turn — Mark Ready isn't your call this beat."

Diff is purely frontend; no backend / LLM-prompt / scenario JSON paths touched, so live tests + scenario update are out of scope per the CLAUDE.md carve-out.

https://claude.ai/code/session_01Bvcp2JvVHc4g3Zq7rnmw6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bvcp2JvVHc4g3Zq7rnmw6p)_