### PR TITLE
ci+backend+docker: unblock docker publish (4 CVE layers, Trivy supply-chain pin, stale operator hint)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -275,6 +275,17 @@ jobs:
         # this is a near-instant cache hit — no real rebuild happens.
         # Skipped automatically if the Trivy step failed because steps
         # default to ``if: success()``.
+        #
+        # ``build-args`` must match the scan step exactly. ``CACHEBUST``
+        # is referenced inside the apt RUN, so it's part of every
+        # downstream layer's cache key. If we omit it here, this step
+        # defaults to ``CACHEBUST=1`` (the Dockerfile fallback), which
+        # is a different cache key than ``CACHEBUST=${{ github.run_id }}``
+        # — pip and apt layers would rebuild, possibly hitting older
+        # cached layers that have CVEs we just gated against. Passing
+        # the same value guarantees a cache hit on the layers the
+        # scan validated, so what we push is byte-identical to what
+        # Trivy approved.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -284,3 +295,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+          build-args: |
+            CACHEBUST=${{ github.run_id }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,6 +95,14 @@ jobs:
           # shouldn't be able to write into a cache that main's
           # subsequent build then consumes.
           cache-from: type=gha
+          # ``CACHEBUST=<run id>`` invalidates the apt + pip layers in
+          # the Dockerfile so debian-security updates and pip's
+          # latest-compatible resolution actually take effect on every
+          # build, instead of the GHA cache replaying a layer captured
+          # weeks ago. The base-image FROM still hits cache; only the
+          # apt/pip layers below the ARG are forced to rebuild.
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
 
       - name: Trivy image scan (HIGH,CRITICAL) — prints CVEs AND gates merge
         # Single gating step. ``format: table`` writes the CVE table
@@ -103,7 +111,19 @@ jobs:
         # Security tab, which PR runs don't even populate) to find
         # which CVE blocked the merge. ``exit-code: "1"`` makes any
         # HIGH/CRITICAL finding fail the PR check.
-        uses: aquasecurity/trivy-action@v0.36.0
+        #
+        # SHA pin (resolves to v0.36.0) per the recommendation in
+        # GHSA-69fq-xp46-6x23 / CVE-2026-33634 (the March 2026
+        # supply-chain compromise that force-pushed 76 of 77
+        # ``trivy-action`` tags to malicious commits with an
+        # infostealer). v0.36.0 itself is in the post-incident safe
+        # range (v0.35.0+ are v-prefixed and clean), but a SHA pin
+        # forecloses on any future tag-move attack — the only way
+        # this resolves to malicious code now is if the SHA itself
+        # is poisoned, which would require a fundamentally different
+        # attack. Dependabot still bumps this; the comment is the
+        # human-readable version label.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
           format: table
@@ -187,6 +207,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # See pr-validate's matching comment: ``CACHEBUST`` forces
+          # the apt + pip layers to rebuild on every run so security
+          # patches actually land in the published image.
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
 
       - name: Trivy image scan (HIGH,CRITICAL) — prints CVEs AND gates the push
         # Single gating step. ``format: table`` writes the CVE table
@@ -201,8 +226,10 @@ jobs:
         # ``ignore-unfixed`` keeps the gate from blocking on CVEs with
         # no upstream patch — the scheduled security.yml run is the
         # catch-all for "still no fix after a week" tracking.
+        # SHA pinned per GHSA-69fq-xp46-6x23 / CVE-2026-33634 — see
+        # pr-validate's matching comment for the supply-chain context.
         id: trivy
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
           format: table
@@ -221,7 +248,9 @@ jobs:
         # populated (SARIF → upload-sarif) without the two responsibilities
         # leaking into each other.
         if: always()
-        uses: aquasecurity/trivy-action@v0.36.0
+        # SHA pinned per GHSA-69fq-xp46-6x23 / CVE-2026-33634 — see
+        # pr-validate's matching comment for the supply-chain context.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
           format: sarif

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,23 +96,13 @@ jobs:
           # subsequent build then consumes.
           cache-from: type=gha
 
-      - name: Trivy image scan (table, informational) — prints CVEs to log
-        # Same scan parameters as the gate below, but ``exit-code: 0``
-        # so this step never fails the build. Surfaces every finding
-        # in the Actions log so a failed gate is self-documenting.
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ steps.scan-target.outputs.ref }}
-          format: table
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: "0"
-          vuln-type: os,library
-
-      - name: Trivy image scan (HIGH,CRITICAL) — gates merge
-        # ``format: table`` (not SARIF) because PR runs don't upload
-        # to Code Scanning. ``exit-code: "1"`` makes a HIGH/CRITICAL
-        # finding fail the PR check, blocking merge.
+      - name: Trivy image scan (HIGH,CRITICAL) — prints CVEs AND gates merge
+        # Single gating step. ``format: table`` writes the CVE table
+        # to this step's stdout so a failed PR check is self-documenting
+        # — reviewers don't have to click into a sibling step (or the
+        # Security tab, which PR runs don't even populate) to find
+        # which CVE blocked the merge. ``exit-code: "1"`` makes any
+        # HIGH/CRITICAL finding fail the PR check.
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
@@ -198,33 +188,39 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Trivy image scan (table, informational) — prints CVEs to log
-        # Same scan parameters as the SARIF gate below, but ``exit-code:
-        # "0"`` so this step never fails the build. Its only purpose is
-        # to surface the human-readable CVE table inside the Actions log
-        # — the SARIF gate that follows writes findings to a file and
-        # does not echo to stdout, which historically forced operators
-        # to dig through the Code Scanning tab to learn *which* CVE
-        # tripped the gate. With this step running first, the next
-        # failed run is self-documenting in the log itself.
+      - name: Trivy image scan (HIGH,CRITICAL) — prints CVEs AND gates the push
+        # Single gating step. ``format: table`` writes the CVE table
+        # directly to this step's stdout, so a failed run is
+        # self-documenting in its own log — no need to click into a
+        # sibling step or the Security tab to find out *which* CVE
+        # tripped the gate (which is what the previous two-step
+        # informational+SARIF pattern forced operators to do).
+        # ``exit-code: "1"`` fails this step on any HIGH/CRITICAL
+        # finding, which causes the Push step below to skip (default
+        # ``if: success()``) so no vulnerable image is ever published.
+        # ``ignore-unfixed`` keeps the gate from blocking on CVEs with
+        # no upstream patch — the scheduled security.yml run is the
+        # catch-all for "still no fix after a week" tracking.
+        id: trivy
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
           format: table
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: "0"
+          exit-code: "1"
           vuln-type: os,library
 
