### PR TITLE
frontend: persist new-session wizard draft across page refresh

### DIFF
--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -1,8 +1,13 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { Facilitator, TopBar } from "../pages/Facilitator";
 import { BottomActionBar } from "../components/brand/BottomActionBar";
 import { api } from "../api/client";
+import {
+  SESSION_DRAFT_STORAGE_KEY,
+  writeStoredSessionDraft,
+} from "../lib/sessionDraftStorage";
+import { DEFAULT_SESSION_FEATURES } from "../api/client";
 
 // Setup wizard splits the form across 3 steps (Scenario → Environment
 // → Roles). Roles live on step 3, so every Roles assertion needs the
@@ -247,6 +252,199 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     expect(
       screen.queryByText(/won't be auto-added as a separate invitee/i),
     ).not.toBeInTheDocument();
+  });
+});
+
+// Refresh-recovery: filling out the wizard then "refreshing" (i.e.
+// unmounting + re-mounting <Facilitator/>) must restore the form
+// fields the operator already typed. Without this, an accidental
+// refresh wipes the entire setup — scenario brief, team, env,
+// constraints, tuning panel, role roster. Storage round-trip is
+// covered separately in sessionDraftStorage.test.ts; this block
+// covers the wiring inside <Facilitator/>.
+describe("Facilitator intro — refresh recovery", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
+      required: false,
+      valid: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("restores scenario brief + current step after re-mount", async () => {
+    const { unmount } = render(<Facilitator />);
+    // Find + fill scenario, then advance one step so we exercise
+    // both per-field persistence AND introStep persistence.
+    const scenario = await screen.findByLabelText(/SCENARIO BRIEF/i);
+    fireEvent.change(scenario, {
+      target: { value: "Ransomware end-quarter close" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /NEXT · ENVIRONMENT/i }),
+    );
+    // Simulate a refresh by tearing down the React tree and rendering
+    // a fresh <Facilitator/>. sessionStorage survives the unmount.
+    unmount();
+    render(<Facilitator />);
+    // Step 2's environment header is the marker for "we landed on
+    // step 2, not step 1". On step 1 the page header reads "Set the
+    // scene"; on step 2 it reads "Shape the exercise".
+    expect(
+      await screen.findByText(/Shape the exercise/i),
+    ).toBeInTheDocument();
+    // The scenario brief value is preserved across the refresh
+    // even though step 2 doesn't render the SCENARIO textarea —
+    // navigate back to step 1 to confirm.
+    fireEvent.click(screen.getByRole("button", { name: /← BACK/i }));
+    const restored = (await screen.findByLabelText(
+      /SCENARIO BRIEF/i,
+    )) as HTMLTextAreaElement;
+    expect(restored.value).toBe("Ransomware end-quarter close");
+  });
+
+  it("restores role-roster edits after re-mount", async () => {
+    const { unmount } = render(<Facilitator />);
+    await advanceToRoles();
+    // Toggle a builtin OFF + add a custom row. The OFF pill is the
+    // one that flips an ACTIVE row off (the ACTIVE pill is a no-op
+    // when the row is already active).
+    fireEvent.click(
+      screen.getByRole("button", { name: /Executive Sponsor off/i }),
+    );
+    const draft = screen.getByLabelText("New role label") as HTMLInputElement;
+    fireEvent.change(draft, { target: { value: "Threat Intel" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add role" }));
+    // Refresh.
+    unmount();
+    render(<Facilitator />);
+    // We're back on step 3 because introStep persisted.
+    expect(
+      await screen.findByRole("group", { name: /Roles to invite/i }),
+    ).toBeInTheDocument();
+    // Custom row survives the round-trip.
+    expect(
+      within(getRolesFieldset()).getByText("Threat Intel"),
+    ).toBeInTheDocument();
+    // Executive Sponsor stays OFF after the round-trip.
+    expect(
+      screen.getByRole("button", { name: /Executive Sponsor off/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("clears stored draft after a successful session create", async () => {
+    // QA review MEDIUM: regression net for the
+    // ``clearStoredSessionDraft()`` call inside ``handleCreate``.
+    // Without this test a future refactor that drops the clear
+    // would leave a stale draft in storage and a refresh after
+    // create would dump the operator back into the wizard with
+    // pre-populated form fields.
+    vi.spyOn(api, "createSession").mockResolvedValue({
+      session_id: "session_test",
+      creator_role_id: "role_creator",
+      creator_token: "tok_creator",
+      creator_join_url: "http://localhost/play/session_test/tok_creator",
+      failed_invitees: [],
+    });
+    vi.spyOn(api, "getSession").mockResolvedValue({
+      id: "session_test",
+      state: "SETUP",
+      created_at: "2026-05-05T00:00:00Z",
+      scenario_prompt: "scenario",
+      plan_title: null,
+      plan_summary: null,
+      settings: {
+        difficulty: "standard",
+        duration_minutes: 60,
+        features: { ...DEFAULT_SESSION_FEATURES },
+      },
+      plan: null,
+      roles: [],
+      current_turn: null,
+      messages: [],
+      setup_notes: [],
+      cost: null,
+      workstreams: [],
+    });
+    // Pre-seed a draft so we can assert it's gone after create.
+    writeStoredSessionDraft({
+      setupParts: {
+        scenario: "to-be-cleared",
+        team: "",
+        environment: "",
+        constraints: "",
+      },
+      creatorLabel: "CISO",
+      creatorDisplayName: "Alice",
+      setupRoleSlots: [
+        {
+          key: "IC",
+          code: "IC",
+          label: "Incident Commander",
+          active: true,
+          builtin: true,
+        },
+      ],
+      setupRoleDraft: "",
+      difficulty: "standard",
+      durationMinutes: 60,
+      features: { ...DEFAULT_SESSION_FEATURES },
+      introStep: 3,
+    });
+    expect(
+      window.sessionStorage.getItem(SESSION_DRAFT_STORAGE_KEY),
+    ).not.toBeNull();
+    render(<Facilitator />);
+    // Land on step 3 thanks to the restored introStep.
+    await screen.findByRole("group", { name: /Roles to invite/i });
+    const rollBtn = screen.getByRole("button", { name: /ROLL SESSION/i });
+    const form = rollBtn.closest("form");
+    if (!form) throw new Error("ROLL SESSION button not inside a form");
+    fireEvent.submit(form);
+    // Wait for the storage entry to drop. The clear happens
+    // synchronously inside ``handleCreate`` right after the
+    // ``setState`` for the creator info.
+    await waitFor(() => {
+      expect(
+        window.sessionStorage.getItem(SESSION_DRAFT_STORAGE_KEY),
+      ).toBeNull();
+    });
+  });
+
+  it("preserves an explicitly emptied roster instead of re-seeding builtins", async () => {
+    // QA review HIGH: if the operator deliberately removed every
+    // builtin row, refreshing must NOT silently restore the canonical
+    // 5. Step 3's Add-role input remains available so the operator
+    // can recover from an empty list — that's the affordance, not a
+    // paternalistic re-seed.
+    const { unmount } = render(<Facilitator />);
+    await advanceToRoles();
+    // Remove all 5 builtins via the × button on each row.
+    for (const label of [
+      "Incident Commander",
+      "Cybersecurity Manager",
+      "Cybersecurity Engineer",
+      "Comms / Legal",
+      "Executive Sponsor",
+    ]) {
+      fireEvent.click(screen.getByLabelText(`Remove ${label}`));
+    }
+    // ROLL SESSION button is disabled (no active invitees).
+    expect(screen.getByRole("button", { name: /ROLL SESSION/i })).toBeDisabled();
+    // Refresh.
+    unmount();
+    render(<Facilitator />);
+    // After refresh we're still on Step 3 with an empty roster — no
+    // builtin re-seed. The submit button stays disabled.
+    expect(
+      await screen.findByRole("group", { name: /Roles to invite/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(getRolesFieldset()).queryByText("Incident Commander"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /ROLL SESSION/i })).toBeDisabled();
   });
 });
 

--- a/frontend/src/__tests__/sessionDraftStorage.test.ts
+++ b/frontend/src/__tests__/sessionDraftStorage.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for ``frontend/src/lib/sessionDraftStorage.ts``.
+ *
+ * The draft storage is the only thing standing between an operator's
+ * half-filled wizard and a tab-refresh wiping the form. The contract
+ * we care about:
+ *
+ *   * round-trips a complete draft byte-for-byte,
+ *   * tolerates an entirely missing entry without throwing,
+ *   * recovers field-by-field when a stored entry was written by a
+ *     prior schema (unknown field → default; valid field → kept),
+ *   * silently no-ops when ``sessionStorage`` is unavailable
+ *     (private mode, strict CSP, quota exhausted).
+ *
+ * A regression in any of these would either lose form data the user
+ * already typed, or — worse — let corrupt storage break the page on
+ * mount before the operator can even reach the form.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_SESSION_FEATURES } from "../api/client";
+import {
+  SESSION_DRAFT_STORAGE_KEY,
+  type SessionDraft,
+  clearStoredSessionDraft,
+  readStoredSessionDraft,
+  writeStoredSessionDraft,
+} from "../lib/sessionDraftStorage";
+
+function _completeDraft(): SessionDraft {
+  return {
+    setupParts: {
+      scenario: "Ransomware mid-quarter close",
+      team: "CISO + IR Lead + Legal",
+      environment: "Azure AD + Defender",
+      constraints: "No real CVEs",
+    },
+    creatorLabel: "CISO",
+    creatorDisplayName: "Alice",
+    setupRoleSlots: [
+      {
+        key: "IC",
+        code: "IC",
+        label: "Incident Commander",
+        description: "Owns the response.",
+        active: true,
+        builtin: true,
+      },
+      {
+        key: "custom-abc-123",
+        label: "Threat Intel",
+        active: false,
+        builtin: false,
+      },
+    ],
+    setupRoleDraft: "Forensics",
+    difficulty: "hard",
+    durationMinutes: 90,
+    features: {
+      active_adversary: true,
+      time_pressure: false,
+      executive_escalation: true,
+      media_pressure: true,
+    },
+    introStep: 2,
+  };
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe("sessionDraftStorage — round-trip", () => {
+  it("read returns null when nothing is stored", () => {
+    expect(readStoredSessionDraft()).toBeNull();
+  });
+
+  it("write + read returns the exact draft", () => {
+    const draft = _completeDraft();
+    writeStoredSessionDraft(draft);
+    expect(readStoredSessionDraft()).toEqual(draft);
+  });
+
+  it("clear removes the entry", () => {
+    writeStoredSessionDraft(_completeDraft());
+    clearStoredSessionDraft();
+    expect(readStoredSessionDraft()).toBeNull();
+  });
+
+  it("write overwrites an existing draft (no merge)", () => {
+    writeStoredSessionDraft(_completeDraft());
+    const next: SessionDraft = {
+      ..._completeDraft(),
+      setupParts: {
+        scenario: "Different scenario",
+        team: "",
+        environment: "",
+        constraints: "",
+      },
+      introStep: 3,
+    };
+    writeStoredSessionDraft(next);
+    expect(readStoredSessionDraft()).toEqual(next);
+  });
+});
+
+describe("sessionDraftStorage — schema tolerance", () => {
+  it("non-JSON storage returns null instead of throwing", () => {
+    window.sessionStorage.setItem(SESSION_DRAFT_STORAGE_KEY, "{not json");
+    expect(readStoredSessionDraft()).toBeNull();
+  });
+
+  it("non-object JSON returns null instead of throwing", () => {
+    window.sessionStorage.setItem(SESSION_DRAFT_STORAGE_KEY, "42");
+    expect(readStoredSessionDraft()).toBeNull();
+  });
+
+  it("missing setupParts falls back to empty strings", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({}),
+    );
+    const out = readStoredSessionDraft();
+    expect(out?.setupParts).toEqual({
+      scenario: "",
+      team: "",
+      environment: "",
+      constraints: "",
+    });
+  });
+
+  it("partial setupParts (missing a field) falls back to all-empty", () => {
+    // A field-type mismatch invalidates the whole subobject — we
+    // don't try to merge half-typed shape because partial-trust on
+    // free-text fields is just as user-confusing as fully losing
+    // them, and the validator stays simple.
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ setupParts: { scenario: "kept" } }),
+    );
+    const out = readStoredSessionDraft();
+    expect(out?.setupParts).toEqual({
+      scenario: "",
+      team: "",
+      environment: "",
+      constraints: "",
+    });
+  });
+
+  it("unknown difficulty falls back to standard", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ difficulty: "extreme" }),
+    );
+    expect(readStoredSessionDraft()?.difficulty).toBe("standard");
+  });
+
+  it("non-numeric durationMinutes falls back to 60", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ durationMinutes: "ninety" }),
+    );
+    expect(readStoredSessionDraft()?.durationMinutes).toBe(60);
+  });
+
+  it("malformed features falls back to defaults", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ features: { active_adversary: "yes" } }),
+    );
+    expect(readStoredSessionDraft()?.features).toEqual(
+      DEFAULT_SESSION_FEATURES,
+    );
+  });
+
+  it("invalid introStep falls back to 1", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ introStep: 4 }),
+    );
+    expect(readStoredSessionDraft()?.introStep).toBe(1);
+  });
+
+  it("setupRoleSlots: invalid entries are dropped; valid entries kept", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        setupRoleSlots: [
+          {
+            key: "IC",
+            label: "Incident Commander",
+            active: true,
+            builtin: true,
+          },
+          { key: 42, label: "bad" }, // wrong type → dropped
+          { label: "no key" }, // missing key → dropped
+          {
+            key: "custom-1",
+            label: "Threat Intel",
+            active: false,
+            builtin: false,
+          },
+        ],
+      }),
+    );
+    const slots = readStoredSessionDraft()?.setupRoleSlots ?? [];
+    expect(slots.map((s) => s.key)).toEqual(["IC", "custom-1"]);
+  });
+
+  it("non-array setupRoleSlots returns empty array (caller falls back to builtins)", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ setupRoleSlots: "oops" }),
+    );
+    expect(readStoredSessionDraft()?.setupRoleSlots).toEqual([]);
+  });
+
+  it("partial setupParts with wrong field TYPE (not just missing) falls back to empty", () => {
+    // The validator rejects {scenario: 42, team: "ok", ...} because
+    // ``scenario`` isn't a string. Per the rest of the contract, the
+    // whole sub-object falls back to all-empty rather than half-typed.
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        setupParts: {
+          scenario: 42,
+          team: "ok",
+          environment: "",
+          constraints: "",
+        },
+      }),
+    );
+    expect(readStoredSessionDraft()?.setupParts).toEqual({
+      scenario: "",
+      team: "",
+      environment: "",
+      constraints: "",
+    });
+  });
+
+  it("durationMinutes NaN falls back to default 60", () => {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      // JSON can't carry NaN literally — JSON.stringify drops it to
+      // null. Test the typeof-narrowing branch with a string instead,
+      // then assert the bound semantics with a separate test below.
+      JSON.stringify({ durationMinutes: null }),
+    );
+    expect(readStoredSessionDraft()?.durationMinutes).toBe(60);
+  });
+
+  it("durationMinutes is clamped to the backend's [15, 180] range", () => {
+    // Defense-in-depth: even though the wizard's range input visually
+    // clamps and the backend rejects out-of-band values with 400, the
+    // storage boundary clamps so a hand-edited sessionStorage entry
+    // can't dump an absurd value into a UI label like "10000000 MIN".
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ durationMinutes: 99999 }),
+    );
+    expect(readStoredSessionDraft()?.durationMinutes).toBe(180);
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ durationMinutes: 1 }),
+    );
+    expect(readStoredSessionDraft()?.durationMinutes).toBe(15);
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify({ durationMinutes: -100 }),
+    );
+    expect(readStoredSessionDraft()?.durationMinutes).toBe(15);
+  });
+});
+
+describe("sessionDraftStorage — silent-failure logging", () => {
+  // CLAUDE.md "Logging rules" require every broad catch to log so a
+  // user reporting "my draft didn't restore" gives the operator a
+  // breadcrumb in the console. These tests pin the wiring — a future
+  // refactor that drops the console.warn would regress diagnosability.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("read: corrupt JSON in storage logs a warning + returns null", () => {
+    window.sessionStorage.setItem(SESSION_DRAFT_STORAGE_KEY, "{not json");
+    expect(readStoredSessionDraft()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[sessionDraft]"),
+      expect.anything(),
+    );
+  });
+
+  it("write: a throwing setItem logs a warning + does not throw", () => {
+    // jsdom's sessionStorage uses prototype methods, so spy on the
+    // Storage prototype rather than the instance property.
+    const setSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+    try {
+      expect(() => writeStoredSessionDraft(_completeDraft())).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[sessionDraft]"),
+        expect.anything(),
+      );
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  it("clear: a throwing removeItem logs a warning + does not throw", () => {
+    const removeSpy = vi
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(() => {
+        throw new Error("nope");
+      });
+    try {
+      expect(() => clearStoredSessionDraft()).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[sessionDraft]"),
+        expect.anything(),
+      );
+    } finally {
+      removeSpy.mockRestore();
+    }
+  });
+});
+
+describe("sessionDraftStorage — multiple custom rows", () => {
+  it("preserves React stable keys across a write→read round trip", () => {
+    // The wizard mints custom keys as ``custom-<ts>-<rand>`` to keep
+    // React reconciliation stable when two rows share a label. The
+    // round-trip must keep each key distinct so a remount doesn't
+    // collapse the rows. Regression net for the "two custom adds"
+    // edge case.
+    const draft: SessionDraft = {
+      ..._completeDraft(),
+      setupRoleSlots: [
+        {
+          key: "custom-abc-111",
+          label: "Threat Intel",
+          active: true,
+          builtin: false,
+        },
+        {
+          key: "custom-def-222",
+          label: "Forensics",
+          active: false,
+          builtin: false,
+        },
+        {
+          key: "custom-ghi-333",
+          label: "Threat Intel",
+          active: true,
+          builtin: false,
+        },
+      ],
+    };
+    writeStoredSessionDraft(draft);
+    const out = readStoredSessionDraft();
+    expect(out?.setupRoleSlots.map((s) => s.key)).toEqual([
+      "custom-abc-111",
+      "custom-def-222",
+      "custom-ghi-333",
+    ]);
+  });
+});

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -148,6 +148,16 @@ interface Props {
   /** Setter for ``advancedToReview`` so the rail clicks can drive
    *  step navigation without round-tripping through the parent. */
   setAdvancedToReview?: (v: boolean) => void;
+  /**
+   * Optional intro-step control. When provided, the wizard renders
+   * the parent-owned step value and forwards user navigation through
+   * ``setIntroStep`` — used by ``<Facilitator/>`` so the active step
+   * can be persisted across page refresh alongside the rest of the
+   * draft state. Falls back to internal ``useState`` when omitted so
+   * unit tests can render the wizard in isolation.
+   */
+  introStep?: 1 | 2 | 3;
+  setIntroStep?: (v: 1 | 2 | 3) => void;
 }
 
 // Stable React keys for custom-role rows the operator adds. We can't
