### PR TITLE
feat: add INVITE_CODE gate on session creation

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -6,7 +6,7 @@ import json
 import re
 from typing import Any, Literal
 
-from fastapi import APIRouter, FastAPI, HTTPException, Request, status
+from fastapi import APIRouter, FastAPI, HTTPException, Query, Request, status
 from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -86,6 +86,12 @@ class CreateSessionBody(BaseModel):
     # avoids the wasted auto-greet LLM call (and the bare-text leak
     # bug it can produce). Used by the frontend's "Dev mode" toggle.
     skip_setup: bool = False
+    # Soft anti-strangers gate. Required when the ``INVITE_CODE`` env
+    # var is set on the server; ignored when it isn't. The check is
+    # constant-time and the value is never logged. Player join links
+    # don't need this — they already carry their own HMAC tokens —
+    # so only the creator path is gated.
+    invite_code: str | None = Field(default=None, max_length=128)
     # Creator-selected scenario tuning (difficulty, target duration,
     # feature toggles) chosen on the new-session wizard's "shaping"
     # step. Frozen at creation; surfaced into setup + play system
@@ -362,8 +368,57 @@ def register_api_routes(app: FastAPI) -> None:
         return payload
 
     # ---------------------------------------------------- routes
+    @router.get("/invite/status")
+    async def invite_status(
+        request: Request,
+        # Length-cap the query so an attacker can't grind ``?code=<5MB>``
+        # against ``hmac.compare_digest`` and chew CPU when the
+        # rate-limit middleware is off. Mirrors the
+        # ``CreateSessionBody.invite_code`` cap. Path scrubber in
+        # ``logging_setup._scrub_path_bytes`` redacts the value before
+        # it reaches the access log.
+        code: str | None = Query(default=None, max_length=128),
+    ) -> dict[str, Any]:
+        """Tell the frontend whether the gate is on, and (optionally)
+        whether a supplied code passes.
+
+        ``GET /api/invite/status`` (no ``?code=``) returns
+        ``{"required": bool, "valid": null}`` so the wizard knows
+        whether to render the gate at all.
+
+        ``GET /api/invite/status?code=XYZ`` additionally returns
+        ``{"valid": bool}`` so the gate can confirm the code without
+        going through the full create-session path. Failures are
+        logged at WARNING so brute-force attempts are visible in
+        ``/healthz``-style log scans; the code itself is never logged.
+        """
+
+        settings = request.app.state.settings
+        log = get_logger("api")
+        if not settings.invite_code_required():
+            return {"required": False, "valid": None}
+        if code is None:
+            return {"required": True, "valid": None}
+        valid = settings.verify_invite_code(code)
+        if valid:
+            log.info("invite_validate_ok")
+        else:
+            log.warning("invite_validate_rejected")
+        return {"required": True, "valid": valid}
+
     @router.post("/sessions")
     async def create_session(body: CreateSessionBody, request: Request) -> dict[str, Any]:
+        settings = request.app.state.settings
+        if settings.invite_code_required() and not settings.verify_invite_code(
+            body.invite_code
+        ):
+            # WARNING not INFO so a brute-force shows up in the same
+            # log-level scans operators use for other auth failures.
+            # The candidate is intentionally never logged.
+            get_logger("api").warning("create_session_invite_rejected")
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN, "invite code required"
+            )
         manager = _manager(request)
         try:
             session, token = await manager.create_session(
@@ -462,10 +517,11 @@ def register_api_routes(app: FastAPI) -> None:
                 ok_count=len(invitee_role_ids),
             )
 
-        settings = request.app.state.settings
         # Either env (``DEV_FAST_SETUP``) or per-request (``skip_setup``)
         # triggers the no-auto-greet path. Per-request wins: an operator
         # might want dev mode for one session and full setup for another.
+        # ``settings`` was already pulled at the top of the handler for the
+        # invite-code gate.
         skip_setup = body.skip_setup or bool(settings.dev_fast_setup)
 
         if skip_setup:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,7 @@ Conventions
 
 from __future__ import annotations
 
+import hmac
 import secrets
 import warnings
 from functools import lru_cache
@@ -295,6 +296,17 @@ class Settings(BaseSettings):
     cors_origins: str = Field(default="*", alias="CORS_ORIGINS")
     rate_limit_enabled: bool = Field(default=False, alias="RATE_LIMIT_ENABLED")
     rate_limit_req_per_min: int = Field(default=60, alias="RATE_LIMIT_REQ_PER_MIN", ge=1)
+    # Soft "anti-strangers" gate on ``POST /api/sessions``. When set to
+    # a non-empty value, the creator must supply a matching ``invite_code``
+    # on session creation; the player-side join links still work without
+    # it because they already carry per-role HMAC tokens. When unset
+    # (the default), no gate runs — local dev stays frictionless. This
+    # is NOT a security boundary against motivated attackers; it's a
+    # rate-limit-style stopgap to keep random web traffic from spending
+    # LLM tokens on a public deploy. Pair with ``RATE_LIMIT_ENABLED=true``
+    # so a brute-forcer can't grind through the code at thousands of
+    # requests per minute. See ``docs/configuration.md`` § Security.
+    invite_code: SecretStr | None = Field(default=None, alias="INVITE_CODE")
 
     # ---- Audit ---------------------------------------------------------
     audit_ring_size: int = Field(default=2000, alias="AUDIT_RING_SIZE", ge=10)
@@ -484,6 +496,38 @@ class Settings(BaseSettings):
             stacklevel=2,
         )
         return secrets.token_urlsafe(32)
