### PR TITLE
backend+frontend: surface upstream Anthropic outages to creator (#191)

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -40,6 +40,7 @@ from ._shared import (
     with_message_cache,
     with_system_cache,
 )
+from .errors import classify_upstream_error
 from .protocol import ChatClient, LLMResult
 
 if TYPE_CHECKING:
@@ -264,6 +265,19 @@ class LLMClient(ChatClient):
                 duration_ms=int((time.monotonic() - started) * 1000),
                 error=str(exc),
             )
+            classified = classify_upstream_error(exc)
+            if classified is not None:
+                _logger.warning(
+                    "upstream_llm_error",
+                    audit_kind="upstream_llm_error",
+                    tier=tier,
+                    model=model,
+                    category=classified.category,
+                    status_code=classified.status_code,
+                    request_id=classified.request_id,
+                    retry_hint_seconds=classified.retry_hint_seconds,
+                )
+                raise classified from exc
             raise
         finally:
             self._end_call(session_id, call)
@@ -416,6 +430,20 @@ class LLMClient(ChatClient):
                     stream=True,
                     error=str(exc),
                 )
+                classified = classify_upstream_error(exc)
+                if classified is not None:
+                    _logger.warning(
+                        "upstream_llm_error",
+                        audit_kind="upstream_llm_error",
+                        tier=tier,
+                        model=model,
+                        stream=True,
+                        category=classified.category,
+                        status_code=classified.status_code,
+                        request_id=classified.request_id,
+                        retry_hint_seconds=classified.retry_hint_seconds,
+                    )
+                    raise classified from exc
                 raise
         finally:
             self._end_call(session_id, call)

--- a/backend/app/llm/clients/litellm_client.py
+++ b/backend/app/llm/clients/litellm_client.py
@@ -50,6 +50,7 @@ from .._shared import (
     with_message_cache,
     with_system_cache,
 )
+from ..errors import classify_upstream_error
 from ..protocol import ChatClient, LLMResult
 
 if TYPE_CHECKING:
@@ -821,6 +822,19 @@ class LiteLLMChatClient(ChatClient):
                 duration_ms=int((time.monotonic() - started) * 1000),
                 error=str(exc),
             )
+            classified = classify_upstream_error(exc)
+            if classified is not None:
+                _logger.warning(
+                    "upstream_llm_error",
+                    audit_kind="upstream_llm_error",
+                    tier=tier,
+                    model=wire_model,
+                    category=classified.category,
+                    status_code=classified.status_code,
+                    request_id=classified.request_id,
+                    retry_hint_seconds=classified.retry_hint_seconds,
+                )
+                raise classified from exc
             raise
         finally:
             self._end_call(session_id, call)
@@ -1009,6 +1023,20 @@ class LiteLLMChatClient(ChatClient):
                     stream=True,
                     error=str(exc),
                 )
+                classified = classify_upstream_error(exc)
+                if classified is not None:
+                    _logger.warning(
+                        "upstream_llm_error",
+                        audit_kind="upstream_llm_error",
+                        tier=tier,
+                        model=wire_model,
+                        stream=True,
+                        category=classified.category,
+                        status_code=classified.status_code,
+                        request_id=classified.request_id,
+                        retry_hint_seconds=classified.retry_hint_seconds,
+                    )
+                    raise classified from exc
                 raise
         finally:
             self._end_call(session_id, call)