@@ -164,7 +174,13 @@ export function SetupWizard(props: Props) {
   // Pre-creation step navigation. The user moves through 1 → 2 → 3,
   // and submitting step 3 triggers session creation. Once created
   // (phase != "intro"), the step is derived from backend state.
-  const [introStep, setIntroStep] = useState<1 | 2 | 3>(1);
+  // When the parent threads ``introStep`` / ``setIntroStep`` through,
+  // we render the controlled value so the step can be persisted to
+  // sessionStorage and survive a page refresh; otherwise we fall
+  // back to internal state for standalone unit-test renders.
+  const [localIntroStep, setLocalIntroStep] = useState<1 | 2 | 3>(1);
+  const introStep = props.introStep ?? localIntroStep;
+  const setIntroStep = props.setIntroStep ?? setLocalIntroStep;
   // Step 5 → 6 advance flag is owned by ``Facilitator`` so the
   // ``SetupReviewView`` (rendered into the ``postCreationContent``
   // slot below) can request a hop back to step 5 without props

--- a/frontend/src/lib/sessionDraftStorage.ts
+++ b/frontend/src/lib/sessionDraftStorage.ts
@@ -1,0 +1,181 @@
+/**
+ * Persistence for the new-session wizard's pre-creation form state.
+ *
+ * Without this, refreshing ``/new`` while filling out the wizard
+ * wipes every field — the operator loses the scenario brief, the
+ * team description, the role toggles, and the tuning panel selection
+ * because all of it lives in <Facilitator/> React state and a
+ * re-mount starts from the defaults.
+ *
+ * Uses ``sessionStorage`` rather than ``localStorage`` so the draft
+ * is scoped to the tab and gets cleaned up automatically when the
+ * tab closes — the goal is "don't lose what I just typed", not
+ * "save a draft forever". Cleared explicitly on a successful
+ * session create so a refresh after the wizard has handed off
+ * doesn't restore a now-stale form.
+ */
+import {
+  DEFAULT_SESSION_FEATURES,
+  type Difficulty,
+  type SessionFeatures,
+} from "../api/client";
+import type {
+  SetupParts,
+  SetupRoleSlot,
+} from "../components/setup/SetupWizard";
+
+export const SESSION_DRAFT_STORAGE_KEY = "crittable.session_draft.v1";
+
+/** JSON-safe snapshot of every field <Facilitator/> owns while the
+ *  user is filling out the wizard. ``introStep`` is included so a
+ *  refresh on Step 2 or Step 3 lands the user back on the same page
+ *  instead of dumping them at Step 1. */
+export interface SessionDraft {
+  setupParts: SetupParts;
+  creatorLabel: string;
+  creatorDisplayName: string;
+  setupRoleSlots: SetupRoleSlot[];
+  setupRoleDraft: string;
+  difficulty: Difficulty;
+  durationMinutes: number;
+  features: SessionFeatures;
+  introStep: 1 | 2 | 3;
+}
+
+function isSetupParts(v: unknown): v is SetupParts {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.scenario === "string" &&
+    typeof o.team === "string" &&
+    typeof o.environment === "string" &&
+    typeof o.constraints === "string"
+  );
+}
+
+function isSetupRoleSlot(v: unknown): v is SetupRoleSlot {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.key === "string" &&
+    typeof o.label === "string" &&
+    typeof o.active === "boolean" &&
+    typeof o.builtin === "boolean" &&
+    (o.code === undefined || typeof o.code === "string") &&
+    (o.description === undefined || typeof o.description === "string")
+  );
+}
+
+function isDifficulty(v: unknown): v is Difficulty {
+  return v === "easy" || v === "standard" || v === "hard";
+}
+
+function isFeatures(v: unknown): v is SessionFeatures {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.active_adversary === "boolean" &&
+    typeof o.time_pressure === "boolean" &&
+    typeof o.executive_escalation === "boolean" &&
+    typeof o.media_pressure === "boolean"
+  );
+}
+
+function isIntroStep(v: unknown): v is 1 | 2 | 3 {
+  return v === 1 || v === 2 || v === 3;
+}
+
+/** Bounds for ``durationMinutes`` mirrored from the backend's
+ *  pydantic validator (``SessionSettings.duration_minutes``,
+ *  ``ge=15, le=180``). Defense-in-depth clamp at the storage
+ *  boundary follows the model-output-trust pattern in CLAUDE.md:
+ *  clamp out-of-band numerics to the documented range instead of
+ *  trusting whatever sat in storage. */
+const DURATION_MIN_MINUTES = 15;
+const DURATION_MAX_MINUTES = 180;
+
+/**
+ * Read + validate the stored draft. Any unrecognized field is
+ * silently replaced with its default so a schema bump never
+ * soft-bricks the form. Returns ``null`` when nothing is stored or
+ * sessionStorage is unavailable (private mode / strict CSP). Logs a
+ * single warning per failure mode so an operator chasing a "draft
+ * didn't restore" mystery finds a breadcrumb instead of a silent
+ * swallow.
+ */
+export function readStoredSessionDraft(): SessionDraft | null {
+  let raw: string | null;
+  try {
+    raw = window.sessionStorage.getItem(SESSION_DRAFT_STORAGE_KEY);
+  } catch (err) {
+    console.warn("[sessionDraft] read failed (storage unavailable?)", err);
+    return null;
+  }
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.warn(
+      "[sessionDraft] stored entry is not valid JSON; discarding",
+      err,
+    );
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const o = parsed as Record<string, unknown>;
+  const setupParts: SetupParts = isSetupParts(o.setupParts)
+    ? o.setupParts
+    : { scenario: "", team: "", environment: "", constraints: "" };
+  const setupRoleSlots: SetupRoleSlot[] = Array.isArray(o.setupRoleSlots)
+    ? o.setupRoleSlots.filter(isSetupRoleSlot)
+    : [];
+  const rawDuration =
+    typeof o.durationMinutes === "number" && Number.isFinite(o.durationMinutes)
+      ? o.durationMinutes
+      : 60;
+  const durationMinutes = Math.min(
+    DURATION_MAX_MINUTES,
+    Math.max(DURATION_MIN_MINUTES, rawDuration),
+  );
+  return {
+    setupParts,
+    creatorLabel:
+      typeof o.creatorLabel === "string" ? o.creatorLabel : "CISO",
+    creatorDisplayName:
+      typeof o.creatorDisplayName === "string" ? o.creatorDisplayName : "",
+    setupRoleSlots,
+    setupRoleDraft:
+      typeof o.setupRoleDraft === "string" ? o.setupRoleDraft : "",
+    difficulty: isDifficulty(o.difficulty) ? o.difficulty : "standard",
+    durationMinutes,
+    features: isFeatures(o.features)
+      ? o.features
+      : { ...DEFAULT_SESSION_FEATURES },
+    introStep: isIntroStep(o.introStep) ? o.introStep : 1,
+  };
+}
+
+export function writeStoredSessionDraft(draft: SessionDraft): void {
+  try {
+    window.sessionStorage.setItem(
+      SESSION_DRAFT_STORAGE_KEY,
+      JSON.stringify(draft),
+    );
+  } catch (err) {
+    // sessionStorage may be disabled (private mode, strict CSP) or
+    // the quota may be exhausted. Form keeps working in memory; the
+    // user just loses the refresh-recovery affordance. Log so an
+    // operator chasing "why didn't my draft come back" has a
+    // breadcrumb instead of a silent no-op.
+    console.warn("[sessionDraft] write failed (storage unavailable?)", err);
+  }
+}
+
+export function clearStoredSessionDraft(): void {
+  try {
+    window.sessionStorage.removeItem(SESSION_DRAFT_STORAGE_KEY);
+  } catch (err) {
+    console.warn("[sessionDraft] clear failed (storage unavailable?)", err);
+  }
+}

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -41,6 +41,11 @@ import {
   clearStoredInviteCode,
   readStoredInviteCode,
 } from "../lib/inviteCodeStorage";