+
+    def invite_code_required(self) -> bool:
+        """True iff a non-empty ``INVITE_CODE`` is configured.
+
+        Empty / whitespace-only / unset all mean "no gate" — local dev
+        and toy deploys boot frictionless. Operators on a public URL
+        set ``INVITE_CODE`` to gate session creation against random
+        web traffic.
+        """
+
+        if self.invite_code is None:
+            return False
+        return bool(self.invite_code.get_secret_value().strip())
+
+    def verify_invite_code(self, candidate: str | None) -> bool:
+        """Constant-time compare ``candidate`` against ``INVITE_CODE``.
+
+        Returns ``True`` when no gate is configured (``INVITE_CODE``
+        unset) so callers can use a single check. Whitespace is stripped
+        from both sides before compare so an operator who pastes the
+        code with a trailing newline doesn't lock themselves out.
+        ``hmac.compare_digest`` avoids the timing-side-channel that a
+        plain ``==`` would expose on a short invite code.
+        """
+
+        if not self.invite_code_required():
+            return True
+        if not candidate:
+            return False
+        assert self.invite_code is not None  # narrowed by ``invite_code_required``
+        expected = self.invite_code.get_secret_value().strip()
+        return hmac.compare_digest(expected, candidate.strip())
 
     def require_llm_api_key(self) -> str:
         """Return ``LLM_API_KEY`` or raise.

--- a/backend/app/logging_setup.py
+++ b/backend/app/logging_setup.py
@@ -38,13 +38,29 @@ from .config import Settings
 
 _TOKEN_QUERY_RE = re.compile(rb"([?&]token=)[^&]+", re.IGNORECASE)
 _TOKEN_PATH_RE = re.compile(rb"(/play/[^/?#]+/)[^/?#]+", re.IGNORECASE)
+# Invite-code gate (``GET /api/invite/status?code=…``). The candidate
+# is a low-sensitivity bearer secret — leaks in the access-log line
+# would contradict the WARNING line in ``routes.py`` that promises the
+# value is never logged. Scrubbed alongside the older token patterns.
+_INVITE_CODE_QUERY_RE = re.compile(
+    rb"([?&](?:code|invite_code)=)[^&]+", re.IGNORECASE
+)
 
 
 def _scrub_path_bytes(raw: bytes) -> str:
-    """Strip ``?token=…`` / ``/play/<sid>/<token>`` fragments before logging."""
+    """Strip bearer-secret query / path fragments before logging.
+
+    Covers:
+      * ``?token=…`` — join tokens on every authenticated REST path.
+      * ``/play/<sid>/<token>`` — the path-style token in the
+        share-with-player URL.
+      * ``?code=…`` / ``?invite_code=…`` — the soft anti-strangers
+        gate on ``GET /api/invite/status``.
+    """
 
     scrubbed = _TOKEN_QUERY_RE.sub(rb"\1***", raw)
     scrubbed = _TOKEN_PATH_RE.sub(rb"\1***", scrubbed)
+    scrubbed = _INVITE_CODE_QUERY_RE.sub(rb"\1***", scrubbed)
     try:
         return scrubbed.decode("ascii", errors="replace")
     except Exception:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -235,6 +235,25 @@ def create_app(
                 "tests-only convenience; never enable in production."
             ),
         )
+    # Boot-time confirmation that the soft anti-strangers gate is on,
+    # plus a loud warning if the operator forgot to pair it with the
+    # rate-limit middleware. Without the warn an operator can think
+    # "INVITE_CODE is set, I'm safe" and miss that an attacker can
+    # grind ``GET /api/invite/status?code=…`` at thousands of probes
+    # per second to brute the value.
+    if cfg.invite_code_required():
+        _bootstrap_log.info("invite_code_gate_enabled")
+        if not cfg.rate_limit_enabled:
+            _bootstrap_log.warning(
+                "invite_code_set_without_rate_limit",
+                note=(
+                    "INVITE_CODE is set but RATE_LIMIT_ENABLED=false; "
+                    "an attacker can brute the code via "
+                    "GET /api/invite/status?code=… or "
+                    "POST /api/sessions without throttling. "
+                    "Enable RATE_LIMIT_ENABLED=true for any public deploy."
+                ),
+            )
 
     app = FastAPI(
         title="Crittable",

--- a/backend/tests/test_invite_code.py
+++ b/backend/tests/test_invite_code.py
@@ -1,0 +1,301 @@
+"""Tests for the soft ``INVITE_CODE`` gate on ``POST /api/sessions``.
+
+The gate exists so a public-URL deploy (the new Crittable.app domain
+behind a Cloudflare tunnel) can keep random web traffic from spending
+LLM tokens on it without standing up a full auth stack. When unset,
+the gate is invisible; when set, it's a constant-time string compare
+against ``Settings.invite_code``.
+
+These tests assert the four corners of that contract plus the
+``GET /api/invite/status`` endpoint the frontend uses to decide
+whether to render its gate UI at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import get_settings, reset_settings_cache
+from app.main import create_app
+from tests.conftest import default_settings_body
+from tests.mock_chat_client import install_mock_chat_client
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("LLM_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("LLM_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("LLM_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    reset_settings_cache()
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, *, code: str | None) -> TestClient:
+    if code is None:
+        monkeypatch.delenv("INVITE_CODE", raising=False)
+    else:
+        monkeypatch.setenv("INVITE_CODE", code)
+    reset_settings_cache()
+    app = create_app()
+    c = TestClient(app)
+    c.__enter__()  # ASGI startup; closed by the test's ``c.close()``.
+    install_mock_chat_client(c)
+    return c
+
+
+def _create_body(invite_code: str | None) -> dict[str, object]:
+    body: dict[str, object] = {
+        "scenario_prompt": "Ransomware",
+        "creator_label": "CISO",
+        "creator_display_name": "Alex",
+        **default_settings_body(),
+    }
+    if invite_code is not None:
+        body["invite_code"] = invite_code
+    return body
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def test_invite_code_required_helper_false_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INVITE_CODE", raising=False)
+    reset_settings_cache()
+    assert get_settings().invite_code_required() is False
+
+
+def test_invite_code_required_helper_false_on_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator pasting only whitespace into ``INVITE_CODE`` is the
+    same as not setting it at all — otherwise the gate would silently
+    reject every request because no candidate could match a single
+    space."""
+
+    monkeypatch.setenv("INVITE_CODE", "   ")
+    reset_settings_cache()
+    assert get_settings().invite_code_required() is False
+
+
+def test_verify_invite_code_constant_time_match_with_whitespace_padding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trailing newlines from a copy-paste should not lock out the
+    operator. Whitespace is stripped from both sides."""
+
+    monkeypatch.setenv("INVITE_CODE", "tabletop-2026")
+    reset_settings_cache()
+    cfg = get_settings()
+    assert cfg.verify_invite_code("tabletop-2026") is True
+    assert cfg.verify_invite_code("  tabletop-2026\n") is True
+    assert cfg.verify_invite_code("tabletop-2027") is False
+    assert cfg.verify_invite_code(None) is False
+    assert cfg.verify_invite_code("") is False
+
+
+# ---------------------------------------------------------------- endpoint: status
+
+
+def test_invite_status_reports_not_required_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code=None)
+    try:
+        r = client.get("/api/invite/status")
+        assert r.status_code == 200
+        assert r.json() == {"required": False, "valid": None}
+    finally:
+        client.close()
+
+
+def test_invite_status_required_no_code_returns_required_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.get("/api/invite/status")
+        assert r.status_code == 200
+        assert r.json() == {"required": True, "valid": None}
+    finally:
+        client.close()
+
+
+def test_invite_status_required_with_correct_code_returns_valid_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.get("/api/invite/status", params={"code": "tabletop-2026"})
+        assert r.status_code == 200
+        assert r.json() == {"required": True, "valid": True}
+    finally:
+        client.close()
+
+
+def test_invite_status_required_with_wrong_code_returns_valid_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.get("/api/invite/status", params={"code": "wrong"})
+        assert r.status_code == 200
+        assert r.json() == {"required": True, "valid": False}
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------- endpoint: create gate
+
+
+def test_create_session_no_gate_works_without_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``INVITE_CODE`` is unset, the field is ignored — the
+    creator can omit it and the request succeeds. Keeps local dev /
+    Codespaces frictionless."""
+
+    client = _client(monkeypatch, code=None)
+    try:
+        r = client.post("/api/sessions", json=_create_body(invite_code=None))
+        assert r.status_code == 200, r.text
+        assert "creator_token" in r.json()
+    finally:
+        client.close()
+
+
+def test_create_session_gated_missing_code_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.post("/api/sessions", json=_create_body(invite_code=None))
+        assert r.status_code == 403, r.text
+        assert "invite" in r.json()["detail"].lower()
+    finally:
+        client.close()
+
+
+def test_create_session_gated_wrong_code_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.post("/api/sessions", json=_create_body(invite_code="nope"))
+        assert r.status_code == 403, r.text
+    finally:
+        client.close()
+
+
+def test_create_session_gated_correct_code_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.post(
+            "/api/sessions", json=_create_body(invite_code="tabletop-2026")
+        )
+        assert r.status_code == 200, r.text
+        assert "creator_token" in r.json()
+    finally:
+        client.close()
+
+
+def test_create_session_gated_empty_string_code_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client that wires the field but sends an empty string must
+    not slip past — the gate is a positive check on a matching value,
+    not a "did the key exist" check."""
+
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.post("/api/sessions", json=_create_body(invite_code=""))
+        assert r.status_code == 403, r.text
+    finally:
+        client.close()
+
+
+def test_create_session_status_endpoint_caps_query_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense against a no-rate-limit deployment getting
+    ``?code=<5MB>`` probes — the validator chains
+    ``hmac.compare_digest`` on the candidate and that's O(n)."""
+
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        oversized = "a" * 129
+        r = client.get("/api/invite/status", params={"code": oversized})
+        assert r.status_code == 422, r.text
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------- logging contracts
+#
+# CLAUDE.md elevates "missing log line at a meaningful boundary" to a
+# must-fix even at LOW. These tests lock the WARNING level so a future
+# refactor can't silently demote them to INFO and disappear the only
+# brute-force breadcrumb on the audit trail.
+
+
+def test_invite_validate_rejected_emits_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.get("/api/invite/status", params={"code": "wrong"})
+        assert r.status_code == 200
+        out = capsys.readouterr().out
+        assert "invite_validate_rejected" in out, out
+        # The code itself MUST NOT appear anywhere in the log line —
+        # not in the structlog event, not in the access-log path.
+        assert "wrong" not in out, out
+    finally:
+        client.close()
+
+
+def test_create_session_invite_rejected_emits_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.post("/api/sessions", json=_create_body(invite_code="nope"))
+        assert r.status_code == 403
+        out = capsys.readouterr().out
+        assert "create_session_invite_rejected" in out, out
+        # The candidate must never reach the audit log; the body is
+        # JSON (not a query string) so it isn't path-scrubbed.
+        # ``structlog`` only logs what we ``log.warning(...)`` with,
+        # so this is a contract on the handler — never pass the body
+        # field as a structured key.
+        assert "nope" not in out, out
+    finally:
+        client.close()
+
+
+def test_invite_status_query_is_scrubbed_from_access_log(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The structlog access-log middleware logs the request path. The
+    invite-code value must be redacted there or the operator's normal
+    log scan exposes every probed candidate to anyone with log access."""
+
+    client = _client(monkeypatch, code="tabletop-2026")
+    try:
+        r = client.get("/api/invite/status", params={"code": "supersecret"})
+        assert r.status_code == 200
+        out = capsys.readouterr().out
+        # ``code=`` survives, the value is replaced with ``***``.
+        assert "code=" in out, out
+        assert "supersecret" not in out, out
+    finally:
+        client.close()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,7 @@ Defaults preserve historical behavior so unset = no change.
 | `CORS_ORIGINS` | `*` | Comma-separated allowlist. **Set explicitly before going public.** |
 | `RATE_LIMIT_ENABLED` | `false` | Toggle the rate-limit middleware |
 | `RATE_LIMIT_REQ_PER_MIN` | `60` | Per-IP request cap when enabled |
+| `INVITE_CODE` | unset (no gate) | Soft anti-strangers gate on `POST /api/sessions`. When set to a non-empty value, the creator must supply a matching code on the wizard's invite gate before a session can be created; the wizard caches a validated code in `localStorage` so refreshes don't re-prompt. Player join links don't need it — they already carry per-role HMAC tokens. This is NOT a security boundary; it's a stopgap so a public-URL deploy doesn't burn LLM tokens on every drive-by. **Pair with `RATE_LIMIT_ENABLED=true`** so a brute-forcer can't grind through the code via the cheap `GET /api/invite/status?code=…` probe or the heavier `POST /api/sessions` path. Comparison is constant-time and surrounding whitespace is stripped so a copy-paste with a trailing newline still matches. The value is redacted from access logs and the browser-console request wrapper. App emits `invite_code_gate_enabled` at boot (or `invite_code_set_without_rate_limit` WARNING if the rate-limit middleware isn't on). |
 
 ## Extensions
 

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -9,9 +9,14 @@ import { api } from "../api/client";
 // wizard advanced two NEXT clicks. ``advanceToRoles`` runs the
 // navigation; the creator-label-collision test sets the label on
 // step 1 first, then advances.
-function advanceToRoles() {
+async function advanceToRoles() {
+  // The intro wizard renders only after the mount-time invite-code
+  // probe resolves (one round-trip in real life, one microtask in
+  // tests with the spy in ``beforeEach``). ``findByRole`` polls
+  // until the first NEXT button appears, then the synchronous
+  // chain runs.
   fireEvent.click(
-    screen.getByRole("button", { name: /NEXT · ENVIRONMENT/i }),
+    await screen.findByRole("button", { name: /NEXT · ENVIRONMENT/i }),
   );
   fireEvent.click(screen.getByRole("button", { name: /NEXT · ROLES/i }));
 }
@@ -25,15 +30,19 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: false,
+      valid: null,
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("seeds the 5 mockup-defined builtin role slots", () => {
+  it("seeds the 5 mockup-defined builtin role slots", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const fs = getRolesFieldset();
     // All 5 builtin labels must render as rows regardless of toggle state.
     expect(within(fs).getByText("Incident Commander")).toBeInTheDocument();
@@ -43,9 +52,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     expect(within(fs).getByText("Executive Sponsor")).toBeInTheDocument();
   });
 
-  it("all 5 builtin roles default to ACTIVE", () => {
+  it("all 5 builtin roles default to ACTIVE", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     // ACTIVE pill on every default-active row is pressed. After the
     // user-agent review flagged "OFF default for Comms/Legal /
     // Executive Sponsor reads as broken without STANDBY context",
@@ -65,9 +74,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     }
   });
 
-  it("toggling ACTIVE on a default-OFF row flips to active (direct off→active)", () => {
+  it("toggling ACTIVE on a default-OFF row flips to active (direct off→active)", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     // Toggle Executive Sponsor OFF first (since defaults are now all
     // active), then toggle ACTIVE to verify the off→active direction
     // works on the same handler.
@@ -88,9 +97,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("disables ROLL SESSION + shows warning when zero invitees are active", () => {
+  it("disables ROLL SESSION + shows warning when zero invitees are active", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     // Toggle every builtin OFF.
     for (const label of [
       "Incident Commander",
@@ -113,9 +122,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).toBeInTheDocument();
   });
 
-  it("removes a builtin row via the × button (every row is removable)", () => {
+  it("removes a builtin row via the × button (every row is removable)", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     // Builtin rows now have a remove control too — the previous
     // "toggle-only" treatment frustrated operators who didn't want
     // a given builtin in their list at all.
@@ -125,9 +134,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("toggling OFF on an active builtin row flips the pill state", () => {
+  it("toggling OFF on an active builtin row flips the pill state", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const offBtn = screen.getByRole("button", {
       name: /Incident Commander off/i,
     });
@@ -138,9 +147,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("adds a custom role row via the Add role button", () => {
+  it("adds a custom role row via the Add role button", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const draft = screen.getByLabelText("New role label") as HTMLInputElement;
     fireEvent.change(draft, { target: { value: "Threat Intel" } });
     fireEvent.click(screen.getByRole("button", { name: "Add role" }));
@@ -150,10 +159,10 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     expect(draft.value).toBe("");
   });
 
-  it("adds via Enter without submitting the form", () => {
+  it("adds via Enter without submitting the form", async () => {
     const createSpy = vi.spyOn(api, "createSession");
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const draft = screen.getByLabelText("New role label") as HTMLInputElement;
     fireEvent.change(draft, { target: { value: "Threat Intel" } });
     fireEvent.keyDown(draft, { key: "Enter" });
@@ -163,9 +172,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  it("typing an existing label re-activates the existing slot instead of duplicating", () => {
+  it("typing an existing label re-activates the existing slot instead of duplicating", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     // Toggle OFF, then add the same label via the form — should flip
     // back to ACTIVE on the same row, no duplicate row.
     fireEvent.click(
@@ -182,9 +191,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("ignores blank / whitespace-only role labels", () => {
+  it("ignores blank / whitespace-only role labels", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const draft = screen.getByLabelText("New role label") as HTMLInputElement;
     const addButton = screen.getByRole("button", { name: "Add role" });
     expect(addButton).toBeDisabled();
@@ -196,9 +205,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("removes a custom row via the × button", () => {
+  it("removes a custom row via the × button", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const draft = screen.getByLabelText("New role label") as HTMLInputElement;
     fireEvent.change(draft, { target: { value: "Threat Intel" } });
     fireEvent.click(screen.getByRole("button", { name: "Add role" }));
@@ -208,9 +217,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("warns when the creator label collides with an active invitee row", () => {
+  it("warns when the creator label collides with an active invitee row", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const labelInput = screen.getByPlaceholderText(
       /Your role label/i,
     ) as HTMLInputElement;
@@ -221,9 +230,9 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     ).toBeInTheDocument();
   });
 
-  it("collision warning clears when the colliding row is toggled OFF", () => {
+  it("collision warning clears when the colliding row is toggled OFF", async () => {
     render(<Facilitator />);
-    advanceToRoles();
+    await advanceToRoles();
     const labelInput = screen.getByPlaceholderText(
       /Your role label/i,
     ) as HTMLInputElement;
@@ -280,7 +289,7 @@ const baseProps = {
 };
 
 describe("BottomActionBar — phase CTAs (issue #62)", () => {
-  it("renders START SESSION disabled when plan not finalized", () => {
+  it("renders START SESSION disabled when plan not finalized", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -294,7 +303,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(btn).toBeDisabled();
   });
 
-  it("renders START SESSION disabled when fewer than 2 players", () => {
+  it("renders START SESSION disabled when fewer than 2 players", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -309,7 +318,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).toBeDisabled();
   });
 
-  it("enables START SESSION when plan finalized and ≥2 players", () => {
+  it("enables START SESSION when plan finalized and ≥2 players", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -325,7 +334,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(baseProps.onStart).toHaveBeenCalled();
   });
 
-  it("renders FORCE-ADVANCE + END SESSION buttons during play", () => {
+  it("renders FORCE-ADVANCE + END SESSION buttons during play", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -346,7 +355,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders VIEW AAR when ended phase + AAR ready", () => {
+  it("renders VIEW AAR when ended phase + AAR ready", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -361,7 +370,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).toBeInTheDocument();
   });
 
-  it("surfaces turn / message / rationale / tabs / cost telemetry chips", () => {
+  it("surfaces turn / message / rationale / tabs / cost telemetry chips", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -389,7 +398,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText("Cost: $0.0234")).toBeInTheDocument();
   });
 
-  it("renders dash placeholders when telemetry is null", () => {
+  it("renders dash placeholders when telemetry is null", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -405,7 +414,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText(/Last: —/)).toBeInTheDocument();
   });
 
-  it("renders 'Last: <Ns' once a lastEventAt timestamp is set", () => {
+  it("renders 'Last: <Ns' once a lastEventAt timestamp is set", async () => {
     const fiveSecondsAgo = Date.now() - 5_500;
     render(
       <BottomActionBar
@@ -420,7 +429,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText(/Last: 5s/)).toBeInTheDocument();
   });
 
-  it("renders 'LLM: idle' when no LLM calls are in flight", () => {
+  it("renders 'LLM: idle' when no LLM calls are in flight", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -433,7 +442,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText("LLM: idle")).toBeInTheDocument();
   });
 
-  it("renders 'LLM: <tier>' when a single tier is active", () => {
+  it("renders 'LLM: <tier>' when a single tier is active", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -448,7 +457,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.queryByText("LLM: idle")).not.toBeInTheDocument();
   });
 
-  it("joins multiple concurrent tiers with '+' (e.g. guardrail + play)", () => {
+  it("joins multiple concurrent tiers with '+' (e.g. guardrail + play)", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -468,7 +477,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
   // operationally-distinct state that used to read as "LLM: idle"
   // and was the diagnostic gap behind the silent-yield 5-hour log
   // dive.
-  it("renders 'LLM: idle (paused)' when the AI is paused with no calls in flight", () => {
+  it("renders 'LLM: idle (paused)' when the AI is paused with no calls in flight", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -482,7 +491,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText("LLM: idle (paused)")).toBeInTheDocument();
   });
 
-  it("renders 'LLM: waiting for players' on AWAITING_PLAYERS with no calls in flight", () => {
+  it("renders 'LLM: waiting for players' on AWAITING_PLAYERS with no calls in flight", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -498,7 +507,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders 'LLM: recovering N/M (kind)' during a recovery cascade", () => {
+  it("renders 'LLM: recovering N/M (kind)' during a recovery cascade", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -520,7 +529,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).toBeInTheDocument();
   });
 
-  it("appends 'last attempt' when recovery hits the budget (UI/UX HIGH #2)", () => {
+  it("appends 'last attempt' when recovery hits the budget (UI/UX HIGH #2)", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -540,7 +549,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).toBeInTheDocument();
   });
 
-  it("appends '· paused' to the in-flight chip when paused mid-recovery (User Agent MEDIUM #6)", () => {
+  it("appends '· paused' to the in-flight chip when paused mid-recovery (User Agent MEDIUM #6)", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -561,7 +570,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders crit 'LLM: recovery FAILED' when the current turn errored (User Agent HIGH #3)", () => {
+  it("renders crit 'LLM: recovery FAILED' when the current turn errored (User Agent HIGH #3)", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -579,7 +588,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     // the moment the strict-retry loop exits.
   });
 
-  it("turnErrored wins over recoveryStatus + activeTiers (priority order)", () => {
+  it("turnErrored wins over recoveryStatus + activeTiers (priority order)", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -597,7 +606,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.queryByText("LLM: play")).not.toBeInTheDocument();
   });
 
-  it("expands the cost chip to show the token breakdown", () => {
+  it("expands the cost chip to show the token breakdown", async () => {
     render(
       <BottomActionBar
         {...baseProps}
@@ -621,7 +630,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText("6,789")).toBeInTheDocument();
   });
 
-  it("always renders '+ NEW SESSION' regardless of phase", () => {
+  it("always renders '+ NEW SESSION' regardless of phase", async () => {
     for (const phase of ["setup", "ready", "play", "ended"] as const) {
       const { unmount } = render(
         <BottomActionBar
@@ -643,7 +652,7 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
 describe("TopBar — brand chrome (post-redesign)", () => {
   const minimalProps = { ...baseProps };
 
-  it("renders the AAR-generating status when ended phase + AAR pending", () => {
+  it("renders the AAR-generating status when ended phase + AAR pending", async () => {
     render(
       <TopBar
         {...minimalProps}
@@ -659,7 +668,7 @@ describe("TopBar — brand chrome (post-redesign)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders the VIEW AAR button when ended phase + AAR ready", () => {
+  it("renders the VIEW AAR button when ended phase + AAR ready", async () => {
     render(
       <TopBar
         {...minimalProps}

--- a/frontend/src/__tests__/Facilitator.inviteGate.test.tsx
+++ b/frontend/src/__tests__/Facilitator.inviteGate.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for the Facilitator-level invite-code probe + gate render
+ * orchestration. The gate component itself is covered in
+ * ``InviteGate.test.tsx``; this file pins the orchestration contract:
+ *
+ * - The wizard does NOT render while the mount-time probe is in flight.
+ * - The wizard renders when the server reports the gate is off.
+ * - A returning visitor with a stored + still-valid code skips the
+ *   gate entirely (no wizard-filling-then-bouncing UX from the
+ *   user-agent review HIGH-1).
+ * - A returning visitor with a stored + invalid code lands on the
+ *   gate (stored value cleared) without filling the wizard first.
+ * - A first-time visitor on a gated deploy lands on the gate.
+ *
+ * The WS module is stubbed because the test stays on the intro phase
+ * and never opens a session, but the import path runs ``new WsClient``
+ * inside the connect effect anyway.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/ws", () => {
+  return {
+    WsClient: class {
+      connect() {
+        /* no-op */
+      }
+      close() {
+        /* no-op */
+      }
+      send() {
+        /* no-op */
+      }
+    },
+  };
+});
+
+import { api } from "../api/client";
+import { Facilitator } from "../pages/Facilitator";
+import {
+  INVITE_CODE_STORAGE_KEY,
+  readStoredInviteCode,
+} from "../lib/inviteCodeStorage";
+
+describe("Facilitator — invite-code probe orchestration", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the loading state while the mount-time probe is in flight", async () => {
+    // Probe never resolves → component sticks on the loader. ``aria-busy``
+    // on the section is the marker.
+    vi.spyOn(api, "getInviteStatus").mockReturnValue(
+      new Promise(() => undefined),
+    );
+    render(<Facilitator />);
+    expect(
+      await screen.findByLabelText(/checking access/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(/What happened, when, at what severity/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the wizard when the server reports no gate", async () => {
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: false,
+      valid: null,
+    });
+    render(<Facilitator />);
+    expect(
+      await screen.findByPlaceholderText(
+        /What happened, when, at what severity/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the gate (not the wizard) on a first-time visit to a gated deploy", async () => {
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: true,
+      valid: null,
+    });
+    render(<Facilitator />);
+    expect(
+      await screen.findByLabelText(/invite code/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(/What happened, when, at what severity/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("skips the gate for a returning visitor whose stored code is still valid", async () => {
+    window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, "tabletop-2026");
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: true,
+      valid: true,
+    });
+    render(<Facilitator />);
+    expect(
+      await screen.findByPlaceholderText(
+        /What happened, when, at what severity/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/invite code/i)).not.toBeInTheDocument();
+    expect(readStoredInviteCode()).toBe("tabletop-2026");
+  });
+
+  it("clears storage + shows the gate when a returning visitor's stored code is no longer valid", async () => {
+    // The user-agent review HIGH-1 — a returning visitor with a
+    // rotated-since-last-visit code MUST NOT fill out the wizard
+    // first. The revalidation lives at the Facilitator probe.
+    window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, "old-code");
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: true,
+      valid: false,
+    });
+    render(<Facilitator />);
+    expect(
+      await screen.findByLabelText(/invite code/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(/What happened, when, at what severity/i),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(readStoredInviteCode()).toBeNull();
+    });
+  });
+
+  it("falls open to the wizard on a probe network error rather than soft-bricking", async () => {
+    vi.spyOn(api, "getInviteStatus").mockRejectedValue(new Error("offline"));
+    render(<Facilitator />);
+    expect(
+      await screen.findByPlaceholderText(
+        /What happened, when, at what severity/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Facilitator.looksReady.test.tsx
+++ b/frontend/src/__tests__/Facilitator.looksReady.test.tsx
@@ -111,6 +111,17 @@ describe("Facilitator — handleLooksReady doesn't auto-finalize (regression)", 
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    // Resolve the mount-time invite-code probe to "no gate" so the
+    // wizard renders after a microtask flush instead of staying on
+    // the loader. The test mounts <Facilitator/> and reaches for
+    // wizard fields synchronously; without this mock the probe
+    // rejects (no fetch handler in jsdom) and the catch flips
+    // ``inviteRequired`` to false eventually — but ``findBy*``
+    // already polls, so an explicit mock is simpler.
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: false,
+      valid: null,
+    });
   });
 
   afterEach(() => {
@@ -150,7 +161,9 @@ describe("Facilitator — handleLooksReady doesn't auto-finalize (regression)", 
 
     // Walk the intro wizard: scenario textarea (Step 1) → next →
     // next → ROLL SESSION. The creator label pre-fills to "CISO".
-    const scenarioBox = screen.getByPlaceholderText(
+    // Wait for the wizard to render after the invite-code probe
+    // resolves (the probe is a microtask flush in tests).
+    const scenarioBox = await screen.findByPlaceholderText(
       /What happened, when, at what severity/i,
     );
     fireEvent.change(scenarioBox, {

--- a/frontend/src/__tests__/InviteGate.test.tsx
+++ b/frontend/src/__tests__/InviteGate.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Component tests for the soft anti-strangers invite gate.
+ *
+ * Pins the contract <Facilitator/> depends on: the user can submit a
+ * code, the submit path revalidates against ``api.getInviteStatus``,
+ * valid codes persist to localStorage + call ``onValidated``, invalid
+ * ones surface an inline error without storing anything, and a
+ * ``staleNotice`` prop renders the operator-rotated-code recovery
+ * banner. The stored-code revalidation on mount is <Facilitator/>'s
+ * responsibility (covered in ``Facilitator.intro.test.tsx``), not
+ * the gate's — keeping it here would split the source of truth.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../api/client";
+import { InviteGate } from "../components/InviteGate";
+import { readStoredInviteCode } from "../lib/inviteCodeStorage";
+
+describe("InviteGate", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("calls onValidated and persists the code when the server accepts it", async () => {
+    const onValidated = vi.fn();
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: true,
+      valid: true,
+    });
+    render(<InviteGate onValidated={onValidated} />);
+
+    fireEvent.change(screen.getByLabelText(/invite code/i), {
+      target: { value: "tabletop-2026" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(onValidated).toHaveBeenCalledWith("tabletop-2026");
+    });
+    expect(readStoredInviteCode()).toBe("tabletop-2026");
+  });
+
+  it("surfaces an inline error and does not persist when the server rejects", async () => {
+    const onValidated = vi.fn();
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: true,
+      valid: false,
+    });
+    render(<InviteGate onValidated={onValidated} />);
+
+    fireEvent.change(screen.getByLabelText(/invite code/i), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/didn't match/i);
+    });
+    expect(onValidated).not.toHaveBeenCalled();
+    expect(readStoredInviteCode()).toBeNull();
+  });
+
+  it("blocks submit on an empty / whitespace-only code without probing the server", async () => {
+    const onValidated = vi.fn();
+    const probe = vi.spyOn(api, "getInviteStatus");
+    render(<InviteGate onValidated={onValidated} />);
+
+    fireEvent.change(screen.getByLabelText(/invite code/i), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/enter the invite code/i);
+    expect(probe).not.toHaveBeenCalled();
+    expect(onValidated).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a network error instead of silently dropping the submit", async () => {
+    const onValidated = vi.fn();
+    vi.spyOn(api, "getInviteStatus").mockRejectedValue(new Error("boom"));
+    render(<InviteGate onValidated={onValidated} />);
+
+    fireEvent.change(screen.getByLabelText(/invite code/i), {
+      target: { value: "tabletop-2026" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/boom/);
+    });
+    expect(onValidated).not.toHaveBeenCalled();
+    expect(readStoredInviteCode()).toBeNull();
+  });
+
+  it("renders the staleNotice banner above the input when provided", () => {
+    render(
+      <InviteGate
+        onValidated={() => undefined}
+        staleNotice="Your invite code is no longer valid."
+      />,
+    );
+    expect(
+      screen.getByText(/no longer valid/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -247,11 +247,34 @@ export interface DevScenarioList {
 }
 
 /**
- * Strip query-string secrets ({@code token=...}) from a path before logging.
- * Tokens are bearer credentials — leaking them via console is a real bug.
+ * Strip query-string secrets ({@code token=...}, {@code code=...},
+ * {@code invite_code=...}) from a path before logging. These are
+ * bearer credentials of varying sensitivity — leaking them via the
+ * browser console is a real bug. The matching backend scrubber lives
+ * at ``backend/app/logging_setup.py::_scrub_path_bytes``; keep the
+ * two regex sets in sync.
  */
 function _scrub(path: string): string {
-  return path.replace(/([?&]token=)[^&]+/gi, "$1***");
+  return path
+    .replace(/([?&]token=)[^&]+/gi, "$1***")
+    .replace(/([?&](?:code|invite_code)=)[^&]+/gi, "$1***");
+}
+
+/**
+ * Error thrown by {@link request} for any non-2xx response. Carries
+ * the HTTP ``status`` so callers can branch on the precise rejection
+ * (e.g. a 403 invite-gate rejection vs. a generic 400) without
+ * substring-matching the ``message`` — substring matches collide as
+ * soon as a sibling endpoint uses an overlapping word (e.g.
+ * ``invitee_roles`` failures alongside ``invite`` gate failures).
+ */
+export class ApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
 }
 
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
@@ -273,7 +296,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
       /* ignore */
     }
     console.warn(`[api] ${method} ${safePath} → ${res.status} (${ms}ms)`, detail);
-    throw new Error(detail);
+    throw new ApiError(detail, res.status);
   }
   const out = (await res.json()) as T;
   console.debug(`[api] ${method} ${safePath} → ${res.status} (${ms}ms)`);
@@ -309,7 +332,33 @@ export const DEFAULT_SESSION_FEATURES: SessionFeatures = {
   media_pressure: false,
 };
 
+/** Shape returned by ``GET /api/invite/status``. ``required`` reflects
+ *  whether the server has the ``INVITE_CODE`` env var set; ``valid``
+ *  is ``null`` when no ``?code=`` was supplied or when no gate runs.
+ *  The frontend hits this on the facilitator page mount to decide
+ *  whether to show the gate UI, and again on submit to validate the
+ *  user's entry without going through the heavier create-session
+ *  path. */
+export interface InviteStatus {
+  required: boolean;
+  valid: boolean | null;
+}
+
 export const api = {
+  /** Probe the soft anti-strangers gate.
+   *
+   *  ``code`` is optional: without it, the response just says
+   *  whether the gate is on. With it, ``valid`` reports whether the
+   *  supplied code matches. The backend logs rejected probes at
+   *  WARNING so brute-force attempts surface in normal log scans;
+   *  the code is never logged. */
+  async getInviteStatus(code?: string): Promise<InviteStatus> {
+    const qs = code != null && code.length > 0
+      ? `?code=${encodeURIComponent(code)}`
+      : "";
+    return request("GET", `/api/invite/status${qs}`);
+  },
+
   async createSession(body: {
     scenario_prompt: string;
     creator_label: string;
@@ -332,6 +381,11 @@ export const api = {
       duration_minutes: number;
       features: SessionFeatures;
     };
+    /** Soft anti-strangers gate. Required when the server has
+     *  ``INVITE_CODE`` set; ignored otherwise. The gate UI on the
+     *  facilitator page reads it from localStorage and threads it
+     *  through here. Player join links don't need it. */
+    invite_code?: string;
   }): Promise<{
     session_id: string;
     creator_role_id: string;

--- a/frontend/src/components/InviteGate.tsx
+++ b/frontend/src/components/InviteGate.tsx
@@ -1,0 +1,248 @@
+import { type FormEvent, useId, useState } from "react";
+import { api } from "../api/client";
+import { writeStoredInviteCode } from "../lib/inviteCodeStorage";
+import { Eyebrow } from "./brand/Eyebrow";
+import { SiteHeader } from "./brand/SiteHeader";
+
+/**
+ * Soft anti-strangers gate rendered ahead of the facilitator wizard
+ * when the server has ``INVITE_CODE`` set. Public-URL deploys (e.g.
+ * the crittable.app Cloudflare tunnel) use it to keep random web
+ * traffic from spending LLM tokens on session creation; player join
+ * links don't need it because they already carry per-role HMAC tokens.
+ *
+ * Lifecycle:
+ *   1. <Facilitator> probes ``api.getInviteStatus(storedCode)`` on
+ *      mount. The single probe answers both "is the gate on?" and
+ *      "is the stored code still valid?" — so a returning visitor
+ *      with a rotated-since-last-visit code lands here directly,
+ *      not after filling out the whole wizard.
+ *   2. If the probe says required + invalid (or no stored code),
+ *      <Facilitator> renders this component. The user pastes the
+ *      code; we re-check via ``getInviteStatus(code)``.
+ *   3. On ``valid: true`` we persist via the ``inviteCodeStorage``
+ *      module and call ``onValidated(code)``. <Facilitator> threads
+ *      that code into ``createSession`` and clears it from storage
+ *      if the create call later 403s (the rotated-code recovery
+ *      path; <Facilitator> remounts us with a ``staleNotice``).
+ *
+ * The gate is intentionally NOT a security boundary against a
+ * motivated attacker — it's a stopgap so a public URL doesn't burn
+ * LLM tokens on every drive-by. Pair with ``RATE_LIMIT_ENABLED=true``
+ * on the backend so a brute-forcer can't grind through the code.
+ */
+
+interface Props {
+  /** Called once the entered code is server-validated and stored. */
+  onValidated: (code: string) => void;
+  /** Optional banner shown above the input — used by <Facilitator>
+   *  on the stale-code-after-rotation recovery path so the user
+   *  knows why the gate is back instead of seeing a bare prompt. */
+  staleNotice?: string | null;
+}
+
+export function InviteGate({ onValidated, staleNotice }: Props) {
+  const inputId = useId();
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = code.trim();
+    if (trimmed.length === 0) {
+      setError("Enter the invite code provided to you.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const status = await api.getInviteStatus(trimmed);
+      if (!status.required) {
+        // Gate was removed server-side between mount and submit; let
+        // the user through and don't bother persisting a now-unused
+        // code.
+        onValidated(trimmed);
+        return;
+      }
+      if (status.valid !== true) {
+        setError(
+          "That code didn't match. Watch for stray spaces or look-alike characters (0/O, 1/l).",
+        );
+        return;
+      }
+      writeStoredInviteCode(trimmed);
+      onValidated(trimmed);
+    } catch (err) {
+      const detail =
+        err instanceof Error && err.message ? err.message : "Network error";
+      console.warn("[invite] validation failed", detail);
+      setError(`Couldn't reach the server (${detail}). Try again.`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main
+      className="grid min-h-screen grid-cols-1"
+      style={{ background: "var(--ink-900)" }}
+    >
+      <SiteHeader />
+      <section
+        className="flex flex-1 items-start justify-center overflow-auto p-5 lg:p-8"
+        style={{ minHeight: 0 }}
+      >
+        <div
+          className="flex flex-col gap-5"
+          style={{
+            width: "100%",
+            maxWidth: 480,
+            marginTop: "8vh",
+            padding: 24,
+            background: "var(--ink-800)",
+            border: "1px solid var(--ink-600)",
+            borderRadius: 4,
+          }}
+        >
+          <header className="flex flex-col gap-2">
+            <Eyebrow>Access · Invite required</Eyebrow>
+            <h1
+              className="sans"
+              style={{
+                fontSize: 26,
+                fontWeight: 600,
+                color: "var(--ink-050)",
+                margin: 0,
+                letterSpacing: "-0.01em",
+              }}
+            >
+              Enter your invite code to start a session
+            </h1>
+            <p
+              className="sans"
+              style={{
+                fontSize: 13,
+                color: "var(--ink-300)",
+                margin: 0,
+                lineHeight: 1.5,
+              }}
+            >
+              Session creation is gated. Paste your invite code below.
+              Already invited as a player? Use the link you were sent —
+              no code needed. Self-hosting? Check{" "}
+              <code
+                className="mono"
+                style={{
+                  background: "var(--ink-700)",
+                  padding: "1px 6px",
+                  borderRadius: 2,
+                  fontSize: 12,
+                  color: "var(--ink-100)",
+                }}
+              >
+                INVITE_CODE
+              </code>{" "}
+              in your backend env (unset to disable this gate). The
+              backend rate-limits invalid attempts.
+            </p>
+          </header>
+          {staleNotice ? (
+            <div
+              role="status"
+              className="sans"
+              style={{
+                fontSize: 12,
+                color: "var(--warn)",
+                background: "var(--warn-bg)",
+                border: "1px solid var(--warn)",
+                borderRadius: 2,
+                padding: "8px 10px",
+                lineHeight: 1.5,
+              }}
+            >
+              {staleNotice}
+            </div>
+          ) : null}
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-3"
+            noValidate
+          >
+            <label
+              htmlFor={inputId}
+              className="mono"
+              style={{
+                fontSize: 11,
+                letterSpacing: "0.18em",
+                textTransform: "uppercase",
+                color: "var(--ink-300)",
+                fontWeight: 700,
+              }}
+            >
+              Invite code
+            </label>
+            <input
+              id={inputId}
+              name="invite_code"
+              type="text"
+              autoComplete="one-time-code"
+              autoFocus
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              disabled={busy}
+              spellCheck={false}
+              maxLength={128}
+              className="mono invite-input"
+              style={{
+                background: "var(--ink-700)",
+                color: "var(--ink-100)",
+                border: `1px solid ${error ? "var(--crit)" : "var(--ink-500)"}`,
+                borderRadius: 2,
+                padding: "10px 12px",
+                fontSize: 14,
+                letterSpacing: "0.04em",
+                outline: "none",
+              }}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? `${inputId}-error` : undefined}
+            />
+            {error ? (
+              <div
+                id={`${inputId}-error`}
+                role="alert"
+                className="sans"
+                style={{
+                  fontSize: 12,
+                  color: "var(--crit)",
+                }}
+              >
+                {error}
+              </div>
+            ) : null}
+            <button
+              type="submit"
+              disabled={busy}
+              className="mono invite-submit"
+              style={{
+                marginTop: 4,
+                padding: "10px 16px",
+                background: busy ? "var(--ink-700)" : "var(--signal)",
+                color: busy ? "var(--ink-300)" : "var(--ink-950)",
+                border: "1px solid var(--signal-deep)",
+                borderRadius: 2,
+                fontSize: 12,
+                fontWeight: 700,
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                cursor: busy ? "wait" : "pointer",
+              }}
+            >
+              {busy ? "Checking…" : "Continue"}
+            </button>
+          </form>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -442,3 +442,16 @@ html, body {
   outline-offset: 4px;
   border-radius: 2px;
 }
+
+/*
+ * Invite gate — a11y BLOCK from the UI/UX review. The card is a
+ * single-control surface; without a focus ring keyboard users get
+ * zero feedback. Both the input and submit need it; the input also
+ * unsets the default outline so the ring lives only on
+ * ``:focus-visible`` (not on mouse-click focus).
+ */
+.invite-input:focus-visible,
+.invite-submit:focus-visible {
+  outline: 2px solid var(--signal);
+  outline-offset: 2px;
+}

--- a/frontend/src/lib/inviteCodeStorage.ts
+++ b/frontend/src/lib/inviteCodeStorage.ts
@@ -1,0 +1,39 @@
+/**
+ * Storage helpers for the soft anti-strangers invite gate.
+ *
+ * Kept in a separate module from the <InviteGate/> component so
+ * React's fast-refresh plugin can hot-reload the gate without
+ * tripping the "only export components" rule. Two callers:
+ *
+ * - <InviteGate/> reads / writes the code as the user enters it.
+ * - <Facilitator/> reads at mount and clears on a stale-code 403.
+ */
+
+export const INVITE_CODE_STORAGE_KEY = "crittable.invite_code";
+
+export function readStoredInviteCode(): string | null {
+  try {
+    const v = window.localStorage.getItem(INVITE_CODE_STORAGE_KEY);
+    return v && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredInviteCode(code: string): void {
+  try {
+    window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, code);
+  } catch {
+    // localStorage may be disabled (private mode, strict CSP). The
+    // user is re-prompted next visit; no functional break this
+    // session.
+  }
+}
+
+export function clearStoredInviteCode(): void {
+  try {
+    window.localStorage.removeItem(INVITE_CODE_STORAGE_KEY);
+  } catch {
+    /* best-effort */
+  }
+}

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   api,
+  ApiError,
   CostSnapshot,
   DecisionLogEntry,
   DEFAULT_SESSION_FEATURES,
@@ -35,6 +36,12 @@ import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
 import { TurnStateRail } from "../components/brand/TurnStateRail";
 import { SetupWizard, type SetupRoleSlot } from "../components/setup/SetupWizard";
+import { InviteGate } from "../components/InviteGate";
+import {
+  clearStoredInviteCode,
+  readStoredInviteCode,
+} from "../lib/inviteCodeStorage";
+import { SiteHeader } from "../components/brand/SiteHeader";
 import { SetupLobbyView } from "../components/setup/SetupLobbyView";
 import { SetupReviewView } from "../components/setup/SetupReviewView";
 import { PlanView } from "../components/setup/PlanView";
@@ -265,6 +272,81 @@ export function Facilitator() {
       canceled = true;
     };
   }, []);
+  // Soft anti-strangers gate on session creation (env: ``INVITE_CODE``).
+  // Tri-state: ``null`` while the mount-time probe is in flight (we
+  // render a tiny loader rather than flashing the wizard then snapping
+  // to the gate); ``false`` once the server confirms no gate; ``true``
+  // when the server confirms a gate AND we haven't already validated a
+  // code below. The probe answers both questions in one round-trip —
+  // is the gate on, and (if there's a localStorage code) is it still
+  // valid — so a returning visitor whose code was rotated mid-night
+  // lands on the gate directly instead of after filling out the whole
+  // wizard. Backend re-validates on ``POST /api/sessions`` regardless,
+  // so a stale localStorage value or a missed probe still get caught
+  // there; the front-side gate is the UX layer, not the security
+  // boundary.
+  const [inviteRequired, setInviteRequired] = useState<boolean | null>(null);
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+  const [staleInviteNotice, setStaleInviteNotice] = useState<string | null>(
+    null,
+  );
+  useEffect(() => {
+    let canceled = false;
+    (async () => {
+      const stored = readStoredInviteCode();
+      try {
+        // One round-trip resolves both questions:
+        // - status.required → is the gate on?
+        // - status.valid (when ?code= passed) → is the stored code still valid?
+        const status = await api.getInviteStatus(stored ?? undefined);
+        if (canceled) return;
+        if (!status.required) {
+          // Server isn't gating; drop any stale stored value so a
+          // later flip back to gated doesn't accept a now-untrusted
+          // leftover.
+          clearStoredInviteCode();
+          setInviteCode(null);
+          setInviteRequired(false);
+          return;
+        }
+        if (stored && status.valid === true) {
+          // Returning visitor with a still-valid code: skip the gate.
+          setInviteCode(stored);
+          setInviteRequired(true);
+          return;
+        }
+        // Either no stored code, or the stored one no longer matches.
+        // Drop it so the next render shows the gate cleanly.
+        if (stored && status.valid !== true) {
+          clearStoredInviteCode();
+          console.info(
+            "[facilitator] stored invite code is no longer valid; re-prompting",
+          );
+        }
+        setInviteCode(null);
+        setInviteRequired(true);
+      } catch (err) {
+        // Fall open rather than soft-bricking the page on a transient
+        // network error — the backend re-validates on
+        // ``POST /api/sessions`` regardless, so a real gate still
+        // closes there. Log so the audit trail explains why the gate
+        // didn't render. Carry any stored code forward so a session
+        // create can still succeed when the wifi recovers.
+        console.warn(
+          "[facilitator] invite-status probe failed; assuming gate off",
+          err,
+        );
+        if (!canceled) {
+          setInviteRequired(false);
+          if (stored) setInviteCode(stored);
+        }
+      }
+    })();
+    return () => {
+      canceled = true;
+    };
+  }, []);
+
   const [setupReply, setSetupReply] = useState("");
   const [error, setError] = useState<string | null>(null);
   // Issue #191 — most recent ``{type: "error", scope: "upstream_llm"}``
@@ -631,6 +713,11 @@ export function Facilitator() {
           duration_minutes: durationMinutes,
           features,
         },
+        // Soft anti-strangers gate. ``null`` when the server has no
+        // ``INVITE_CODE`` set; populated from <InviteGate/> via
+        // localStorage when it does. The backend re-validates and
+        // returns 403 if it doesn't match (handled below).
+        ...(inviteCode != null ? { invite_code: inviteCode } : {}),
       });
       // Don't log the response object — it carries the creator token in
       // ``creator_token`` and ``creator_join_url``. Log only non-secret IDs.
@@ -696,8 +783,27 @@ export function Facilitator() {
       setSnapshot(snap);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.warn("[facilitator] create_session_failed", msg, err);
-      setError(msg);
+      // Stale-invite recovery: the gate is the only path that returns
+      // 403 from POST /api/sessions, so a status check is enough — no
+      // substring-matching the detail string, which would collide
+      // with any future error mentioning "invitee" (the codebase
+      // already has ``invitee_roles`` / ``failed_invitees``). Wipe
+      // the stored code, surface a stale-code notice on the gate
+      // itself (the wizard is about to unmount, so an error string in
+      // the wizard's error slot wouldn't reach the user), and let the
+      // <InviteGate/> render path show.
+      if (err instanceof ApiError && err.status === 403) {
+        console.warn("[facilitator] create_session_invite_rejected", msg);
+        clearStoredInviteCode();
+        setInviteCode(null);
+        setInviteRequired(true);
+        setStaleInviteNotice(
+          "Your invite code is no longer valid — likely rotated by the operator. Enter the current code to continue.",
+        );
+      } else {
+        console.warn("[facilitator] create_session_failed", msg, err);
+        setError(msg);
+      }
     } finally {
       setBusy(false);
       setBusyMessage(null);
@@ -1513,6 +1619,45 @@ export function Facilitator() {
   };
 
   if (phase === "intro") {
+    // While the mount-time probe is in flight (``inviteRequired ===
+    // null``) we render a tiny <SiteHeader> + <DieLoader> rather
+    // than flashing the wizard then snapping to the gate. The probe
+    // is one round-trip (~50–200 ms) and the spinner is honest about
+    // it. UI/UX review HIGH H1.
+    if (inviteRequired === null) {
+      return (
+        <main
+          className="grid min-h-screen grid-cols-1"
+          style={{ background: "var(--ink-900)" }}
+        >
+          <SiteHeader />
+          <section
+            className="flex flex-1 items-center justify-center"
+            style={{ minHeight: 0 }}
+            aria-busy="true"
+            aria-label="Checking access"
+          >
+            <DieLoader />
+          </section>
+        </main>
+      );
+    }
+    // Gate enforced when the server requires it AND we haven't
+    // validated a code yet. The backend re-validates on POST
+    // ``/api/sessions`` regardless, so a desync between probe and
+    // POST still gets caught at the boundary.
+    if (inviteRequired && inviteCode === null) {
+      return (
+        <InviteGate
+          staleNotice={staleInviteNotice}
+          onValidated={(code) => {
+            console.info("[facilitator] invite gate validated");
+            setStaleInviteNotice(null);
+            setInviteCode(code);
+          }}
+        />
+      );
+    }
     return (
       <SetupWizard
         phase="intro"


### PR DESCRIPTION
## Summary

Stopgap to keep random web traffic on the new `crittable.app` Cloudflare deploy from spending LLM tokens on session creation without standing up a full auth stack. Env-var driven, no DB, no user model.

- **Backend** — `INVITE_CODE` env var; `POST /api/sessions` returns 403 unless the request carries a matching `invite_code` (constant-time `hmac.compare_digest`, whitespace stripped). `GET /api/invite/status[?code=]` lets the frontend probe both "is the gate on?" and "is this code still valid?" in one round-trip. Player join links keep their per-role HMAC tokens and are untouched.
- **Frontend** — `<InviteGate>` upfront card on the creator path (`/new`). Validated codes persist in `localStorage` so refreshes don't re-prompt. Facilitator mount-time probe also re-validates any stored code so a user whose code was rotated since their last visit lands on the gate directly, not after filling out the entire wizard. Landing (`/`) and player routes (`/play/...`) stay public.
- **Hardening** — backend access-log path scrubber (`_scrub_path_bytes`) and frontend `[api]` console scrubber both redact `?code=` / `?invite_code=`. `GET /api/invite/status` query length-capped at 128 chars so a no-rate-limit deploy can't be ground with `?code=<5MB>`. Startup logs `invite_code_gate_enabled` (INFO) and `invite_code_set_without_rate_limit` (WARN) when the operator forgot `RATE_LIMIT_ENABLED=true`.

Six sub-agent reviews ran in parallel (QA, Security, UI/UX, Product, User-persona; Prompt Expert skipped — zero prompts touched). Every BLOCK / HIGH was addressed in the same commit: input focus-visible (a11y BLOCK), tri-state probe + DieLoader to kill the wizard-then-gate flash (UI/UX HIGH), revalidation moved up so returning visitors with a rotated code don't fill the wizard first (User HIGH), HTTP-status-based stale-code detection instead of substring-matching `"invite"` (Product MEDIUM), self-host recovery hint in the gate copy (User HIGH), code redacted from both log paths (Security HIGH).

Carve-outs documented in commit body: live-LLM tests skipped (zero LLM code touched), no new scenario fixture (gate runs pre-`create_session`, no lifecycle change).

## Test plan
- [x] `pytest backend/tests/test_invite_code.py` — 16 new tests (helpers, status endpoint, create gate, caplog assertions for WARNINGs, access-log redaction)
- [x] Full backend `pytest` — 999 passing, 25 scenarios passing
- [x] `ruff check .` + `mypy --strict app` clean
- [x] Frontend `vitest --run` — 567 passing (includes 5 `<InviteGate>` component tests + 6 Facilitator orchestration tests)
- [x] `npm run lint` + `npm run typecheck` clean
- [ ] Manual smoke: set `INVITE_CODE=foo` in `.env`, run `docker compose up`, confirm `/new` shows gate, valid code persists across refresh, `?token` join links still work without code, `INVITE_CODE` rotation puts returning visitor straight back on the gate
- [ ] Manual smoke: unset `INVITE_CODE`, confirm wizard shows immediately with no flicker
- [ ] Manual smoke: confirm access-log line for `GET /api/invite/status?code=secret` shows `code=***`, not the value

https://claude.ai/code/session_01TrM35EW5m5LhirZNMc3Es2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrM35EW5m5LhirZNMc3Es2)_