-      - name: Trivy image scan (HIGH,CRITICAL) — gates the push
-        # Scans the locally-loaded image for OS-package and language-dep
-        # CVEs BEFORE it reaches the registry. HIGH/CRITICAL findings
-        # fail this step, the push step below is skipped, and no
-        # vulnerable image is ever published under ``main``/version
-        # tags. ``ignore-unfixed`` keeps the gate from blocking on
-        # CVEs with no upstream patch — the scheduled security.yml run
-        # is the catch-all for "still no fix after a week" tracking.
-        id: trivy
+      - name: Trivy SARIF re-scan for Code Scanning upload
+        # Runs whether the gate passed or failed (``if: always()``) so
+        # findings always reach the Security tab regardless of build
+        # outcome. ``exit-code: "0"`` because the gate above is the
+        # authoritative pass/fail decision — this step is upload-only.
+        # The duplicate scan adds ~15s to the run but keeps the gate
+        # log readable (table → stdout) AND the Code Scanning tab
+        # populated (SARIF → upload-sarif) without the two responsibilities
+        # leaking into each other.
+        if: always()
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ steps.scan-target.outputs.ref }}
@@ -232,13 +228,12 @@ jobs:
           output: trivy-results.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: "1"
+          exit-code: "0"
           vuln-type: os,library
 
       - name: Upload Trivy SARIF to Code Scanning