+import {
+  clearStoredSessionDraft,
+  readStoredSessionDraft,
+  writeStoredSessionDraft,
+} from "../lib/sessionDraftStorage";
 import { SiteHeader } from "../components/brand/SiteHeader";
 import { SetupLobbyView } from "../components/setup/SetupLobbyView";
 import { SetupReviewView } from "../components/setup/SetupReviewView";
@@ -128,20 +133,49 @@ function _composeScenarioPrompt(parts: typeof DEV_SETUP_PREFILL): string {
 export function Facilitator() {
   const [state, setState] = useState<CreatorState | null>(null);
   const [snapshot, setSnapshot] = useState<SessionSnapshot | null>(null);
+  // Refresh-recovery for the wizard. Read sessionStorage ONCE at
+  // mount so each ``useState`` lazy initializer below can pull its
+  // default from the stored draft without each one repeating the
+  // JSON.parse + validation. Returns ``null`` when nothing was
+  // stored or storage is unavailable; each field falls back to its
+  // hard-coded default in that case. See lib/sessionDraftStorage.ts
+  // for the validation contract — an unrecognized field is dropped
+  // silently so a schema bump never soft-bricks the form.
+  const [restoredDraft] = useState(() => {
+    const stored = readStoredSessionDraft();
+    if (stored) {
+      // Log only the non-secret shape so the next operator chasing
+      // "why is the wizard pre-populated?" finds a breadcrumb. The
+      // scenario brief can contain operator-typed PII; log a
+      // presence flag rather than the body.
+      console.info("[facilitator] restored draft from sessionStorage", {
+        introStep: stored.introStep,
+        hasScenario: stored.setupParts.scenario.length > 0,
+        roleSlotCount: stored.setupRoleSlots.length,
+      });
+    }
+    return stored;
+  });
   // Multi-section setup intro. Each section is optional except
   // ``scenario`` which is required by the backend. The four sections
   // are combined into a single ``scenario_prompt`` string at submit
   // time so the API surface doesn't need to change. Pre-fix the intro
   // had a single textarea; operators were either leaving the AI to
   // ask 5+ setup questions OR pasting a wall of text into one box.
-  const [setupParts, setSetupParts] = useState({
-    scenario: "",
-    team: "",
-    environment: "",
-    constraints: "",
-  });
-  const [creatorLabel, setCreatorLabel] = useState("CISO");
-  const [creatorDisplayName, setCreatorDisplayName] = useState("");
+  const [setupParts, setSetupParts] = useState(() =>
+    restoredDraft?.setupParts ?? {
+      scenario: "",
+      team: "",
+      environment: "",
+      constraints: "",
+    },
+  );
+  const [creatorLabel, setCreatorLabel] = useState(
+    () => restoredDraft?.creatorLabel ?? "CISO",
+  );
+  const [creatorDisplayName, setCreatorDisplayName] = useState(
+    () => restoredDraft?.creatorDisplayName ?? "",
+  );
   // Issue #61 + roles-page redesign: roles to invite, declared
   // *before* the session is created so the operator doesn't add seats
   // one-by-one in the lobby AND the AI sees the full roster on its
@@ -206,21 +240,45 @@ export function Facilitator() {
       builtin: true,
     },
   ];
-  const [setupRoleSlots, setSetupRoleSlots] = useState<SetupRoleSlot[]>(() =>
-    SETUP_ROLE_BUILTINS.map((s) => ({ ...s })),
+  const [setupRoleSlots, setSetupRoleSlots] = useState<SetupRoleSlot[]>(() => {
+    // Respect an explicit empty roster on restore — the operator may
+    // have deliberately removed every builtin row, and silently
+    // re-seeding them would contradict the "don't lose what I just
+    // typed" contract. Step 3's "Add role" input is always available
+    // so the operator can recover from an empty list. Only fall back
+    // to the canonical builtins when there was no stored draft at all
+    // (fresh visit).
+    if (restoredDraft) return restoredDraft.setupRoleSlots;
+    return SETUP_ROLE_BUILTINS.map((s) => ({ ...s }));
+  });
+  const [setupRoleDraft, setSetupRoleDraft] = useState(
+    () => restoredDraft?.setupRoleDraft ?? "",
   );
-  const [setupRoleDraft, setSetupRoleDraft] = useState("");
+  // Wizard step index. Lifted from <SetupWizard/> so a refresh on
+  // Step 2 or Step 3 lands the operator back on the same step rather
+  // than dropping them at Step 1 with the rest of their data
+  // restored — which would look like the persistence partially
+  // failed. Defaulted to 1 for first-load.
+  const [introStep, setIntroStep] = useState<1 | 2 | 3>(
+    () => restoredDraft?.introStep ?? 1,
+  );
   // Creator-selected scenario tuning (issue #33). Picked on the
   // wizard's step 2 alongside environment / constraints — the UI
   // calls them "TUNING" — and frozen at session creation. Defaults
   // mirror the backend's ``SessionSettings`` (standard, 60min,
   // adversary + time + executive ON, media OFF) so an operator who
   // ignores the panel still gets a sensible balanced tabletop.
-  const [difficulty, setDifficulty] = useState<Difficulty>("standard");
-  const [durationMinutes, setDurationMinutes] = useState<number>(60);
-  const [features, setFeatures] = useState<SessionFeatures>(() => ({
-    ...DEFAULT_SESSION_FEATURES,
-  }));
+  const [difficulty, setDifficulty] = useState<Difficulty>(
+    () => restoredDraft?.difficulty ?? "standard",
+  );
+  const [durationMinutes, setDurationMinutes] = useState<number>(
+    () => restoredDraft?.durationMinutes ?? 60,
+  );
+  const [features, setFeatures] = useState<SessionFeatures>(() =>
+    restoredDraft?.features
+      ? { ...restoredDraft.features }
+      : { ...DEFAULT_SESSION_FEATURES },
+  );
   // Step 5 → 6 advance flag for the post-creation wizard. Default
   // ``false``: after the plan is finalised the wizard lands on step
   // 5 (Invite players) so the creator can share join links and watch
@@ -245,6 +303,20 @@ export function Facilitator() {
   // for any individual session.
   const [devMode, setDevMode] = useState(false);
   useEffect(() => {
+    // Refresh-recovery: when a draft was restored, skip the auto-flip
+    // to avoid the visual flicker where the operator briefly sees
+    // their pre-filled textareas with the "Dev mode" toggle showing
+    // OFF before the async probe lands and snaps it on. The operator
+    // can still toggle devMode manually if they want the prefills
+    // and the scenario picker. ``devMode`` itself is intentionally
+    // not part of the persisted draft — it's a deployment-default
+    // signal, not user content.
+    if (restoredDraft) {
+      console.debug(
+        "[facilitator] skipping dev-tools probe (restored draft)",
+      );
+      return;
+    }
     let canceled = false;
     (async () => {
       try {
@@ -271,7 +343,11 @@ export function Facilitator() {
     return () => {
       canceled = true;
     };
-  }, []);
+    // ``restoredDraft`` is set once via a lazy ``useState`` initializer
+    // and never re-set, so it's stable for the lifetime of the
+    // component — listing it in deps is for correctness, not because
+    // the effect needs to re-run.
+  }, [restoredDraft]);
   // Soft anti-strangers gate on session creation (env: ``INVITE_CODE``).
   // Tri-state: ``null`` while the mount-time probe is in flight (we
   // render a tiny loader rather than flashing the wizard then snapping
@@ -554,6 +630,41 @@ export function Facilitator() {
   // "only if near bottom" rule still applies for incoming messages
   // from other roles.
 
+  // Refresh-recovery sync: persist the in-progress wizard draft on
+  // every change while the operator is still in the pre-creation
+  // form (``state === null``). Once the session has been created the
+  // form is no longer the operator's working surface — a stale draft
+  // restored after a refresh-into-session would surprise them — so
+  // we stop syncing the moment ``state`` lands. The matching
+  // ``clearStoredSessionDraft()`` call inside ``handleCreate`` wipes
+  // the entry on a successful create so a refresh-then-new-session
+  // flow starts fresh.
+  useEffect(() => {
+    if (state !== null) return;
+    writeStoredSessionDraft({
+      setupParts,
+      creatorLabel,
+      creatorDisplayName,
+      setupRoleSlots,
+      setupRoleDraft,
+      difficulty,
+      durationMinutes,
+      features,
+      introStep,
+    });
+  }, [
+    state,
+    setupParts,
+    creatorLabel,
+    creatorDisplayName,
+    setupRoleSlots,
+    setupRoleDraft,
+    difficulty,
+    durationMinutes,
+    features,
+    introStep,
+  ]);
+
   const phase: Phase = useMemo(() => {
     if (!snapshot) return "intro";
     if (snapshot.state === "ENDED") return "ended";
@@ -757,6 +868,12 @@ export function Facilitator() {
         creatorRoleId: created.creator_role_id,
         joinUrl: created.creator_join_url,
       });
+      // Refresh-recovery: the wizard's job is done. Drop the stored
+      // draft so a later refresh-into-session doesn't restore the
+      // now-frozen form fields (the session's settings are locked
+      // server-side at create time anyway) and so a fresh "new
+      // session" later in the tab lifecycle starts from defaults.
+      clearStoredSessionDraft();
       if (devMode) {
         // ``start_session`` requires ≥ 2 player roles. Dev mode adds a
         // SOC Analyst backstop ONLY when the operator didn't pre-declare
@@ -1364,6 +1481,34 @@ export function Facilitator() {
     console.info("[facilitator] reset to intro");
     wsRef.current?.close();
     wsRef.current = null;
+    // Reset wizard form state to defaults BEFORE flipping ``state``
+    // to null. The persistence effect re-fires the instant ``state``
+    // lands at null; without an explicit reset it would otherwise
+    // write the *previous session's* wizard values back to
+    // sessionStorage and a subsequent refresh would restore them —
+    // contradicting the operator's "+ New session" intent. Mirror
+    // the lazy-initializer defaults at the top of the component so a
+    // "+ New session" click feels the same as a fresh page load.
+    setSetupParts({
+      scenario: "",
+      team: "",
+      environment: "",
+      constraints: "",
+    });
+    setCreatorLabel("CISO");
+    setCreatorDisplayName("");
+    setSetupRoleSlots(SETUP_ROLE_BUILTINS.map((s) => ({ ...s })));
+    setSetupRoleDraft("");
+    setIntroStep(1);
+    setDifficulty("standard");
+    setDurationMinutes(60);
+    setFeatures({ ...DEFAULT_SESSION_FEATURES });
+    // Belt-and-suspenders clear: the persistence effect's next pass
+    // will overwrite with these reset values anyway, but clearing
+    // immediately means a refresh in the window between this call
+    // and the effect's commit lands on a clean form rather than the
+    // stale one.
+    clearStoredSessionDraft();
     setState(null);
     setSnapshot(null);
     setStreamingActive(false);
@@ -1683,6 +1828,8 @@ export function Facilitator() {
         setDurationMinutes={setDurationMinutes}
         features={features}
         setFeatures={setFeatures}
+        introStep={introStep}
+        setIntroStep={setIntroStep}
       />
     );
   }

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach } from "vitest";
 
 // jsdom's Range implementation has no getBoundingClientRect; the
 // HighlightActionPopover (issue #98) calls it from a selectionchange
@@ -24,3 +25,22 @@ if (
     toJSON: () => ({}),
   });
 }
+
+// jsdom's localStorage / sessionStorage persist across tests in the
+// same file unless explicitly cleared. The wizard's draft persistence
+// (lib/sessionDraftStorage.ts) writes to sessionStorage every time
+// the operator touches a field, which would otherwise let one test's
+// draft restore on the next test's mount — e.g. tests advancing past
+// step 1 would land subsequent tests on step 2 or 3 instead of the
+// expected fresh-start step 1. Wipe both per-test so every render
+// starts from defaults; individual tests can re-seed storage in their
+// own setup if they need to.
+beforeEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});


### PR DESCRIPTION
## Summary

Refreshing `/new` while filling out the new-session wizard wiped every field — the operator lost their scenario brief, team description, environment, constraints, role roster, and tuning panel selections because all of it lived in `<Facilitator/>` React state and a re-mount started from the hard-coded defaults.

This PR adds sessionStorage-backed refresh-recovery: the draft is persisted on every change and restored on mount, so an accidental refresh (or a browser tab restore) lands the operator back on the same wizard step with their work intact.

## What changed

- **New module** `frontend/src/lib/sessionDraftStorage.ts` — sessionStorage round-trip with field-by-field validation (drop unknown / coerce wrong types), `durationMinutes` clamped to the backend's `[15, 180]` bounds, `console.warn` on every silent catch.
- **`frontend/src/pages/Facilitator.tsx`** — lazy `useState` initializers restore from storage; a `useEffect` persists on change while `state === null`; `clearStoredSessionDraft()` fires on a successful create AND on `handleNewSession` (with a full form reset) so refresh-after-"+ New session" starts fresh. Dev-tools probe skipped when a draft was restored to avoid a visual flicker. `introStep` lifted from `<SetupWizard/>` so a refresh on Step 2 lands on Step 2.
- **`frontend/src/components/setup/SetupWizard.tsx`** — accepts optional `introStep` / `setIntroStep` props with an internal-state fallback for isolated unit-test renders.
- **`frontend/src/test-setup.ts`** — global `beforeEach`/`afterEach` clears sessionStorage + localStorage so the new persistence doesn't pollute test state between tests.

## Design notes

- **sessionStorage, not localStorage** — tab-scoped, auto-cleared on close. The goal is "don't lose what I just typed", not "save a draft forever". Mirrors the `inviteCodeStorage.ts` pattern (which IS localStorage, because invite codes are long-lived credentials).
- **Boundary validation per field** — a schema bump never soft-bricks the form. An unknown / wrong-type field falls back to its default.
- **Empty roster respected on restore** — if the operator deliberately removed every builtin row, refreshing must NOT silently re-seed them. Step 3's Add-role input is always available so an empty list is recoverable. (QA review HIGH.)
- **handleNewSession does a hard reset** — without resetting the form fields, the persistence effect would re-write the previous session's draft to storage the moment `state` flipped null. (UI/UX + user-persona review HIGH.)

## Sub-agent review

All six sub-agent reviews ran in parallel per `CLAUDE.md`. Every CRITICAL / BLOCK / HIGH finding plus all logging-debuggability findings (always in scope per the project rules) are addressed in this commit:

- **QA** — added the empty-roster regression test, the clear-on-create integration test, silent-failure-path tests, and a multi-custom-row round-trip test. 13 new unit tests; 4 new Facilitator integration tests.
- **Security** — `durationMinutes` now clamps to backend bounds at the storage read; every silent catch logs a `console.warn`. No persisted field carries tokens / IDs / credentials.
- **UI/UX** — handleNewSession reset + storage clear so refresh-after-"+ New session" starts fresh; `console.info` breadcrumb on restore.
- **Product/app-owner** — confirmed all wizard fields are covered (scenario / team / env / constraints / tuning / roles / step). No scope drift.
- **User-persona** — dev-tools probe skipped when a draft was restored, eliminating the "prefilled textareas but Dev-mode toggle OFF" flicker.
- **Prompt Expert** — skipped, no LLM prompts / tools / call sites touched.

Deferred to follow-up (LOW priority, design choices that warrant their own discussion):
- Optional "draft restored" visual affordance / dismiss-and-clear chip.
- Tab-close `beforeunload` prompt for very-long drafts.

## Test plan

- [x] `cd frontend && npm test -- --run` — 48 files / 592 tests pass
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run typecheck` — clean
- [ ] Manual: open `/new`, fill out Steps 1-3, hit refresh — confirm all fields + current step restore.
- [ ] Manual: fill out Step 3 with custom roles, refresh — confirm custom rows preserved.
- [ ] Manual: remove every builtin role, refresh — confirm empty roster preserved (not re-seeded).
- [ ] Manual: create a session successfully, refresh — confirm wizard does NOT pre-populate with the previous draft.
- [ ] Manual: in a live session, click "+ New session" → land on wizard → confirm a fresh form, not the previous session's values.

https://claude.ai/code/session_01Cy7L65L7Un9xCn6RWvo5sB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy7L65L7Un9xCn6RWvo5sB)_