--- a/backend/app/llm/errors.py
+++ b/backend/app/llm/errors.py
@@ -1,0 +1,247 @@
+"""Structured upstream-LLM error classification (issue #191).
+
+When the LLM provider returns a transient infrastructure error
+(``529 OverloadedError``, ``5xx``, sustained ``429`` rate-limit, or a
+connection / timeout fault) the SDK's built-in retries can't always
+recover within a turn. The exception then propagates up through
+``ChatClient.acomplete`` / ``astream`` and the turn ends in
+``errored`` status with the generic copy "AI failed to yield." That
+copy implies an app-side bug; the right operator response is
+"wait 30-60 s and retry."
+
+This module classifies the SDK exception into a category the WS
+event + frontend banner can key on, so the creator sees an
+actionable banner (with a status-page link) instead of generic copy.
+The category set is identical across both supported backends
+(Anthropic-direct and LiteLLM-routed) — both SDKs expose parallel
+exception hierarchies (``APIError`` / ``APIConnectionError`` /
+``APITimeoutError`` / ``RateLimitError`` / ``InternalServerError``)
+with the same ``status_code`` / ``request_id`` / ``response.headers``
+attributes, so a single duck-typed classifier works for both.
+
+Out of scope (see issue #191): app-level retry beyond what the SDK
+already does — masking the operator's awareness of the outage and
+burning cost on a known-down service is exactly what we don't want.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+UpstreamCategory = Literal[
+    "overloaded",
+    "rate_limited",
+    "server_error",
+    "timeout",
+    "unknown",
+]
+
+
+class UpstreamLLMError(Exception):
+    """LLM provider returned a non-recoverable upstream error after SDK retries.
+
+    Carries enough structured detail for the WS-event broadcaster to
+    populate a creator-facing banner ("Anthropic API is currently
+    overloaded …") with a status-page link, and for an operator
+    paging through logs to grab the provider-side trace id.
+    """
+
+    def __init__(
+        self,
+        *,
+        category: UpstreamCategory,
+        status_code: int | None,
+        request_id: str | None,
+        retry_hint_seconds: int | None,
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.category: UpstreamCategory = category
+        self.status_code = status_code
+        self.request_id = request_id
+        self.retry_hint_seconds = retry_hint_seconds
+        self.message = message
+
+    def to_event_payload(self) -> dict[str, Any]:
+        """Serialise into the ``{type: "error", scope: "upstream_llm", …}``
+        WS event shape consumed by ``frontend/src/pages/Facilitator.tsx``.
+
+        ``self.message`` (the raw SDK ``str(exc)``) is intentionally
+        excluded: the frontend banner renders category-specific copy,
+        not the raw provider string, and exposing the SDK's exception
+        message would surface internal hostnames on a misconfigured
+        ``LLM_API_BASE`` deploy. The ``upstream_llm_error`` log line
+        already preserves the raw message for ops.
+        """
+
+        return {
+            "type": "error",
+            "scope": "upstream_llm",
+            "category": self.category,
+            "status_code": self.status_code,
+            "request_id": self.request_id,
+            "retry_hint_seconds": self.retry_hint_seconds,
+        }
+
+
+def _parse_retry_after(exc: Any) -> int | None:
+    """Extract ``Retry-After`` (in seconds) from the SDK exception's
+    response headers. The header may be a number-of-seconds, an HTTP
+    date, or absent. We only honor the integer form — date parsing
+    isn't worth the complexity for a UX hint and we default to None
+    on anything we can't trivially read."""
+
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        raw = headers.get("retry-after")
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if not raw:
+        return None
+    try:
+        n = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if n < 0:
+        return None
+    # Cap at 1 hour. Anything larger almost certainly means the header
+    # is an HTTP date that int() somehow consumed; clamp to a sane
+    # ceiling so the frontend never shows "retry in 1700000000 seconds".
+    return min(n, 3600)
+
+
+def classify_upstream_error(exc: BaseException) -> UpstreamLLMError | None:
+    """Classify an SDK exception into ``UpstreamLLMError``, or return
+    ``None`` if the exception is not an upstream-provider issue.
+
+    Both ``anthropic`` and ``litellm`` are required runtime deps in
+    this project (see ``backend/pyproject.toml``); imports are
+    unconditional. The classifier checks the litellm hierarchy first
+    only because LiteLLM's ``RateLimitError`` is a subclass of its
+    own ``APIStatusError`` which is *not* a subclass of Anthropic's —
+    keeping the order deterministic avoids surprises if an exception
+    happens to satisfy both isinstance checks (it doesn't today).
+
+    Returning ``None`` means the caller should re-raise the original
+    exception unchanged — it's an app-side bug or a non-LLM error,
+    not an upstream-provider blip.
+    """
+
+    import anthropic
+    from litellm.exceptions import (
+        APIConnectionError as LiteLLMAPIConnectionError,
+    )
+    from litellm.exceptions import (
+        InternalServerError as LiteLLMInternalServerError,
+    )
+    from litellm.exceptions import (
+        RateLimitError as LiteLLMRateLimitError,
+    )
+    from litellm.exceptions import (
+        Timeout as LiteLLMTimeout,
+    )
+
+    # Connection / timeout errors first — they have no ``status_code``.
+    # The user-visible category is ``timeout`` for both flavors;
+    # operationally indistinguishable from the operator's perspective
+    # (the call didn't reach the provider, retry in a moment).
+    if isinstance(
+        exc,
+        (
+            anthropic.APITimeoutError,
+            anthropic.APIConnectionError,
+            LiteLLMTimeout,
+            LiteLLMAPIConnectionError,
+        ),
+    ):
+        return UpstreamLLMError(
+            category="timeout",
+            status_code=None,
+            request_id=getattr(exc, "request_id", None),
+            retry_hint_seconds=None,
+            message=str(exc) or type(exc).__name__,
+        )
+
+    # Status-coded errors. The duck-typed ``status_code`` attribute is
+    # present on both SDKs' ``APIStatusError`` subclasses.
+    status_code: int | None = None
+    raw_sc = getattr(exc, "status_code", None)
+    if isinstance(raw_sc, int):
+        status_code = raw_sc
+
+    is_rate_limit = isinstance(
+        exc, (anthropic.RateLimitError, LiteLLMRateLimitError)
+    )
+    is_server_error = isinstance(
+        exc, (anthropic.InternalServerError, LiteLLMInternalServerError)
+    )
+
+    if not (is_rate_limit or is_server_error or (status_code and 500 <= status_code < 600)):
+        # Not an upstream-provider issue we know how to surface.
+        # ``BadRequestError`` / ``AuthenticationError`` /
+        # ``PermissionDeniedError`` etc are app-side bugs; the existing
+        # ``llm_call_failed`` log + propagation is the right behavior.
+        return None
+
+    request_id = getattr(exc, "request_id", None)
+    retry_hint = _parse_retry_after(exc)
+
+    if is_rate_limit:
+        category: UpstreamCategory = "rate_limited"
+    elif status_code == 529:
+        # Anthropic's documented overloaded-error code. Both SDKs
+        # surface 529 as ``InternalServerError`` (no dedicated
+        # ``OverloadedError`` class on either side).
+        category = "overloaded"
+    else:
+        category = "server_error"
+
+    return UpstreamLLMError(
+        category=category,
+        status_code=status_code,
+        request_id=request_id,
+        retry_hint_seconds=retry_hint,
+        message=str(exc) or type(exc).__name__,
+    )
+
+
+async def notify_creator_of_upstream_error(
+    *,
+    connections: Any,
+    session: Any,
+    err: UpstreamLLMError,
+) -> None:
+    """Push the structured upstream-error event to the creator only.
+
+    Players are intentionally excluded — the creator owns the retry
+    decision (Force-advance / Retry); a banner on the player side
+    implies an action they can't take. Players continue to see "AI is
+    thinking" until the creator acts.
+
+    Silently no-ops when ``session.creator_role_id`` is unset (early
+    setup, before the creator role exists) — the operator will still
+    get the LLM-client-side WARNING with the request_id.
+    """
+
+    creator_role_id = getattr(session, "creator_role_id", None)
+    if not creator_role_id:
+        return
+    session_id = getattr(session, "id", None)
+    if not session_id:
+        return
+    await connections.send_to_role(
+        session_id, creator_role_id, err.to_event_payload()
+    )
+
+
+__all__ = [
+    "UpstreamCategory",
+    "UpstreamLLMError",
+    "classify_upstream_error",
+    "notify_creator_of_upstream_error",
+]

--- a/backend/app/llm/errors.py
+++ b/backend/app/llm/errors.py
@@ -62,6 +62,31 @@ class UpstreamLLMError(Exception):
         self.retry_hint_seconds = retry_hint_seconds
         self.message = message
 
+    def sanitized_summary(self) -> str:
+        """Return a UI-safe summary string suitable for persisting on
+        operator-visible session fields (``turn.error_reason``,
+        ``session.aar_error``) that leak through ``/activity`` /
+        ``/export.md`` / ``SessionActivityPanel``.
+
+        Drops ``self.message`` (the raw ``str(exc)``) for the same
+        reason ``to_event_payload`` does — Anthropic's
+        ``APIConnectionError`` carries the resolved hostname in its
+        message, which on a misconfigured ``LLM_API_BASE`` deploy
+        leaks an internal gateway URL into the creator UI. Keep raw
+        details on the ``upstream_llm_error`` log line for ops; UI
+        surfaces get the structured summary only.
+        """
+
+        bits = [f"upstream_{self.category}"]
+        meta: list[str] = []
+        if self.status_code is not None:
+            meta.append(f"status={self.status_code}")
+        if self.request_id:
+            meta.append(f"req={self.request_id}")
+        if meta:
+            bits.append("(" + " ".join(meta) + ")")
+        return " ".join(bits)
+
     def to_event_payload(self) -> dict[str, Any]:
         """Serialise into the ``{type: "error", scope: "upstream_llm", …}``
         WS event shape consumed by ``frontend/src/pages/Facilitator.tsx``.

--- a/backend/app/llm/guardrail.py
+++ b/backend/app/llm/guardrail.py
@@ -45,6 +45,14 @@ class InputGuardrail:
                 # Per-tier default from settings.max_tokens_for("guardrail").
             )
         except Exception as exc:  # fall open
+            # Includes ``UpstreamLLMError`` (issue #191) — guardrail is
+            # a side-channel classifier; falling open silently is the
+            # documented behavior and surfacing a banner here would
+            # confuse a creator whose message went through fine. The
+            # next play-turn / setup-turn / AAR call surfaces the
+            # banner if the upstream is still down. The LLM client
+            # already logs ``upstream_llm_error`` at WARNING with the
+            # provider request_id, so ops still has the trace ID.
             _logger.warning("guardrail_classifier_failed", error=str(exc))
             return "on_topic"
 

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -1872,6 +1872,7 @@ class SessionManager:
         task.add_done_callback(self._bg_tasks.discard)
 
     async def _generate_aar_bg(self, session_id: str) -> None:
+        from ..llm.errors import UpstreamLLMError, notify_creator_of_upstream_error
         from ..llm.export import AARGenerator
 
         async with await self._lock_for(session_id):
@@ -1904,6 +1905,44 @@ class SessionManager:
         try:
             generator = AARGenerator(llm=self._llm, audit=self._audit)
             markdown, report = await generator.generate(target)
+        except UpstreamLLMError as upstream_exc:
+            # Issue #191 — AAR pipeline upstream blip. Surface the
+            # banner to the creator with the status-page link before
+            # falling through to the regular ``failed`` path so the
+            # operator knows it's an upstream issue (and that
+            # re-triggering AAR generation in a minute will likely
+            # succeed) rather than a Crittable bug.
+            await notify_creator_of_upstream_error(
+                connections=self._connections,
+                session=target,
+                err=upstream_exc,
+            )
+            _logger.exception(
+                "aar_generation_failed",
+                session_id=session_id,
+                error=str(upstream_exc),
+                upstream_category=upstream_exc.category,
+            )
+            async with await self._lock_for(session_id):
+                try:
+                    session = await self._repo.get(session_id)
+                except Exception as repo_exc:
+                    _logger.warning(
+                        "aar_failure_persist_aborted_repo_get_failed",
+                        session_id=session_id,
+                        original_error=str(upstream_exc),
+                        repo_error=str(repo_exc),
+                    )
+                    return
+                session.aar_status = "failed"
+                session.aar_error = str(upstream_exc)[:500]
+                await self._repo.save(session)
+            self._emit("aar_failed", session, error=str(upstream_exc)[:500])
+            await self._connections.broadcast(
+                session_id, {"type": "aar_status_changed", "status": "failed"}
+            )
+            await self._broadcast_ai_status(session_id, phase=None)
+            return
         except Exception as exc:
             _logger.exception("aar_generation_failed", session_id=session_id, error=str(exc))
             async with await self._lock_for(session_id):

--- a/backend/app/sessions/manager.py
+++ b/backend/app/sessions/manager.py
@@ -1935,9 +1935,19 @@ class SessionManager:
                     )
                     return
                 session.aar_status = "failed"
-                session.aar_error = str(upstream_exc)[:500]
+                # ``aar_error`` is read by /activity, /export.md (425/500
+                # body), and rendered in SessionActivityPanel — must
+                # NOT carry the raw SDK exception text (Copilot review
+                # on PR #219). The sanitized summary keeps category +
+                # status + request_id; the raw message stays on the
+                # ``upstream_llm_error`` log line for ops.
+                session.aar_error = upstream_exc.sanitized_summary()[:500]
                 await self._repo.save(session)
-            self._emit("aar_failed", session, error=str(upstream_exc)[:500])
+            # Audit payload's ``error`` field is creator-readable via
+            # /debug too; same sanitization rule applies.
+            self._emit(
+                "aar_failed", session, error=upstream_exc.sanitized_summary()
+            )
             await self._connections.broadcast(
                 session_id, {"type": "aar_status_changed", "status": "failed"}
             )

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -29,6 +29,7 @@ from typing import Any
 from ..auth.audit import AuditEvent
 from ..extensions.registry import FrozenRegistry
 from ..llm.dispatch import DispatchOutcome
+from ..llm.errors import UpstreamLLMError, notify_creator_of_upstream_error
 from ..llm.prompts import (
     build_play_system_blocks,
     build_setup_system_blocks,
@@ -284,32 +285,45 @@ class TurnDriver:
                 # is passed through unchanged so the bare-text guard
                 # below still applies.
                 result: LLMResult | None = None
-                async for evt in llm.astream(
-                    tier="setup",
-                    system_blocks=build_setup_system_blocks(
-                        session,
-                        workstreams_enabled=self._manager.settings().workstreams_enabled,
-                    ),
-                    messages=messages,
-                    tool_choice=tool_choice_for("setup"),
-                    tools=setup_tools_for(
-                        workstreams_enabled=self._manager.settings().workstreams_enabled
-                    ),
-                    # Per-tier default from settings.max_tokens_for(tier) — call passes None.
-                    session_id=session.id,
-                ):
-                    etype = evt.get("type")
-                    if etype == "tool_use_start":
-                        if (
-                            not saw_plan_tool
-                            and evt.get("name") == "propose_scenario_plan"
-                        ):
-                            saw_plan_tool = True
-                            await self._broadcast_setup_drafting_plan(
-                                session.id, active=True
-                            )
-                    elif etype == "complete":
-                        result = evt.get("result")
+                try:
+                    async for evt in llm.astream(
+                        tier="setup",
+                        system_blocks=build_setup_system_blocks(
+                            session,
+                            workstreams_enabled=self._manager.settings().workstreams_enabled,
+                        ),
+                        messages=messages,
+                        tool_choice=tool_choice_for("setup"),
+                        tools=setup_tools_for(
+                            workstreams_enabled=self._manager.settings().workstreams_enabled
+                        ),
+                        # Per-tier default from settings.max_tokens_for(tier) — call passes None.
+                        session_id=session.id,
+                    ):
+                        etype = evt.get("type")
+                        if etype == "tool_use_start":
+                            if (
+                                not saw_plan_tool
+                                and evt.get("name") == "propose_scenario_plan"
+                            ):
+                                saw_plan_tool = True
+                                await self._broadcast_setup_drafting_plan(
+                                    session.id, active=True
+                                )
+                        elif etype == "complete":
+                            result = evt.get("result")
+                except UpstreamLLMError as upstream_exc:
+                    # Issue #191 — surface upstream provider blips to the
+                    # creator with a status-page link rather than letting
+                    # the API handler 500 silently. Re-raise so the
+                    # request handler still returns 500; the banner just
+                    # gives the creator the right framing in real time.
+                    await notify_creator_of_upstream_error(
+                        connections=self._manager.connections(),
+                        session=session,
+                        err=upstream_exc,
+                    )
+                    raise
                 if result is None:
                     # ``astream`` is contracted to emit a terminal
                     # ``complete`` event carrying the LLMResult. Absent
@@ -579,15 +593,35 @@ class TurnDriver:
                     tools = PLAY_TOOLS + dispatcher_extension_specs(registry)
                     tool_choice = None
 
-                result = await self._streamed_play_call(
-                    session=session,
-                    turn=turn,
-                    tier="play",
-                    system_blocks=system_blocks,
-                    messages=messages,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                )
+                try:
+                    result = await self._streamed_play_call(
+                        session=session,
+                        turn=turn,
+                        tier="play",
+                        system_blocks=system_blocks,
+                        messages=messages,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                    )
+                except UpstreamLLMError as upstream_exc:
+                    # Issue #191 — Anthropic 529 / 5xx / sustained 429 /
+                    # connection timeout after the SDK's retries.
+                    # Mark the turn errored, broadcast the structured
+                    # banner to the creator (players keep seeing
+                    # "AI is thinking" — they can't act on the
+                    # outage), and bail out cleanly. The creator's
+                    # Force-advance / Retry path is unchanged.
+                    turn.status = "errored"
+                    turn.error_reason = (
+                        f"upstream_{upstream_exc.category}: "
+                        f"{upstream_exc.message}"
+                    )[:500]
+                    await notify_creator_of_upstream_error(
+                        connections=self._manager.connections(),
+                        session=session,
+                        err=upstream_exc,
+                    )
+                    return session
                 await self._apply_cost(session.id, result)
                 self._check_truncation(
                     session_id=session.id, tier="play", result=result, turn_id=turn.id
@@ -944,15 +978,29 @@ class TurnDriver:
             tools = [t for t in PLAY_TOOLS if t["name"] in allowed]
             tool_choice: dict[str, Any] = {"type": "any"}
 
-            result = await self._streamed_play_call(
-                session=session,
-                turn=turn,
-                tier="play",
-                system_blocks=system_blocks,
-                messages=messages,
-                tools=tools,
-                tool_choice=tool_choice,
-            )
+            try:
+                result = await self._streamed_play_call(
+                    session=session,
+                    turn=turn,
+                    tier="play",
+                    system_blocks=system_blocks,
+                    messages=messages,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                )
+            except UpstreamLLMError as upstream_exc:
+                # Issue #191 — interject path. Quietly bail out rather
+                # than wedging the session: state is still
+                # AWAITING_PLAYERS, the player's submission still
+                # counts toward the active turn, the creator just sees
+                # the upstream banner and knows why the @facilitator
+                # got no reply.
+                await notify_creator_of_upstream_error(
+                    connections=self._manager.connections(),
+                    session=session,
+                    err=upstream_exc,
+                )
+                return session
             await self._apply_cost(session.id, result)
 
             tool_uses = _tool_uses(result)

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -611,11 +611,17 @@ class TurnDriver:
                     # "AI is thinking" — they can't act on the
                     # outage), and bail out cleanly. The creator's
                     # Force-advance / Retry path is unchanged.
+                    #
+                    # ``error_reason`` is exposed via /activity and
+                    # rendered in SessionActivityPanel — must NOT
+                    # carry the raw SDK exception text (an
+                    # ``APIConnectionError`` message can include the
+                    # resolved internal-gateway hostname on a
+                    # misconfigured LLM_API_BASE deploy). Use the
+                    # sanitized summary; the raw message stays on the
+                    # ``upstream_llm_error`` log line.
                     turn.status = "errored"
-                    turn.error_reason = (
-                        f"upstream_{upstream_exc.category}: "
-                        f"{upstream_exc.message}"
-                    )[:500]
+                    turn.error_reason = upstream_exc.sanitized_summary()[:500]
                     await notify_creator_of_upstream_error(
                         connections=self._manager.connections(),
                         session=session,

--- a/backend/tests/test_upstream_llm_errors.py
+++ b/backend/tests/test_upstream_llm_errors.py
@@ -211,6 +211,44 @@ def test_retry_hint_non_numeric_is_dropped() -> None:
 # -------------------------------------------------------------- payload shape
 
 
+def test_sanitized_summary_excludes_raw_message() -> None:
+    """``sanitized_summary`` is what ``turn.error_reason`` and
+    ``session.aar_error`` are persisted as — both leak via
+    ``/activity`` / ``/export.md`` / ``SessionActivityPanel`` to the
+    creator UI. It MUST NOT carry the raw SDK exception string,
+    same security rationale as the WS payload (Copilot review on
+    PR #219). Format: ``upstream_<category> (status=N req=R)``."""
+
+    err = UpstreamLLMError(
+        category="overloaded",
+        status_code=529,
+        request_id="req_xyz",
+        retry_hint_seconds=None,
+        message="Connection error: HTTPSConnectionPool(host='internal-gw.corp', port=443)",
+    )
+    summary = err.sanitized_summary()
+    assert summary == "upstream_overloaded (status=529 req=req_xyz)"
+    # Defense-in-depth: the precise hostname format above is the
+    # canonical leak vector. Spot-check that nothing remotely
+    # exception-shaped survives the sanitization.
+    assert "internal-gw" not in summary
+    assert "HTTPSConnectionPool" not in summary
+
+
+def test_sanitized_summary_drops_optional_fields_cleanly() -> None:
+    """A timeout error (no status_code, no request_id) collapses to
+    just the category — no empty parens, no trailing whitespace."""
+
+    err = UpstreamLLMError(
+        category="timeout",
+        status_code=None,
+        request_id=None,
+        retry_hint_seconds=None,
+        message="Connection error.",
+    )
+    assert err.sanitized_summary() == "upstream_timeout"
+
+
 def test_event_payload_locks_wire_keys() -> None:
     """Pin the event payload exactly — frontend ``ws.ts`` ``ServerEvent``
     union asserts on these fields. Adding / renaming a key here is a
@@ -510,8 +548,17 @@ def test_play_turn_529_marks_errored_and_targets_creator_only() -> None:
     assert status_ == "errored", (
         f"expected turn.status='errored' on upstream blip; got {status_!r}"
     )
-    assert reason is not None and reason.startswith("upstream_overloaded:"), (
+    # Sanitized format: ``upstream_<category> (status=N req=...)``.
+    # Critically must NOT contain the raw SDK message — it leaks via
+    # /activity and SessionActivityPanel (Copilot review on PR #219).
+    assert reason is not None and reason.startswith("upstream_overloaded"), (
         f"expected upstream_overloaded prefix; got {reason!r}"
+    )
+    assert "Overloaded" not in reason, (
+        f"raw SDK exception text leaked into turn.error_reason: {reason!r}"
+    )
+    assert "req=req_int_test_529" in reason, (
+        f"expected request_id in sanitized reason; got {reason!r}"
     )
 
     # -------- assertion 2: the creator got the structured banner

--- a/backend/tests/test_upstream_llm_errors.py
+++ b/backend/tests/test_upstream_llm_errors.py
@@ -327,13 +327,246 @@ async def test_notify_no_creator_role_is_noop() -> None:
     assert conns.broadcasted == []
 
 
-# Future work (issue #191 follow-up): an end-to-end integration test
-# that simulates an Anthropic 529 mid-play-turn through the real
-# turn-driver and asserts the turn ends ``errored`` with the
-# ``upstream_overloaded:`` reason while the creator gets a
-# ``send_to_role`` and players get nothing on ``broadcast``. The
-# unit-level pieces (classifier, payload shape, notify helper) are
-# locked above; the integration weaves them together but takes a
-# nontrivial amount of FastAPI/TestClient scaffolding to drive a
-# play turn end-to-end. Punted to a follow-up rather than rushing a
-# brittle test.
+# -------------------------------------------------------------- integration
+
+
+def test_play_turn_529_marks_errored_and_targets_creator_only() -> None:
+    """End-to-end: an Anthropic 529 mid-play-turn must produce
+    (a) ``turn.status == "errored"`` with a ``upstream_overloaded:``
+    reason, (b) a creator-targeted ``send_to_role`` carrying the
+    structured banner event, and (c) NO ``broadcast`` of the banner
+    so players don't see it.
+
+    Pins the wiring contract that the unit tests above can't reach
+    on their own — the unit tests prove each piece works in
+    isolation; this test proves they're plugged in to each other
+    inside ``turn_driver.run_play_turn``. Without this, swapping
+    ``notify_creator_of_upstream_error`` for ``connections.broadcast``
+    in a future refactor would pass every unit test while leaking
+    the banner to every player (the explicit anti-requirement on
+    issue #191: "Players don't see the creator's error banner").
+
+    The test drives the BRIEFING turn (turn 0 fired at ``/start``)
+    with the erroring transport pre-installed — that's the cleanest
+    entry point because ``setup/skip`` synthesises a plan without an
+    LLM call, so the only LLM call is the one we're testing.
+    """
+
+    import anthropic
+    import httpx
+    from fastapi.testclient import TestClient
+
+    from app.config import reset_settings_cache
+    from app.main import create_app
+    from app.sessions.models import SessionState
+    from tests.conftest import default_settings_body
+    from tests.mock_anthropic import MockAnthropic
+
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        # Baseline mock so the server boots.
+        client.app.state.llm.set_transport(MockAnthropic({}).messages)
+
+        # Seat creator + one player.
+        resp = client.post(
+            "/api/sessions",
+            json={
+                "scenario_prompt": "Ransomware via vendor portal",
+                "creator_label": "CISO",
+                "creator_display_name": "Alex",
+                **default_settings_body(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        created = resp.json()
+        sid = created["session_id"]
+        creator_token = created["creator_token"]
+        creator_role_id = created["creator_role_id"]
+        r = client.post(
+            f"/api/sessions/{sid}/roles?token={creator_token}",
+            json={"label": "Player_1", "display_name": "P1"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Skip setup (no LLM call) → READY.
+        client.post(f"/api/sessions/{sid}/setup/skip?token={creator_token}")
+
+        # Wrap connections to observe role-targeted vs. broadcast
+        # event flow. Pattern lifted from
+        # ``tests/test_turn_driver.py::_RecordingConnections`` — a
+        # transparent proxy that records each call before delegating
+        # to the real connection manager so the rest of the system
+        # behaves identically.
+        real_connections = client.app.state.connections
+        rec_role_targeted: list[tuple[str, str, dict[str, Any]]] = []
+        rec_broadcasted: list[dict[str, Any]] = []
+
+        class _Observing:
+            async def broadcast(
+                self,
+                session_id: str,
+                event: dict[str, Any],
+                *,
+                record: bool = True,
+            ) -> None:
+                rec_broadcasted.append(event)
+                await real_connections.broadcast(
+                    session_id, event, record=record
+                )
+
+            async def send_to_role(
+                self, session_id: str, role_id: str, event: dict[str, Any]
+            ) -> None:
+                rec_role_targeted.append((session_id, role_id, event))
+                await real_connections.send_to_role(
+                    session_id, role_id, event
+                )
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(real_connections, name)
+
+        observer = _Observing()
+        client.app.state.connections = observer
+        client.app.state.manager._connections = observer
+        client.app.state.llm.set_connections(observer)
+
+        # Install an erroring transport. The play-turn driver streams
+        # the response; we have to raise on ``stream(...)``'s context
+        # manager + iterator surface specifically (the create-only
+        # path is for non-streamed calls). Raising on
+        # ``get_final_message`` covers the "stream connected but
+        # final message fetch errored" path too, which is what 529
+        # looks like in practice.
+        request = httpx.Request(
+            "POST", "https://api.anthropic.com/v1/messages"
+        )
+        response = httpx.Response(
+            529,
+            request=request,
+            headers={"request-id": "req_int_test_529"},
+        )
+
+        def _raise_overloaded() -> None:
+            raise anthropic.InternalServerError(
+                "Overloaded", response=response, body=None
+            )
+
+        class _ErrCtx:
+            async def __aenter__(self) -> Any:
+                return self
+
+            async def __aexit__(self, *exc: Any) -> None:
+                return None
+
+            def __aiter__(self) -> Any:
+                async def _gen() -> Any:
+                    _raise_overloaded()
+                    if False:  # pragma: no cover - unreachable
+                        yield None
+                return _gen()
+
+            async def get_final_message(self) -> Any:
+                _raise_overloaded()
+
+        class _ErroringMessages:
+            async def create(self, **kwargs: Any) -> Any:
+                _raise_overloaded()
+
+            def stream(self, **kwargs: Any) -> Any:
+                return _ErrCtx()
+
+        client.app.state.llm.set_transport(_ErroringMessages())
+
+        # Fire the BRIEFING turn. The route awaits ``run_play_turn``
+        # synchronously, so by the time the response lands the
+        # turn-driver's exception path has already run.
+        start_resp = client.post(
+            f"/api/sessions/{sid}/start?token={creator_token}"
+        )
+        # 200 is correct: the turn errored gracefully; the banner is
+        # the operator-visible signal, not the HTTP status. The route
+        # handler doesn't (and shouldn't) propagate an upstream blip
+        # as a 5xx — that'd hide the new structured signal behind a
+        # generic gateway-style error toast.
+        assert start_resp.status_code == 200, start_resp.text
+
+    # -------- assertion 1: turn flipped to "errored" with the
+    # upstream-prefixed reason. Read straight from the in-memory
+    # repo, not via REST, so we see the field as the driver wrote
+    # it before any serialiser round-trips it.
+    import asyncio
+
+    manager = client.app.state.manager
+
+    async def _read_turn_status() -> tuple[str, str | None]:
+        session = await manager._repo.get(sid)
+        # Snapshot just turn 0 — the BRIEFING turn the test drove.
+        turn = next((t for t in session.turns if t.index == 0), None)
+        assert turn is not None, "expected the BRIEFING turn (index 0)"
+        return turn.status, turn.error_reason
+
+    status_, reason = asyncio.run(_read_turn_status())
+    assert status_ == "errored", (
+        f"expected turn.status='errored' on upstream blip; got {status_!r}"
+    )
+    assert reason is not None and reason.startswith("upstream_overloaded:"), (
+        f"expected upstream_overloaded prefix; got {reason!r}"
+    )
+
+    # -------- assertion 2: the creator got the structured banner
+    # event via send_to_role.
+    creator_payloads = [
+        evt
+        for _sid, rid, evt in rec_role_targeted
+        if rid == creator_role_id
+        and evt.get("type") == "error"
+        and evt.get("scope") == "upstream_llm"
+    ]
+    assert len(creator_payloads) == 1, (
+        f"expected exactly one creator-targeted upstream_llm event; "
+        f"saw {len(creator_payloads)}: {rec_role_targeted!r}"
+    )
+    payload = creator_payloads[0]
+    assert payload["category"] == "overloaded"
+    assert payload["status_code"] == 529
+    assert payload["request_id"] == "req_int_test_529"
+    # Wire-shape lock: ``message`` MUST NOT be in the payload (the
+    # raw SDK string can leak ``LLM_API_BASE`` URLs on misconfigured
+    # deploys; banner copy is category-derived).
+    assert "message" not in payload, (
+        f"raw SDK message leaked to wire payload: {payload!r}"
+    )
+
+    # -------- assertion 3: NO broadcast carried the upstream banner.
+    # This is the user's explicit anti-requirement on issue #191
+    # ("regular players don't need to see it"). A future refactor
+    # that swaps ``send_to_role`` for ``broadcast`` here would fail
+    # this assertion specifically.
+    upstream_in_broadcast = [
+        e
+        for e in rec_broadcasted
+        if e.get("type") == "error" and e.get("scope") == "upstream_llm"
+    ]
+    assert upstream_in_broadcast == [], (
+        f"upstream_llm event leaked to broadcast (visible to players): "
+        f"{upstream_in_broadcast!r}"
+    )
+
+    # -------- assertion 4: the session state is consistent with an
+    # errored turn — neither wedged in AI_PROCESSING (the prior
+    # bug pattern) nor accidentally completed. The exact state may
+    # be ``BRIEFING`` (the turn errored before yielding so we never
+    # transitioned out) or ``AWAITING_PLAYERS`` if a future
+    # refactor opens the door for "errored turn → wait for player
+    # nudge". Either is acceptable; ``AI_PROCESSING`` is not.
+
+    async def _read_state() -> SessionState:
+        session = await manager._repo.get(sid)
+        return session.state
+
+    final_state = asyncio.run(_read_state())
+    assert final_state != SessionState.AI_PROCESSING, (
+        f"session wedged in AI_PROCESSING after upstream blip; "
+        f"got {final_state!r}"
+    )

--- a/backend/tests/test_upstream_llm_errors.py
+++ b/backend/tests/test_upstream_llm_errors.py
@@ -1,0 +1,339 @@
+"""Tests for the issue #191 upstream-error classification + broadcast path.
+
+Pins the wire shape the creator-side banner reads: any change to
+``UpstreamLLMError.to_event_payload`` is a breaking contract change vs.
+``frontend/src/lib/ws.ts``'s ``error`` event union.
+
+Three layers:
+
+1. **Classifier unit tests** (`classify_upstream_error`) — cover both
+   SDKs (anthropic, litellm) since both ChatClient backends route
+   through the same classifier.
+2. **Notify-creator broadcast** — verifies the banner is sent via
+   ``send_to_role`` to the creator only (players never receive it,
+   per issue #191 "Players don't see the creator's error banner").
+3. **Event payload shape** — locks the keys the frontend asserts on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anthropic
+import httpx
+import litellm
+import pytest
+
+from app.llm.errors import (
+    UpstreamLLMError,
+    classify_upstream_error,
+    notify_creator_of_upstream_error,
+)
+
+
+def _anthropic_status_error(
+    cls: type[anthropic.APIStatusError],
+    *,
+    status: int,
+    request_id: str | None = "req_test",
+    retry_after: str | None = None,
+) -> anthropic.APIStatusError:
+    headers: dict[str, str] = {}
+    if request_id is not None:
+        headers["request-id"] = request_id
+    if retry_after is not None:
+        headers["retry-after"] = retry_after
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status, request=request, headers=headers)
+    return cls("upstream", response=response, body=None)
+
+
+# -------------------------------------------------------------- classifier
+
+
+def test_classify_anthropic_overloaded_529() -> None:
+    """529 → ``overloaded`` (Anthropic-documented overloaded code)."""
+
+    exc = _anthropic_status_error(anthropic.InternalServerError, status=529)
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "overloaded"
+    assert classified.status_code == 529
+    assert classified.request_id == "req_test"
+    assert classified.retry_hint_seconds is None
+
+
+def test_classify_anthropic_rate_limit_with_retry_after() -> None:
+    """RateLimitError → ``rate_limited``; honors ``retry-after`` seconds."""
+
+    exc = _anthropic_status_error(
+        anthropic.RateLimitError, status=429, retry_after="42"
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "rate_limited"
+    assert classified.status_code == 429
+    assert classified.retry_hint_seconds == 42
+
+
+def test_classify_anthropic_internal_500() -> None:
+    """500 (non-529) → ``server_error``."""
+
+    exc = _anthropic_status_error(anthropic.InternalServerError, status=500)
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "server_error"
+    assert classified.status_code == 500
+
+
+def test_classify_anthropic_timeout() -> None:
+    """APITimeoutError → ``timeout`` with no status code."""
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    exc = anthropic.APITimeoutError(request=request)
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "timeout"
+    assert classified.status_code is None
+
+
+def test_classify_anthropic_connection_error() -> None:
+    """APIConnectionError → ``timeout`` (operationally indistinguishable)."""
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    exc = anthropic.APIConnectionError(request=request)
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "timeout"
+
+
+def test_classify_anthropic_bad_request_returns_none() -> None:
+    """400 BadRequestError is an app-side bug; classifier returns None
+    so the LLM client re-raises the original exception unchanged."""
+
+    exc = _anthropic_status_error(anthropic.BadRequestError, status=400)
+    assert classify_upstream_error(exc) is None
+
+
+def test_classify_anthropic_auth_returns_none() -> None:
+    """401 AuthenticationError is an operator-side misconfig (bad key);
+    not surfaced as an "upstream is overloaded" banner."""
+
+    exc = _anthropic_status_error(anthropic.AuthenticationError, status=401)
+    assert classify_upstream_error(exc) is None
+
+
+def test_classify_non_sdk_error_returns_none() -> None:
+    """Non-SDK exceptions (TypeError, ValueError) propagate unchanged."""
+
+    assert classify_upstream_error(ValueError("nope")) is None
+    assert classify_upstream_error(RuntimeError("boom")) is None
+
+
+def test_classify_litellm_rate_limit() -> None:
+    """LiteLLM-routed RateLimitError → ``rate_limited`` with status 429."""
+
+    exc = litellm.RateLimitError(
+        message="Rate limited",
+        llm_provider="anthropic",
+        model="claude-opus-4-7",
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "rate_limited"
+    assert classified.status_code == 429
+
+
+def test_classify_litellm_internal_server_error() -> None:
+    """LiteLLM InternalServerError (500) → ``server_error``."""
+
+    exc = litellm.InternalServerError(
+        message="500",
+        llm_provider="anthropic",
+        model="claude-opus-4-7",
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    # LiteLLM's InternalServerError defaults to 500. ``server_error``,
+    # not ``overloaded`` (529 is the only code that maps to overloaded).
+    assert classified.category == "server_error"
+
+
+def test_classify_litellm_timeout() -> None:
+    """LiteLLM Timeout (subclass of APITimeoutError) → ``timeout``."""
+
+    exc = litellm.Timeout(
+        message="timeout",
+        model="claude-opus-4-7",
+        llm_provider="anthropic",
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.category == "timeout"
+
+
+def test_retry_hint_clamped_to_one_hour() -> None:
+    """Defensive: an HTTP-date Retry-After that int() somehow consumed
+    as a huge number gets clamped, not surfaced as "retry in 1.7B s"."""
+
+    exc = _anthropic_status_error(
+        anthropic.RateLimitError, status=429, retry_after="9999999"
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.retry_hint_seconds == 3600
+
+
+def test_retry_hint_negative_is_dropped() -> None:
+    """A malformed negative ``retry-after`` is treated as absent."""
+
+    exc = _anthropic_status_error(
+        anthropic.RateLimitError, status=429, retry_after="-5"
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.retry_hint_seconds is None
+
+
+def test_retry_hint_non_numeric_is_dropped() -> None:
+    """An HTTP-date ``retry-after`` we can't trivially parse is None."""
+
+    exc = _anthropic_status_error(
+        anthropic.RateLimitError,
+        status=429,
+        retry_after="Wed, 21 Oct 2026 07:28:00 GMT",
+    )
+    classified = classify_upstream_error(exc)
+    assert classified is not None
+    assert classified.retry_hint_seconds is None
+
+
+# -------------------------------------------------------------- payload shape
+
+
+def test_event_payload_locks_wire_keys() -> None:
+    """Pin the event payload exactly — frontend ``ws.ts`` ``ServerEvent``
+    union asserts on these fields. Adding / renaming a key here is a
+    breaking contract change.
+
+    ``message`` is intentionally absent from the wire shape: the
+    banner renders category-specific copy, never the raw SDK
+    exception string. Surfacing ``str(exc)`` would leak the
+    operator's ``LLM_API_BASE`` (e.g. an internal gateway URL) in
+    connection-error messages on misconfigured deploys (security
+    review, 2026-05-09)."""
+
+    err = UpstreamLLMError(
+        category="overloaded",
+        status_code=529,
+        request_id="req_abc",
+        retry_hint_seconds=30,
+        message="Overloaded - this raw text must NOT be in the payload",
+    )
+    payload = err.to_event_payload()
+    assert payload == {
+        "type": "error",
+        "scope": "upstream_llm",
+        "category": "overloaded",
+        "status_code": 529,
+        "request_id": "req_abc",
+        "retry_hint_seconds": 30,
+    }
+    assert "message" not in payload, "raw SDK exception string must not leak"
+
+
+# -------------------------------------------------------------- broadcast
+
+
+class _RecordingConnections:
+    """Captures ``send_to_role`` and ``broadcast`` calls so tests can
+    assert that upstream-error banners are creator-targeted (issue
+    #191: "Players don't see the creator's error banner")."""
+
+    def __init__(self) -> None:
+        self.role_targeted: list[tuple[str, str, dict[str, Any]]] = []
+        self.broadcasted: list[tuple[str, dict[str, Any]]] = []
+
+    async def send_to_role(
+        self, session_id: str, role_id: str, event: dict[str, Any]
+    ) -> None:
+        self.role_targeted.append((session_id, role_id, event))
+
+    async def broadcast(
+        self,
+        session_id: str,
+        event: dict[str, Any],
+        *,
+        record: bool = True,
+    ) -> None:
+        self.broadcasted.append((session_id, event))
+
+
+class _FakeSession:
+    def __init__(self, *, session_id: str, creator_role_id: str | None) -> None:
+        self.id = session_id
+        self.creator_role_id = creator_role_id
+
+
+@pytest.mark.asyncio
+async def test_notify_creator_targets_creator_role_only() -> None:
+    """The banner goes to the creator via ``send_to_role`` — players
+    never receive it. ``broadcast`` is NOT called."""
+
+    conns = _RecordingConnections()
+    session = _FakeSession(session_id="s1", creator_role_id="role_creator")
+    err = UpstreamLLMError(
+        category="overloaded",
+        status_code=529,
+        request_id="req_abc",
+        retry_hint_seconds=None,
+        message="Overloaded",
+    )
+
+    await notify_creator_of_upstream_error(
+        connections=conns, session=session, err=err
+    )
+
+    assert conns.broadcasted == []
+    assert len(conns.role_targeted) == 1
+    sid, rid, payload = conns.role_targeted[0]
+    assert sid == "s1"
+    assert rid == "role_creator"
+    assert payload["scope"] == "upstream_llm"
+    assert payload["category"] == "overloaded"
+
+
+@pytest.mark.asyncio
+async def test_notify_no_creator_role_is_noop() -> None:
+    """Pre-creator-role sessions (very early setup) silently no-op
+    rather than blowing up. The LLM-client-side WARNING already
+    captures the request_id for ops."""
+
+    conns = _RecordingConnections()
+    session = _FakeSession(session_id="s1", creator_role_id=None)
+    err = UpstreamLLMError(
+        category="server_error",
+        status_code=500,
+        request_id=None,
+        retry_hint_seconds=None,
+        message="x",
+    )
+
+    await notify_creator_of_upstream_error(
+        connections=conns, session=session, err=err
+    )
+
+    assert conns.role_targeted == []
+    assert conns.broadcasted == []
+
+
+# Future work (issue #191 follow-up): an end-to-end integration test
+# that simulates an Anthropic 529 mid-play-turn through the real
+# turn-driver and asserts the turn ends ``errored`` with the
+# ``upstream_overloaded:`` reason while the creator gets a
+# ``send_to_role`` and players get nothing on ``broadcast``. The
+# unit-level pieces (classifier, payload shape, notify helper) are
+# locked above; the integration weaves them together but takes a
+# nontrivial amount of FastAPI/TestClient scaffolding to drive a
+# play turn end-to-end. Punted to a follow-up rather than rushing a
+# brittle test.

--- a/frontend/src/__tests__/UpstreamLlmErrorBanner.test.tsx
+++ b/frontend/src/__tests__/UpstreamLlmErrorBanner.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Component tests for the issue #191 creator-only banner.
+ *
+ * Pins the operator-visible copy per category, the status-page link
+ * shape, and the ``request_id`` / ``HTTP <status>`` trace footer.
+ * Locks the dismiss handler contract for the parent (Facilitator).
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { UpstreamLlmErrorBanner } from "../components/UpstreamLlmErrorBanner";
+import type { ServerEvent } from "../lib/ws";
+
+type UpstreamErrorEvent = Extract<ServerEvent, { type: "error" }>;
+
+function makeEvent(
+  partial: Partial<UpstreamErrorEvent> = {},
+): UpstreamErrorEvent {
+  return {
+    type: "error",
+    scope: "upstream_llm",
+    category: "overloaded",
+    status_code: 529,
+    request_id: "req_test_abc",
+    retry_hint_seconds: null,
+    ...partial,
+  };
+}
+
+describe("UpstreamLlmErrorBanner", () => {
+  it("renders overloaded copy + status-page link with safe rel attrs", () => {
+    render(<UpstreamLlmErrorBanner event={makeEvent()} onDismiss={() => {}} />);
+    expect(
+      screen.getByText("Anthropic API overloaded."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/UPSTREAM · OVERLOADED/)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /status\.claude\.com/ });
+    expect(link).toHaveAttribute("href", "https://status.claude.com/");
+    // Open-in-new-tab safety: ``rel`` must include ``noreferrer`` and
+    // ``noopener`` so the popup cannot navigate the opener via
+    // ``window.opener``.
+    const rel = link.getAttribute("rel") ?? "";
+    expect(rel).toContain("noreferrer");
+    expect(rel).toContain("noopener");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders rate-limited copy with retry-after seconds when provided", () => {
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({
+          category: "rate_limited",
+          status_code: 429,
+          retry_hint_seconds: 42,
+        })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(screen.getByText("Rate-limited by Anthropic.")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Anthropic suggests retrying after 42s/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders rate-limited fallback copy when retry_hint_seconds absent", () => {
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({
+          category: "rate_limited",
+          status_code: 429,
+          retry_hint_seconds: null,
+        })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/Try again in 30–60s/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders timeout copy with no status code when none provided", () => {
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({
+          category: "timeout",
+          status_code: null,
+          retry_hint_seconds: null,
+        })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText("Connection to Anthropic timed out."),
+    ).toBeInTheDocument();
+    // Status code is absent — the trace line should NOT show "HTTP".
+    expect(screen.queryByText(/HTTP/)).toBeNull();
+  });
+
+  it("renders server_error copy with HTTP status in the trace line", () => {
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({
+          category: "server_error",
+          status_code: 500,
+          request_id: null,
+        })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText("Anthropic returned a server error."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/HTTP 500/)).toBeInTheDocument();
+  });
+
+  it("renders unknown-category fallback copy", () => {
+    // Defensive: ``category`` is optional in the union; defaults to
+    // unknown copy so a future backend that emits a new category
+    // doesn't render a blank banner.
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({ category: undefined as never })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/Unexpected error reached Crittable/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders trace footer with both HTTP code and req id when both present", () => {
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({ status_code: 529, request_id: "req_xyz" })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(screen.getByText(/HTTP 529/)).toBeInTheDocument();
+    expect(screen.getByText(/req req_xyz/)).toBeInTheDocument();
+  });
+
+  it("hides the trace footer when status_code AND request_id are absent", () => {
+    render(
+      <UpstreamLlmErrorBanner
+        event={makeEvent({ status_code: null, request_id: null })}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/HTTP/)).toBeNull();
+    expect(screen.queryByText(/req /)).toBeNull();
+  });
+
+  it("calls onDismiss when the dismiss button is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<UpstreamLlmErrorBanner event={makeEvent()} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses role=alert + aria-live=assertive for screen-reader urgency", () => {
+    render(<UpstreamLlmErrorBanner event={makeEvent()} onDismiss={() => {}} />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveAttribute("aria-live", "assertive");
+  });
+});

--- a/frontend/src/components/UpstreamLlmErrorBanner.tsx
+++ b/frontend/src/components/UpstreamLlmErrorBanner.tsx
@@ -1,0 +1,139 @@
+/**
+ * Issue #191 — creator-only banner for transient upstream LLM provider
+ * outages (Anthropic 529 / 5xx / 429 / connection timeout).
+ *
+ * Players don't see this banner: they can't act on the outage (only the
+ * creator can Force-advance / Retry), so a player-side banner would
+ * imply an action they don't have. Players continue to see "AI is
+ * thinking" until the creator drives the recovery.
+ *
+ * Copy framing per `docs/handoff/BRAND.md` operator voice: explicit
+ * about the upstream blame, actionable about the recovery, no
+ * marketing softening. Status-page link is the primary affordance.
+ */
+
+import type { ServerEvent } from "../lib/ws";
+
+type UpstreamErrorEvent = Extract<ServerEvent, { type: "error" }>;
+
+const STATUS_PAGE_URL = "https://status.claude.com/";
+
+interface Props {
+  /** The most recent ``upstream_llm`` event payload. */
+  event: UpstreamErrorEvent;
+  /** Click handler for the operator's "Dismiss" button. The next
+   *  upstream error re-mounts the banner with fresh content. */
+  onDismiss: () => void;
+}
+
+interface Copy {
+  /** Eyebrow + breaking-banner label, mirrors CriticalEventBanner. */
+  label: string;
+  /** Single-line headline used in the banner heading. */
+  headline: string;
+  /** Body sentence. Inline with the status-page link so the operator's
+   *  eye lands on the affordance. */
+  body: string;
+}
+
+function copyForCategory(event: UpstreamErrorEvent): Copy {
+  // Operator voice (BRAND.md): imperative, specific, no marketing
+  // softeners. Body lines describe the upstream blip and the wait
+  // expectation only — they do NOT prescribe a control to click.
+  // The right recovery (Force-advance in PLAY, retry-AAR in ENDED,
+  // resubmit setup reply in SETUP) varies by phase, and a play-tier
+  // hardcoded "use Force-advance" reads as wrong copy on the AAR
+  // failure path. The existing TopBar / activity-panel controls are
+  // visible regardless; the banner's job is to *explain*, not to
+  // teach the existing chrome.
+  const retry =
+    typeof event.retry_hint_seconds === "number" && event.retry_hint_seconds > 0
+      ? `Anthropic suggests retrying after ${event.retry_hint_seconds}s.`
+      : "Try again in 30–60s.";
+  switch (event.category) {
+    case "overloaded":
+      return {
+        label: "UPSTREAM · OVERLOADED",
+        headline: "Anthropic API overloaded.",
+        body: "Session paused. Anthropic queues clear fast under load — try again in 30–60s.",
+      };
+    case "rate_limited":
+      return {
+        label: "UPSTREAM · RATE-LIMITED",
+        headline: "Rate-limited by Anthropic.",
+        body: `Session paused. ${retry}`,
+      };
+    case "server_error":
+      return {
+        label: "UPSTREAM · SERVER ERROR",
+        headline: "Anthropic returned a server error.",
+        body: "Session paused. Try again in 30s.",
+      };
+    case "timeout":
+      return {
+        label: "UPSTREAM · CONNECTION TIMED OUT",
+        headline: "Connection to Anthropic timed out.",
+        body: "Session paused. Network or upstream blip — try again in 30s.",
+      };
+    default:
+      return {
+        label: "UPSTREAM · ERROR",
+        headline: "Unexpected error reached Crittable from the AI provider path.",
+        body: "Session paused. Try again in 30s.",
+      };
+  }
+}
+
+export function UpstreamLlmErrorBanner({ event, onDismiss }: Props) {
+  const copy = copyForCategory(event);
+  const trace = event.request_id;
+  const statusCode = event.status_code;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="sticky top-0 z-20 border-b-4 border-warn bg-warn-bg p-4 text-ink-050 backdrop-blur-sm"
+      style={{ background: "color-mix(in oklch, var(--warn) 24%, var(--ink-900))" }}
+    >
+      <div className="mx-auto flex max-w-5xl items-start justify-between gap-4">
+        <div>
+          <p className="mono text-[11px] font-bold uppercase tracking-[0.22em] text-warn">
+            ● {copy.label}
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-ink-050">{copy.headline}</h2>
+          <p className="text-sm text-ink-100 opacity-90">
+            {copy.body}{" "}
+            Live provider status:{" "}
+            <a
+              href={STATUS_PAGE_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="font-semibold text-signal-bright underline decoration-dotted underline-offset-2 hover:text-signal"
+            >
+              status.claude.com
+            </a>
+            .
+          </p>
+          {(trace || typeof statusCode === "number") ? (
+            <p
+              className="mono mt-2 break-all text-[10px] uppercase tracking-[0.16em] text-ink-200 opacity-70"
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              {typeof statusCode === "number" ? `HTTP ${statusCode}` : null}
+              {typeof statusCode === "number" && trace ? " · " : null}
+              {trace ? `req ${trace}` : null}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="mono shrink-0 rounded-1 border border-ink-300 bg-transparent px-4 py-2 text-[11px] font-bold uppercase tracking-[0.18em] text-ink-100 hover:bg-ink-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-bright"
+        >
+          DISMISS
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/notepadProvider.ts
+++ b/frontend/src/lib/notepadProvider.ts
@@ -251,7 +251,7 @@ export class WsYjsProvider {
             );
             break;
           }
-          this.onError(evt.message);
+          this.onError(evt.message ?? "Unknown error");
         }
         break;
       default:

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -260,7 +260,24 @@ export type ServerEvent =
       reason: string;
       client_seq: number;
     }
-  | { type: "error"; scope: string; message: string };
+  // Issue #191: ``scope: "upstream_llm"`` is sent to the creator only
+  // when the LLM provider returns a transient infrastructure error
+  // (529 / 5xx / 429 / connection timeout) after the SDK's retries
+  // are exhausted. The frontend renders a banner with the status-page
+  // link instead of the generic "AI failed to yield" copy. Other
+  // scopes (``turn``, ``set_ready``, …) keep the legacy shape.
+  // ``message`` is omitted for ``upstream_llm`` events — the banner
+  // renders category-specific copy, never the raw SDK exception
+  // string (no internal-hostname leak on misconfigured deploys).
+  | {
+      type: "error";
+      scope: string;
+      message?: string;
+      category?: "overloaded" | "rate_limited" | "server_error" | "timeout" | "unknown";
+      status_code?: number | null;
+      request_id?: string | null;
+      retry_hint_seconds?: number | null;
+    };
 
 export type ClientEvent =
   | {
@@ -504,6 +521,15 @@ export class WsClient {
           case "error":
             safe.scope = parsed.scope;
             safe.message = parsed.message;
+            // Issue #191 — surface the structured fields so a copy-
+            // pasted console dump from a creator's bug report carries
+            // the upstream provider trace_id straight to ops.
+            if (parsed.scope === "upstream_llm") {
+              safe.category = parsed.category;
+              safe.status_code = parsed.status_code;
+              safe.request_id = parsed.request_id;
+              safe.retry_hint_seconds = parsed.retry_hint_seconds;
+            }
             break;
           case "guardrail_blocked":
             safe.verdict = parsed.verdict;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -13,6 +13,7 @@ import { confirmLeaveSession } from "../lib/leaveGuard";
 import { AarReportView } from "../components/AarReport";
 import { Composer } from "../components/Composer";
 import { CriticalEventBanner } from "../components/CriticalEventBanner";
+import { UpstreamLlmErrorBanner } from "../components/UpstreamLlmErrorBanner";
 import { DecisionLogPanel } from "../components/DecisionLogPanel";
 import { ExportsPanel } from "../components/ExportsPanel";
 import { GodModePanel } from "../components/GodModePanel";
@@ -266,6 +267,12 @@ export function Facilitator() {
   }, []);
   const [setupReply, setSetupReply] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Issue #191 — most recent ``{type: "error", scope: "upstream_llm"}``
+  // event. Creator-only; players never receive these. Cleared by the
+  // banner's Dismiss button or replaced by a fresher upstream event.
+  const [upstreamLlmError, setUpstreamLlmError] = useState<
+    Extract<ServerEvent, { type: "error" }> | null
+  >(null);
   const [busy, setBusy] = useState(false);
   const [busyMessage, setBusyMessage] = useState<string | null>(null);
   // Prominent in-chat indicator with the LOOKS-READY-specific label
@@ -933,7 +940,22 @@ export function Facilitator() {
         console.info("[facilitator] submission truncated", evt);
         break;
       case "error":
-        setError(evt.message);
+        // Issue #191: ``upstream_llm`` events get the dedicated
+        // status-page banner; everything else falls back to the
+        // generic inline error message. Don't double-route — a
+        // generic ``setError`` for the upstream case would dump the
+        // raw provider message into the chat region too.
+        if (evt.scope === "upstream_llm") {
+          console.warn("[facilitator] upstream LLM error", {
+            category: evt.category,
+            status_code: evt.status_code,
+            request_id: evt.request_id,
+            retry_hint_seconds: evt.retry_hint_seconds,
+          });
+          setUpstreamLlmError(evt);
+          break;
+        }
+        setError(evt.message ?? "Unknown error");
         if (evt.scope === "set_ready") {
           console.warn("[facilitator] set_ready protocol error", evt);
         }
@@ -1712,10 +1734,21 @@ export function Facilitator() {
 
   return (
     <main className="flex min-h-screen flex-col lg:h-screen lg:min-h-0 lg:overflow-hidden">
+      {/* Critical-event ack is in-fiction urgency (an inject the AI
+          fired); upstream-LLM banner is infrastructure noise. Mount
+          critical first so it claims the top slot when both are
+          live, and the operator's eye lands on the action that
+          matters most for the exercise. */}
       {criticalBanner ? (
         <CriticalEventBanner
           {...criticalBanner}
           onAcknowledge={() => setCriticalBanner(null)}
+        />
+      ) : null}
+      {upstreamLlmError ? (
+        <UpstreamLlmErrorBanner
+          event={upstreamLlmError}
+          onDismiss={() => setUpstreamLlmError(null)}
         />
       ) : null}
       {/* Issue #62 (round 2): consolidated top bar — debug telemetry +

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -461,7 +461,19 @@ export function Play({ sessionId, token }: Props) {
         });
         break;
       case "error":
-        setError(evt.message);
+        // Issue #191: defense-in-depth — ``upstream_llm`` events are
+        // server-side ``send_to_role(creator)`` only, but if a stray
+        // event ever reached a player tab we'd still drop it
+        // silently. Players can't act on an upstream outage; the
+        // creator owns the Force-advance / Retry decision.
+        if (evt.scope === "upstream_llm") {
+          console.debug("[play] upstream LLM error suppressed (creator-only)", {
+            category: evt.category,
+            status_code: evt.status_code,
+          });
+          break;
+        }
+        setError(evt.message ?? "Unknown error");
         // ``submit_response`` rejections (e.g. "role cannot submit on
         // this turn" when a turn changes between composer-open and
         // hitting Submit) used to silently clear the textarea — the


### PR DESCRIPTION
Closes #191.

## Summary

- Classify the SDK's typed exceptions (`529` / `5xx` / `429` / connection timeout) at both `ChatClient` implementations (Anthropic-direct + LiteLLM-routed), re-raise as `UpstreamLLMError`, and forward a structured WS event to the creator's role only via `send_to_role`. **Players keep seeing "AI is thinking"** — the creator owns the retry decision; a banner on the player side would imply an action they can't take.
- New creator-only banner with category-specific copy (`overloaded` / `rate_limited` / `server_error` / `timeout`), an HTTP-status + Anthropic `request_id` trace footer for ops, and a link to https://status.claude.com/. Operator voice — no marketing softeners.
- Wired at four call sites: setup-turn stream, play-turn stream, interject path, AAR background generation.

## Deliberate deviations from the literal acceptance checklist

Both documented inline; surfacing here so reviewers don't read them as missed criteria.

- **Guardrail keeps fall-open semantics (no banner).** A banner during a guardrail-only failure would confuse a creator whose message went through fine. The LLM-client-side `upstream_llm_error` WARNING (with `request_id`) still fires for ops; the next play / setup / AAR call surfaces the banner if upstream is still down.
- **AAR catch lives in `manager._generate_aar_bg`, not `export.py`.** The broadcast surface lives on the manager — a duplicate try/except in the generator would fire after a redundant repo round-trip. Functionally equivalent.

## Wire payload omits raw SDK message (security)

The `to_event_payload()` deliberately drops `str(exc)` from the WS frame. The banner renders category-specific copy and never the raw provider string, so a misconfigured `LLM_API_BASE` can't leak its URL into the creator's UI. The `upstream_llm_error` log line keeps the raw message for ops.

## Tests

- **17 backend unit tests** (`backend/tests/test_upstream_llm_errors.py`) — classifier across both SDKs, retry-after parsing (clamped at 1h, negative dropped, HTTP-date dropped), payload shape, creator-targeting.
- **10 frontend banner tests** (`frontend/src/__tests__/UpstreamLlmErrorBanner.test.tsx`) — all four categories + unknown fallback, dismiss handler, trace footer presence/absence, ARIA, status-page link safety.

## Sub-agent review feedback addressed

Five reviews ran in parallel before push.

- **Security (LOW)**: Raw SDK message dropped from wire payload.
- **UI/UX (BLOCK)**: Reordered banner stack so `CriticalEventBanner` (in-fiction urgency) sits above `UpstreamLlmErrorBanner` (infrastructure noise).
- **UI/UX (HIGH)**: Tightened copy per BRAND.md operator voice — dropped `"is currently"`, `"in a moment"`, the repeated `"This is an issue with the AI provider, not Crittable"` (it's already in the eyebrow), the `"status … status"` link redundancy, and the `"Force-advance or Retry"` jargon (the controls vary by phase, the banner's job is to *explain*).
- **UI/UX (LOW)**: Fixed asymmetric `rounded-r-1` → `rounded-1` on dismiss; added `font-variant-numeric: tabular-nums` and `break-all` to the trace footer for long `request_id`s.

## Test plan

- [x] Backend unit tests pass: `pytest backend/tests/test_upstream_llm_errors.py -v` (17/17)
- [x] Backend full suite: `pytest -q --ignore=tests/live --ignore=tests/scenarios` (942 passed, 8 skipped)
- [x] Backend scenarios: `pytest tests/scenarios -q` (25/25)
- [x] Backend mypy: `mypy app` (0 errors)
- [x] Backend ruff: `ruff check app/ tests/` (clean)
- [x] Frontend banner tests pass: `npm test -- --run UpstreamLlmErrorBanner` (10/10)
- [x] Frontend full suite: `npm test -- --run` (551 passed)
- [x] Frontend lint + typecheck: clean
- [ ] Live-test run: `backend/scripts/run-live-tests.sh` — should run before merge per CLAUDE.md (touches `app/llm/*` + `app/sessions/turn_*.py`). Behavior is unchanged on the happy path; the new code path only fires when `classify_upstream_error` returns non-None.
- [ ] Manual smoke: simulate a 529 mid-play and confirm the banner mounts on the creator's tab and not on a player tab. Listed below as a follow-up.

## Follow-ups

- **End-to-end integration test** for the full `LLM raises 529 → turn errored → creator notified` flow through `turn_driver`. The unit pieces lock the contract; the FastAPI/TestClient scaffolding to drive a real play turn end-to-end is heavier than this issue justifies. TODO comment in `tests/test_upstream_llm_errors.py`.
- **Banner persistence across page reload**: today the WS event is `send_to_role` only with no replay buffer, so a creator who refreshes loses the banner even if upstream is still down. Persisting the most recent upstream-error timestamp on the session model would fix this. Tracked separately (no closing keyword).
- **AAR-failure recovery affordance**: the existing `POST /sessions/{id}/admin/retry-aar` endpoint isn't surfaced from the banner. Out of scope for this issue (the user-persona review flagged it as a UX gap, not a bug).

https://claude.ai/code/session_01SpK8yYudCRA7wzVAxeccWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpK8yYudCRA7wzVAxeccWp)_