-        # Always upload, even if the scan failed — findings land in the
-        # Security tab and can be triaged from there instead of
-        # disappearing with the failed run.
+        # Always upload, even if the gate failed — findings land in the
+        # Security tab and can be triaged from there.
         if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -51,11 +51,18 @@ dependencies = [
     # build never regresses below the fix for GHSA-mf9w-mj56-hr94
     # (CVE-2026-28684) — symlink-following file overwrite in
     # ``set_key`` when the .env path is a symlink across filesystems.
-    # We never call ``set_key`` ourselves (only ``load_dotenv`` via
-    # litellm), but Trivy reports this as HIGH/CRITICAL from a
-    # non-GitHub vendor and gates the runtime-image push on it. Fix
-    # landed in python-dotenv 1.2.2. litellm's own constraint stays
-    # at ``>=1.0.0,<2.0`` so this is a deliberate floor lift.
+    # We never call ``set_key`` ourselves, and we also never call
+    # ``load_dotenv`` — ``app/llm/_shared.py`` sets
+    # ``LITELLM_MODE=PRODUCTION`` before ``import litellm`` precisely
+    # to skip litellm's import-time ``dotenv.load_dotenv()``. So the
+    # runtime attack surface from this CVE is zero for us. The pin
+    # exists because Trivy flags the *installed package* regardless
+    # of whether the vulnerable code path runs, reports it as
+    # HIGH/CRITICAL from a non-GitHub vendor, and gates the runtime-
+    # image push on it. Fix landed in python-dotenv 1.2.2; litellm's
+    # own constraint stays at ``>=1.0.0,<2.0``, so this is a
+    # deliberate floor lift to keep the gate green without changing
+    # behavior.
     "python-dotenv>=1.2.2",
 ]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,6 +34,16 @@ dependencies = [
     # Anthropic prompt-caching round-trips cleanly (validated in PoC,
     # see issue #193 Phase 0).
     "litellm>=1.83",
+    # Transitive of litellm, pinned to the patched range here so a
+    # build never regresses below the fix for GHSA-mf9w-mj56-hr94
+    # (CVE-2026-28684) — symlink-following file overwrite in
+    # ``set_key`` when the .env path is a symlink across filesystems.
+    # We never call ``set_key`` ourselves (only ``load_dotenv`` via
+    # litellm), but Trivy reports this as HIGH/CRITICAL from a
+    # non-GitHub vendor and gates the runtime-image push on it. Fix
+    # landed in python-dotenv 1.2.2. litellm's own constraint stays
+    # at ``>=1.0.0,<2.0`` so this is a deliberate floor lift.
+    "python-dotenv>=1.2.2",
 ]
 
 [project.optional-dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,7 +33,20 @@ dependencies = [
     # lazily; the import-time footprint is small. Pinned to >=1.83 so
     # Anthropic prompt-caching round-trips cleanly (validated in PoC,
     # see issue #193 Phase 0).
-    "litellm>=1.83",
+    #
+    # The ``>=1.83.10`` lower bound is the security floor — every
+    # release before it has at least one of the four 2026-05 CVEs
+    # (CVE-2026-42208 CRITICAL SQL injection in the proxy path,
+    # CVE-2026-40217 HIGH bytecode-rewriting code execution,
+    # CVE-2026-42203 HIGH unsandboxed prompt-template code execution,
+    # CVE-2026-42271 HIGH MCP stdio command execution). 1.83.7 fixes
+    # three of them; 1.83.10 fixes the last. Without this floor, on
+    # ``python:3.14-slim`` pip silently backtracks to 1.83.0 (because
+    # litellm 1.83.10+ pins ``requires_python = "<3.14"``) and the
+    # vulnerable version ships. The Dockerfile pin to ``python:3.13``
+    # is what actually lets pip resolve to 1.86.2; this constraint is
+    # the belt to that Dockerfile's braces.
+    "litellm>=1.83.10",
     # Transitive of litellm, pinned to the patched range here so a
     # build never regresses below the fix for GHSA-mf9w-mj56-hr94
     # (CVE-2026-28684) — symlink-following file overwrite in

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,17 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # build actually fetches them. The Trivy gate in ``docker.yml``
 # rejects the push otherwise — this RUN keeps the gate green without
 # waiting on a Docker Inc. rebuild of the slim image.
-RUN apt-get update \
+#
+# ``echo "$CACHEBUST"`` is load-bearing: BuildKit only treats an
+# ``ARG`` as part of a downstream RUN's cache key if that RUN
+# *references* the variable. A bare ``ARG CACHEBUST=1`` declaration
+# above doesn't invalidate this layer on its own; the cache key
+# depends on the RUN text and any referenced vars. So we echo the
+# bust value into the command itself — that makes ``CACHEBUST=<run id>``
+# from the workflow actually force this layer to rebuild every CI run,
+# which is the whole point.
+RUN echo "cache-bust: $CACHEBUST" \
+ && apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,18 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 
+# ``apt-get upgrade -y`` pulls every available debian-security update
+# at build time. Without it, the runtime image inherits whatever
+# package versions were baked into the upstream ``python:3.14-slim``
+# at its last rebuild — typically weeks behind debian-security. As of
+# 2026-05 that's 11 HIGH/CRITICAL CVEs in the base (libgnutls30t64
+# CVE-2026-33845/42010 CRITICAL, libk5* / libcap2 / libnghttp2-14
+# HIGH) that all have ``+deb13uN`` fixes available, but only if the
+# build actually fetches them. The Trivy gate in ``docker.yml``
+# rejects the push otherwise — this RUN keeps the gate green without
+# waiting on a Docker Inc. rebuild of the slim image.
 RUN apt-get update \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,16 @@ COPY frontend/ ./
 RUN npm run build
 
 # ---------- Stage 2: python runtime ----------
-FROM python:3.14-slim AS runtime
+# Pinned to 3.13-slim, NOT 3.14-slim, because litellm — our single
+# LLM transport — has ``requires_python = "<3.14,>=3.10"`` on every
+# release through 1.87.0rc2 (latest stable 1.86.2 at time of writing,
+# 2026-05). On 3.14, pip backtracks to litellm 1.83.0 which carries
+# 4 unpatched CVEs (CVE-2026-42208 CRITICAL SQL injection,
+# CVE-2026-40217 / 42203 / 42271 HIGH arbitrary code / command
+# execution). With 3.13 pip resolves to litellm 1.86.2 (CVE-free).
+# When upstream litellm publishes a release that lifts the ``<3.14``
+# upper bound, bump this back via the Dependabot docker ecosystem.
+FROM python:3.13-slim AS runtime
 
 # Cache-bust the apt + pip layers below on every CI run. Without this,
 # the GHA buildx cache replays whatever package versions a build from
@@ -29,7 +38,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # ``apt-get upgrade -y`` pulls every available debian-security update
 # at build time. Without it, the runtime image inherits whatever
-# package versions were baked into the upstream ``python:3.14-slim``
+# package versions were baked into the upstream ``python:3.13-slim``
 # at its last rebuild — typically weeks behind debian-security. As of
 # 2026-05 that's 11 HIGH/CRITICAL CVEs in the base (libgnutls30t64
 # CVE-2026-33845/42010 CRITICAL, libk5* / libcap2 / libnghttp2-14

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,17 @@ RUN npm run build
 # ---------- Stage 2: python runtime ----------
 FROM python:3.14-slim AS runtime
 
+# Cache-bust the apt + pip layers below on every CI run. Without this,
+# the GHA buildx cache replays whatever package versions a build from
+# weeks ago captured — so even after a debian-security patch lands
+# upstream, the layer reused from cache still ships the unpatched
+# version and the Trivy gate stays red forever. CI passes
+# ``--build-arg CACHEBUST=${{ github.run_id }}`` so each run gets a
+# unique value, invalidating this ARG and every subsequent layer.
+# Local ``docker build`` without ``--build-arg`` defaults to ``1`` and
+# behaves as before (full cache reuse).
+ARG CACHEBUST=1
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -2654,8 +2654,8 @@ export function SetupView({
             No setup messages yet. The AI usually responds in 5–20 seconds.
             If nothing appears soon, check the backend container logs — the
             most common causes are a missing{" "}
-            <code className="mx-1 rounded-r-1 bg-ink-900 px-1 text-signal">ANTHROPIC_API_KEY</code>{" "}
-            or a network issue reaching the Anthropic API.
+            <code className="mx-1 rounded-r-1 bg-ink-900 px-1 text-signal">LLM_API_KEY</code>{" "}
+            or a network issue reaching the LLM provider.
           </p>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Six coupled fixes from the same diagnosis session. The root cause: every push-to-main Docker workflow run since PR #194 (2026-05-07) has failed at the Trivy gate, blocking `ghcr.io/nebriv/crittable:latest` from being republished for 21 days. The Trivy failures had **four** layers (each revealed only after fixing the previous one), and the gate UX hid all of them.

## CVE layers cleared, in order

### Layer 1 — Python dep transitively pulled by litellm
**`python-dotenv 1.0.1`** → GHSA-mf9w-mj56-hr94 / CVE-2026-28684 (symlink file overwrite). GitHub Moderate (CVSS 6.6); Trivy pulls HIGH/CRITICAL from another vendor. Pinned `python-dotenv>=1.2.2` in `backend/pyproject.toml`. (commit `0808d48`)

### Layer 2 — Base image debian-security backlog
11 unpatched HIGH/CRITICAL CVEs in the cached `python:3.14-slim` runtime layer (libgnutls30t64 CRITICAL ×2, krb5/cap/nghttp2 HIGH ×9). All `Status: fixed` in debian-security `+deb13uN`. Added `apt-get upgrade -y` in the runtime RUN. (commit `0d18b23`)

### Layer 3 — GHA buildx cache replaying stale layers
After Layers 1–2, builds still failed. Root cause: `cache-from: type=gha` replayed apt and pip layers captured weeks ago; even my new `apt-get upgrade` RUN sat on top of a cached apt-cache layer with no fresh package indexes visible.

Two-step fix:
- `ARG CACHEBUST=1` near the top of the runtime stage in `docker/Dockerfile`
- `--build-arg CACHEBUST=${{ github.run_id }}` on both `pr-validate` and `build-and-push` build steps (commit `f90bae3`)

But BuildKit only honors an `ARG` as a cache key for downstream RUNs if those RUNs **reference** the variable. So I had to actually `echo "cache-bust: $CACHEBUST"` inside the apt RUN to make the cache key actually depend on `CACHEBUST` (commit `3889ab2`). Once that landed, the build successfully produced a Debian 13.5 layer with **0 HIGH/CRITICAL OS CVEs** — confirming Layers 1–3 cleared.

### Layer 4 — litellm Python 3.14 backtrack
That same CACHEBUST-clean build then exposed the layer that had been hiding behind the cache all along: **`litellm 1.83.0`** (resolved by pip on Python 3.14) with **4 CVEs**:

| CVE | Severity | Fix | What |
|---|---|---|---|
| CVE-2026-42208 | CRITICAL | 1.83.7 | SQL injection (server/proxy paths) |
| CVE-2026-40217 | HIGH | **1.83.10** | Arbitrary code execution via bytecode rewriting |
| CVE-2026-42203 | HIGH | 1.83.7 | Arbitrary code execution via unsandboxed prompt templates |
| CVE-2026-42271 | HIGH | 1.83.7 | Command execution via MCP stdio endpoints |

Why pip picked 1.83.0 specifically: every patched litellm release (1.83.10 through latest stable 1.86.2 and pre-release 1.87.0rc2) pins `requires_python = "<3.14,>=3.10"`. The Dependabot bump to `python:3.14-slim` (PR #142, skipping 3.13) forced pip to backtrack past every CVE-clear version.

Two-piece fix in commit `ec5587c`:
1. `docker/Dockerfile`: `FROM python:3.14-slim` → `python:3.13-slim`. Bump back when upstream lifts the `<3.14` constraint.
2. `backend/pyproject.toml`: `litellm>=1.83` → `litellm>=1.83.10`. The security floor. If the base is ever bumped back to 3.14 before litellm catches up, pip hard-errors instead of silently downgrading.

## Trivy gate UX + supply-chain hardening

### Gate UX (commit `0808d48`)
Previous gate ran Trivy twice (`table/exit-0/prints` then `sarif/exit-1/gates`). When it failed, the failing step's log was empty — the CVEs were in the sibling green step or Security → Code Scanning. This bit us multiple times during the diagnosis. Consolidated to a single gating step (`table` + `exit-code: 1`) + an `if: always()` SARIF re-scan for the Security tab.

### Supply-chain pin (commit `f90bae3`)
GHSA-69fq-xp46-6x23 / CVE-2026-33634 — the March 19-23 2026 supply-chain compromise force-pushed 76 of 77 `aquasecurity/trivy-action` tags to malicious commits with an infostealer. We adopted v0.36.0 on 2026-05-05 (post-incident), so CI was never running compromised code. SHA-pinned all 3 references in docker.yml to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0). Dependabot's already-configured `github-actions` ecosystem understands the trailing `# v0.36.0` comment.

## Stale operator hint (commit `ef3ff02`)
`Facilitator.tsx:2657` still named `ANTHROPIC_API_KEY`. Updated to `LLM_API_KEY`.

## Commits

- `ef3ff02` — frontend: stale `ANTHROPIC_API_KEY` hint → `LLM_API_KEY`
- `0808d48` — `python-dotenv>=1.2.2` + Trivy gate UX rework
- `0d18b23` — `apt-get upgrade -y` in runtime stage
- `f90bae3` — SHA-pin trivy-action + `CACHEBUST` plumbing
- `3889ab2` — actually reference `$CACHEBUST` in RUN so BuildKit honors it
- `ec5587c` — `python:3.14-slim` → `python:3.13-slim` + `litellm>=1.83.10`

## Test plan

- [ ] `pr-validate` Trivy gate goes green on `ec5587c` (0 HIGH/CRITICAL across all layers)
- [ ] On merge: push-to-main Docker run prints "no HIGH/CRITICAL" and publishes a fresh `:latest`
- [ ] `docker pull ghcr.io/nebriv/crittable:latest` on a clean box — boot succeeds, startup checks `LLM_API_KEY`, no `require_anthropic_key()` error
- [ ] Security → Code Scanning shows the python-dotenv alert on `main` clears after the merge build completes
- [ ] Manual smoke: setup-warning copy reads `LLM_API_KEY` instead of `ANTHROPIC_API_KEY`

## Lifecycle scenario carve-out

CI / dep-pin / Dockerfile / copy-only changes. No `SessionState` transition, no turn-pump path, no `MessageKind` / tool / message field touched. Replay path unaffected. The Python runtime drop 3.14 → 3.13 doesn't affect any code path — `pyproject.toml`'s `requires-python = ">=3.12"` keeps 3.13 fully supported, and there's no 3.14-specific syntax in the codebase.