### PR TITLE
backend: gate force-advance on creator role

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1099,7 +1099,7 @@ def register_api_routes(app: FastAPI) -> None:
         manager = _manager(request)
         token = await _bind_token(request, session_id)
         try:
-            require_participant(token)
+            require_creator(token)
             await manager.force_advance(session_id=session_id, by_role_id=token["role_id"])
         except AuthorizationError as exc:
             raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -1356,6 +1356,22 @@ class SessionManager:
         # second call between our check and the state mutation,
         # producing the very race we're guarding against.
         async with await self._lock_for(session_id):
+            session = await self._repo.get(session_id)
+            # Creator-only gate (issue #215). Mirrors the equivalent
+            # check in ``end_session`` so the wire contract matches the
+            # UI contract: PR #214 removed the player-facing button, so
+            # any non-creator caller is either a buggy client or a
+            # probe and we surface it in the audit log.
+            if session.creator_role_id != by_role_id:
+                _logger.warning(
+                    "force_advance_unauthorized",
+                    session_id=session_id,
+                    by_role_id=by_role_id,
+                    creator_role_id=session.creator_role_id,
+                )
+                raise AuthorizationError(
+                    "only the creator can force-advance the session"
+                )
             in_flight = self._llm.in_flight_for(session_id)
             if any(c.tier == "play" for c in in_flight):
                 _logger.info(
@@ -1367,7 +1383,6 @@ class SessionManager:
                 raise IllegalTransitionError(
                     "AI is still processing — wait a few seconds before forcing advance"
                 )
-            session = await self._repo.get(session_id)
             turn = session.current_turn
             if turn is None:
                 raise IllegalTransitionError("nothing to force-advance")

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -8,7 +8,7 @@ from typing import Any
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, status
 
 from ..auth.authn import HMACAuthenticator, InvalidTokenError, ParticipantKindLiteral
-from ..auth.authz import AuthorizationError, require_participant
+from ..auth.authz import AuthorizationError, require_creator, require_participant
 from ..config import Settings
 from ..logging_setup import bind_session_context, clear_session_context, get_logger
 from ..sessions.manager import SessionManager
@@ -764,6 +764,28 @@ async def _client_pump(
                                 session=session, turn=turn, for_role_id=role_id
                             )
             elif event_type == "request_force_advance":
+                # Creator-only admin action (issue #215). The UI hides the
+                # button on player views (PR #214); this gate enforces the
+                # same contract on the wire so a player can't bypass via a
+                # hand-crafted WS frame. The manager re-checks the same
+                # invariant inside the lock as defense-in-depth.
+                try:
+                    require_creator(token_payload)
+                except AuthorizationError as exc:
+                    _logger.warning(
+                        "ws_force_advance_unauthorized",
+                        session_id=session_id,
+                        by_role_id=role_id,
+                        kind=token_payload["kind"],
+                    )
+                    await websocket.send_json(
+                        {
+                            "type": "error",
+                            "scope": "force_advance",
+                            "message": str(exc),
+                        }
+                    )
+                    continue
                 try:
                     await manager.force_advance(
                         session_id=session_id, by_role_id=role_id
@@ -774,6 +796,10 @@ async def _client_pump(
                         await TurnDriver(manager=manager).run_play_turn(
                             session=session, turn=turn
                         )
+                except AuthorizationError as exc:
+                    await websocket.send_json(
+                        {"type": "error", "scope": "force_advance", "message": str(exc)}
+                    )
                 except IllegalTransitionError as exc:
                     await websocket.send_json(
                         {"type": "error", "scope": "force_advance", "message": str(exc)}

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -462,8 +462,15 @@ def test_plan_not_revealed_to_non_creator(client: TestClient) -> None:
     assert other_view["cost"] is None, "non-creator must not see the cost meter"
 
 
-def test_force_advance_from_any_participant(client: TestClient) -> None:
-    """Acceptance gate: any seated participant can force-advance a stalled turn."""
+def test_force_advance_creator_only(client: TestClient) -> None:
+    """Issue #215: only the creator can force-advance.
+
+    PR #214 hid the player-facing button; this gate enforces the same
+    contract on the wire so a player can't bypass via curl or a
+    hand-crafted WS frame. The creator-only check is duplicated at the
+    REST gate (``require_creator``) and inside ``manager.force_advance``
+    (defense in depth).
+    """
 
     seats = _create_and_seat(client, role_count=3)
     _install_mock_and_drive(
@@ -481,9 +488,19 @@ def test_force_advance_from_any_participant(client: TestClient) -> None:
     if snap["state"] != "AWAITING_PLAYERS":
         pytest.skip("first AI turn did not yield to players (mock variance)")
 
-    # Non-creator force-advances — should be allowed.
+    # Non-creator force-advance — rejected with 403.
     r = client.post(
         f"/api/sessions/{sid}/force-advance?token={non_creator}"
+    )
+    assert r.status_code == 403, r.text
+
+    # Session state is unchanged.
+    snap = client.get(f"/api/sessions/{sid}?token={cr}").json()
+    assert snap["state"] == "AWAITING_PLAYERS"
+
+    # Creator force-advance — allowed.
+    r = client.post(
+        f"/api/sessions/{sid}/force-advance?token={cr}"
     )
     assert r.status_code == 200, r.text
 

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -115,6 +115,103 @@ def test_force_advance_rejects_while_play_tier_call_in_flight(client: TestClient
             llm._in_flight.pop(seats["sid"], None)
 
 
+def test_force_advance_rejects_non_creator_at_manager(
+    client: TestClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #215: defense-in-depth at the manager layer — even if a
+    non-creator slips past the route gate, ``force_advance`` must reject
+    them with ``AuthorizationError`` and emit a warning audit line.
+    structlog is configured with ``PrintLoggerFactory`` so log output
+    lands on stdout; ``capsys`` is the matching capture mechanism."""
+
+    import asyncio
+
+    from app.auth.authz import AuthorizationError
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(f"/api/sessions/{seats['sid']}?token={seats['creator_token']}").json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+
+    manager = client.app.state.manager
+
+    async def _call_as_player() -> None:
+        await manager.force_advance(
+            session_id=seats["sid"], by_role_id=seats["other_role_id"]
+        )
+
+    # Drain stdout buffered up to this point so we only assert against
+    # the warning emitted inside the rejected call.
+    capsys.readouterr()
+    with pytest.raises(AuthorizationError, match="only the creator"):
+        asyncio.run(_call_as_player())
+    captured = capsys.readouterr().out
+    assert "force_advance_unauthorized" in captured, captured
+    assert seats["sid"] in captured
+    assert seats["other_role_id"] in captured
+    assert seats["creator_role_id"] in captured
+
+    # State unchanged.
+    snap2 = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['creator_token']}"
+    ).json()
+    assert snap2["state"] == "AWAITING_PLAYERS"
+
+
+def test_force_advance_rest_rejects_player_with_403(client: TestClient) -> None:
+    """Issue #215: REST gate — a player token must get 403, not 200."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(f"/api/sessions/{seats['sid']}?token={seats['creator_token']}").json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+
+    r = client.post(
+        f"/api/sessions/{seats['sid']}/force-advance?token={seats['other_token']}"
+    )
+    assert r.status_code == 403, r.text
+
+    # State unchanged — a buggy route that 403's AND mutates would slip
+    # through without this check (QA review LOW-2).
+    snap2 = client.get(
+        f"/api/sessions/{seats['sid']}?token={seats['creator_token']}"
+    ).json()
+    assert snap2["state"] == "AWAITING_PLAYERS"
+
+
+def test_force_advance_ws_rejects_player_with_error_frame(client: TestClient) -> None:
+    """Issue #215: WS gate — a player frame must surface an error frame
+    (scope=force_advance) and not mutate session state."""
+
+    seats = _seat_two(client)
+    _drive_to_play(client, seats)
+    snap = client.get(f"/api/sessions/{seats['sid']}?token={seats['creator_token']}").json()
+    if snap["state"] != "AWAITING_PLAYERS":
+        pytest.skip("scripted setup did not yield to players")
+
+    sid = seats["sid"]
+    ptok = seats["other_token"]
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={ptok}") as ws:
+        ws.send_json({"type": "request_force_advance"})
+        saw_rejection = False
+        for _ in range(64):
+            try:
+                evt = ws.receive_json()
+            except Exception:
+                break
+            if evt.get("type") == "error" and evt.get("scope") == "force_advance":
+                saw_rejection = True
+                break
+        assert saw_rejection, "player must be rejected on request_force_advance"
+
+    # State unchanged.
+    snap2 = client.get(f"/api/sessions/{sid}?token={seats['creator_token']}").json()
+    assert snap2["state"] == "AWAITING_PLAYERS"
+
+
 def test_force_advance_allowed_with_only_non_play_calls_in_flight(
     client: TestClient,
 ) -> None:

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -194,18 +194,33 @@ def test_force_advance_ws_rejects_player_with_error_frame(client: TestClient) ->
     sid = seats["sid"]
     ptok = seats["other_token"]
 
-    with client.websocket_connect(f"/ws/sessions/{sid}?token={ptok}") as ws:
-        ws.send_json({"type": "request_force_advance"})
-        saw_rejection = False
+    import concurrent.futures
+
+    from starlette.websockets import WebSocketDisconnect
+
+    def _wait_for_rejection(ws_local: Any) -> dict[str, Any] | None:
         for _ in range(64):
             try:
-                evt = ws.receive_json()
-            except Exception:
-                break
+                evt = ws_local.receive_json()
+            except WebSocketDisconnect:
+                return None
             if evt.get("type") == "error" and evt.get("scope") == "force_advance":
-                saw_rejection = True
-                break
-        assert saw_rejection, "player must be rejected on request_force_advance"
+                return evt
+        return None
+
+    with client.websocket_connect(f"/ws/sessions/{sid}?token={ptok}") as ws:
+        ws.send_json({"type": "request_force_advance"})
+        # Bounded wait (Copilot review on PR #217): if a future
+        # regression breaks the error-frame emission, fail fast in
+        # CI rather than stalling the whole suite. starlette's
+        # ``BlockingPortal`` makes the WS receive thread-safe.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            fut = ex.submit(_wait_for_rejection, ws)
+            try:
+                result = fut.result(timeout=5.0)
+            except concurrent.futures.TimeoutError:
+                pytest.fail("WS did not emit a force_advance error frame within 5s")
+        assert result is not None, "player must be rejected on request_force_advance"
 
     # State unchanged.
     snap2 = client.get(f"/api/sessions/{sid}?token={seats['creator_token']}").json()


### PR DESCRIPTION
## Summary

Closes #215.

PR #214 removed the player-facing Force-Advance button so the affordance only renders on the creator's `BottomActionBar`. The UI contract became "force-advance is a creator admin action," but the wire stayed `require_participant` — a player could still craft the WS frame `{"type":"request_force_advance"}` or hit the REST endpoint with their own token and nudge the AI past a turn the room hadn't agreed to advance.

This narrows the wire to match the UI, with defense-in-depth at the manager layer.

- `backend/app/ws/routes.py` — explicit `require_creator(token_payload)` inside the `request_force_advance` branch; on rejection, emits `ws_force_advance_unauthorized` and an `{type:"error", scope:"force_advance"}` frame.
- `backend/app/api/routes.py` — `require_participant` → `require_creator` on `POST /api/sessions/{id}/force-advance`. `AuthorizationError` already maps to 403 via the existing handler.
- `backend/app/sessions/manager.py` — creator gate inside `force_advance`, raising `AuthorizationError("only the creator can force-advance the session")` and logging `force_advance_unauthorized` with `session_id`, `by_role_id`, `creator_role_id`. Runs **inside** the per-session lock so a concurrent creator-transfer can't race; runs **before** the in-flight-LLM check so authz precedes resource state.

## Test plan

- [x] `tests/test_session_manager.py::test_force_advance_rejects_non_creator_at_manager` — manager raises `AuthorizationError`, emits the audit line (asserted via `capsys` since structlog uses `PrintLoggerFactory`), state unchanged.
- [x] `tests/test_session_manager.py::test_force_advance_rest_rejects_player_with_403` — REST 403 + state unchanged.
- [x] `tests/test_session_manager.py::test_force_advance_ws_rejects_player_with_error_frame` — WS error frame + state unchanged.
- [x] `tests/test_e2e_session.py::test_force_advance_creator_only` — inverted from `test_force_advance_from_any_participant`; asserts non-creator → 403, creator → 200.
- [x] Backend test suite (`pytest tests/ --ignore=tests/live --ignore=tests/scenarios`): 928 passed, 8 skipped.
- [x] Scenarios: 25 passed.
- [x] `ruff check` + `mypy app`: clean.
- [x] `tests/test_kick_regression.py::test_kicked_token_cannot_force_advance_via_websocket` still passes (kicked token rejected by `_role_still_authorized` before reaching the new creator gate).

## Sub-agent reviews

Six in parallel (QA / Security / UI/UX / Product / User-persona / Prompt-expert). No BLOCK / CRITICAL / HIGH. Addressed: QA LOW-2 (added state-unchanged assertion to the REST test). Deferred: Security MEDIUM-1 — `end_session` shape divergence (`IllegalTransitionError` + REST `require_participant`); out of scope for #215, worth a follow-up issue.

https://claude.ai/code/session_014J2sbLJrGmoFgpxTSVFDqe

---
_Generated by [Claude Code](https://claude.ai/code/session_014J2sbLJrGmoFgpxTSVFDqe)_