### PR TITLE
setup: recover from over-length scenario briefs; raise cap to 16k

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Re-run the prompt to get a different scenario against the same
 environment; the bracketed setup is meant to be filled in once and
 re-used.
 
+Crittable combines the four sections into a single field capped at
+**16,000 characters** (headers and blank lines included). The prompt
+below tells your LLM to stay under that, and the setup wizard shows a
+live character counter — if you do overrun, the counter turns red and
+the forward button (NEXT, or ROLL SESSION on the final step) is disabled
+until you trim, so you'll never get bounced by the server after the
+fact. Role labels and display names are capped at 64 characters each
+(the wizard's role inputs stop you at the limit), and a session can have
+at most 32 invited roles.
+
 > Tip: name systems by product (Splunk, Defender, Okta, IRIS, PagerDuty),
 > not generic categories. The more concrete the environment, the more it
 > shows up in the AI's injects during play.
@@ -175,12 +185,24 @@ CONSTRAINTS:
   actually subject to"]
 - Time budget: [e.g. "60 minutes"]
 
+LIMITS (Crittable rejects the brief if you exceed these — stay inside
+them):
+
+- The four sections COMBINED must be under 16,000 characters total
+  (~2,500 words). Crittable joins them into one field with that hard
+  cap. Be vivid but tight — cut filler, not detail; if you're running
+  long, shorten prose before dropping facts.
+- Each role label (e.g. "IR Lead", "Comms") is at most 64 characters,
+  and so is each person's display name. Propose at most 32 roles.
+- Target duration must be between 15 and 180 minutes.
+
 Now draft the brief in EXACTLY these four sections, each under a clear
 header, no preamble, no closing summary. Pick the scenario yourself —
 surprise me — but make it realistic for the environment above
 (ransomware, BEC, OAuth phish, supply-chain compromise, leaked cloud
 creds, malicious insider, etc.). Include the plausible first signal
-that would land in our SIEM.
+that would land in our SIEM. Keep the whole thing under the 16,000-char
+limit above.
 
 [1] SCENARIO BRIEF
 What happened, when, at what severity. ~3–5 short bullets or a tight

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -67,11 +67,21 @@ class InviteeRoleSpec(BaseModel):
 
 class CreateSessionBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    # Bumped from 4000 to 8000: the multi-prompt intro composes four
+    # Bumped 4000 → 8000 → 16000: the multi-prompt intro composes four
     # sections (scenario / team / environment / constraints) plus
-    # headers, which can run past 4000 chars on a richly-described
-    # exercise.
-    scenario_prompt: str = Field(min_length=1, max_length=8000)
+    # headers, and a richly-described real-world exercise (full team +
+    # environment + constraints + facilitator notes) routinely composes
+    # past 8000 — a genuine ~10.6k brief tripped the old cap with an
+    # unrecoverable 422. The prompt rides in the cached system block
+    # (cache_control: ephemeral), so the per-turn token cost of the
+    # extra headroom is paid once at cache creation, not every turn.
+    # Keep this in sync with ``SCENARIO_PROMPT_MAX_CHARS`` in
+    # ``frontend/src/components/setup/scenarioPrompt.ts`` (which drives
+    # the wizard's live counter + submit gate), the replay schema's
+    # ``scenario_prompt`` cap in ``app/devtools/scenario.py``, and the
+    # cap stated in the README's "Drafting a brief with your work's LLM"
+    # prompt template.
+    scenario_prompt: str = Field(min_length=1, max_length=16000)
     creator_label: str = Field(min_length=1, max_length=64)
     creator_display_name: str = Field(min_length=1, max_length=64)
     # Pre-declared invitee roles from the wizard's step 3. We add

--- a/backend/app/devtools/scenario.py
+++ b/backend/app/devtools/scenario.py
@@ -254,7 +254,11 @@ class Scenario(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     meta: ScenarioMeta
-    scenario_prompt: str = Field(min_length=1, max_length=8000)
+    # Mirrors ``CreateSessionBody.scenario_prompt`` in ``app/api/routes.py``
+    # — keep the cap in lockstep so a real (10-16k) brief that creates
+    # fine via the API can also be recorded/replayed. (Was 8000; bumped
+    # with the route cap.)
+    scenario_prompt: str = Field(min_length=1, max_length=16000)
     creator_label: str = Field(min_length=1, max_length=64)
     creator_display_name: str = Field(min_length=1, max_length=64)
     # Creator-selected scenario tuning (frozen on the live ``Session``

--- a/backend/tests/test_api_routes_gaps.py
+++ b/backend/tests/test_api_routes_gaps.py
@@ -470,3 +470,51 @@ def test_get_session_exposes_plan_title_summary_to_non_creator(
     assert cbody["plan"] is not None
     assert cbody["plan"]["title"] == plan.title
 
+
+# ---------------------------------------------------------------- scenario_prompt length cap
+
+
+def test_create_session_rejects_scenario_prompt_over_cap(client: TestClient) -> None:
+    """``scenario_prompt`` is capped at 16000 chars. One char over returns
+    a 422 whose ``detail`` is the Pydantic validation *array* — the exact
+    shape the frontend api-client now formats into a readable message
+    (the old code stringified the array and rendered ``[object Object]``
+    in the setup wizard). Locking the shape here keeps that contract
+    honest from the server side."""
+
+    r = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "A" * 16001,
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+            **default_settings_body(),
+        },
+    )
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert isinstance(detail, list)
+    entry = detail[0]
+    assert entry["loc"][-1] == "scenario_prompt"
+    assert entry["type"] == "string_too_long"
+    assert entry["ctx"]["max_length"] == 16000
+
+
+def test_create_session_accepts_scenario_prompt_at_cap(client: TestClient) -> None:
+    """A brief exactly at the 16000-char cap is accepted. A realistic
+    ~10.6k-char exercise (the one that tripped the old 8000 cap with an
+    unrecoverable error) sits comfortably under the new ceiling — assert
+    the boundary itself goes through so a future cap change can't silently
+    regress the headroom."""
+
+    r = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "A" * 16000,
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+            **default_settings_body(),
+        },
+    )
+    assert r.status_code == 200, r.text
+

--- a/frontend/src/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/__tests__/SetupWizard.test.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SetupWizard, type SetupParts } from "../components/setup/SetupWizard";
+import { SetupWizard } from "../components/setup/SetupWizard";
+import {
+  composeScenarioPrompt,
+  SCENARIO_PROMPT_MAX_CHARS,
+  type SetupParts,
+} from "../components/setup/scenarioPrompt";
 import {
   DEFAULT_SESSION_FEATURES,
   type ScenarioPlan,
@@ -400,5 +405,83 @@ describe("SetupWizard — error display (UI/UX HIGH#3)", () => {
     );
     const alert = screen.getByRole("alert");
     expect(alert).toHaveTextContent(/failed to copy join link/i);
+  });
+});
+
+describe("SetupWizard — brief length budget & submit gate", () => {
+  it("composeScenarioPrompt joins non-empty sections with headers and drops blanks", () => {
+    expect(
+      composeScenarioPrompt({
+        scenario: "S",
+        team: "",
+        environment: "E",
+        constraints: "",
+      }),
+    ).toBe("SCENARIO BRIEF\nS\n\nENVIRONMENT\nE");
+  });
+
+  it("renders the live brief-length counter on step 1", () => {
+    render(
+      <SetupWizard
+        phase="intro"
+        {...baseProps()}
+        setupParts={{ ...EMPTY_PARTS, scenario: "hello" }}
+      />,
+    );
+    expect(screen.getByText(/BRIEF LENGTH/i)).toBeInTheDocument();
+  });
+
+  it("disables the forward CTA and shows a trim reason when the brief overruns the cap", () => {
+    const over = "A".repeat(SCENARIO_PROMPT_MAX_CHARS + 50);
+    render(
+      <SetupWizard
+        phase="intro"
+        {...baseProps()}
+        setupParts={{ ...EMPTY_PARTS, scenario: over }}
+      />,
+    );
+    // Step 1's primary CTA is "NEXT · ENVIRONMENT →" — gated off-limit so
+    // the operator can't even reach the submit step over the cap.
+    const next = screen.getByRole("button", { name: /NEXT.*ENVIRONMENT/i });
+    expect(next).toBeDisabled();
+    // The inline reason tells the operator exactly how much to cut.
+    // "to continue" is unique to the NavRow reason (the counter says
+    // "· TRIM <n>"), so this won't collide across the two surfaces.
+    expect(screen.getByText(/to continue/i)).toBeInTheDocument();
+  });
+
+  it("leaves the forward CTA enabled for an in-budget brief", () => {
+    render(
+      <SetupWizard
+        phase="intro"
+        {...baseProps()}
+        setupParts={{ ...EMPTY_PARTS, scenario: "A reasonable brief." }}
+      />,
+    );
+    const next = screen.getByRole("button", { name: /NEXT.*ENVIRONMENT/i });
+    expect(next).not.toBeDisabled();
+    expect(screen.queryByText(/to continue/i)).not.toBeInTheDocument();
+  });
+
+  it("caps the creator-role / display-name / custom-role inputs at 64 chars", () => {
+    // Mirrors the backend's 64-char ``label`` / ``display_name`` caps so
+    // a verbose (e.g. LLM-proposed) role label can't last-click-422 on
+    // ROLL SESSION — the same failure class the brief gate prevents.
+    render(<SetupWizard phase="intro" {...baseProps()} />);
+    // Walk to step 3 (Roles) where these inputs live.
+    fireEvent.click(screen.getByRole("button", { name: /NEXT.*ENVIRONMENT/i }));
+    fireEvent.click(screen.getByRole("button", { name: /NEXT.*ROLES/i }));
+    expect(screen.getByPlaceholderText(/Your role label/i)).toHaveAttribute(
+      "maxLength",
+      "64",
+    );
+    expect(screen.getByPlaceholderText(/Your display name/i)).toHaveAttribute(
+      "maxLength",
+      "64",
+    );
+    expect(screen.getByPlaceholderText(/Add custom role/i)).toHaveAttribute(
+      "maxLength",
+      "64",
+    );
   });
 });

--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -19,7 +19,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api } from "../api/client";
+import { api, ApiError } from "../api/client";
 
 type FetchInit = RequestInit | undefined;
 
@@ -100,6 +100,105 @@ describe("api/client — request wrapper", () => {
       }),
     );
     await expect(api.start("s1", "tok")).rejects.toThrow("session not yet ended");
+  });
+
+  it("formats a Pydantic 422 detail array into '<field>: <msg>' (never [object Object])", async () => {
+    // This is the bug the HAR captured: an over-length scenario_prompt
+    // returns ``detail: [{loc:["body","scenario_prompt"], msg:"…"}]``.
+    // The old ``json.detail as string`` stringified the array to
+    // "[object Object]" and rendered that red blob in the wizard.
+    _mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            detail: [
+              {
+                type: "string_too_long",
+                loc: ["body", "scenario_prompt"],
+                msg: "String should have at most 16000 characters",
+                ctx: { max_length: 16000 },
+              },
+            ],
+          }),
+          { status: 422, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const err = (await api
+      .createSession({
+        scenario_prompt: "x".repeat(20000),
+        creator_label: "CISO",
+        creator_display_name: "Alex",
+        settings: {
+          difficulty: "standard",
+          duration_minutes: 60,
+          features: {
+            active_adversary: true,
+            time_pressure: true,
+            executive_escalation: true,
+            media_pressure: false,
+          },
+        },
+      })
+      .catch((e) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(422);
+    // Field name is humanised from the snake_case schema id so it reads
+    // like something on the form, and the [object Object] blob is gone.
+    expect(err.message).toBe(
+      "Scenario prompt: String should have at most 16000 characters",
+    );
+    expect(err.message).not.toContain("[object Object]");
+    expect(err.message).not.toContain("scenario_prompt");
+  });
+
+  it("joins multiple 422 validation errors with '; '", async () => {
+    _mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            detail: [
+              { loc: ["body", "scenario_prompt"], msg: "too long" },
+              { loc: ["body", "creator_label"], msg: "field required" },
+            ],
+          }),
+          { status: 422, headers: { "content-type": "application/json" } },
+        ),
+    );
+    await expect(api.start("s1", "tok")).rejects.toThrow(
+      "Scenario prompt: too long; Creator label: field required",
+    );
+  });
+
+  it("humanises a nested loc with a numeric array index", async () => {
+    // A too-long invitee role label: loc carries the array index.
+    _mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            detail: [
+              {
+                loc: ["body", "invitee_roles", 0, "label"],
+                msg: "String should have at most 64 characters",
+              },
+            ],
+          }),
+          { status: 422, headers: { "content-type": "application/json" } },
+        ),
+    );
+    await expect(api.start("s1", "tok")).rejects.toThrow(
+      "Label: String should have at most 64 characters",
+    );
+  });
+
+  it("falls back to ``<status>`` for an empty or unparseable detail array", async () => {
+    _mockFetch(
+      async () =>
+        new Response(JSON.stringify({ detail: [] }), {
+          status: 422,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(api.start("s1", "tok")).rejects.toThrow(/422/);
   });
 
   it("falls back to ``<status>`` when the error body isn't JSON", async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -277,6 +277,69 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Turn a Pydantic ``loc`` array into a field name a human recognises.
+ * Drops the protocol-noise ``body`` / ``query`` / ``path`` prefix and
+ * numeric array indices, then humanises the field's snake_case into
+ * sentence case: ``["body","creator_label"]`` → ``"Creator label"``,
+ * ``["body","invitee_roles",0,"label"]`` → ``"Label"``. A raw schema id
+ * like ``creator_label`` means nothing to an operator staring at a form
+ * field labelled "CREATOR ROLE"; "Creator label" at least lands in the
+ * right ballpark without coupling this generic wrapper to any one form.
+ */
+function _humanizeLoc(loc: unknown[]): string {
+  const segs = loc.filter(
+    (s) => s !== "body" && s !== "query" && s !== "path",
+  );
+  // The field is the last *string* segment; trailing numeric segments
+  // are array indices (noise). Fall back to the dotted path if there's
+  // no string segment at all.
+  const field = [...segs].reverse().find((s) => typeof s === "string");
+  if (typeof field !== "string") return segs.join(".");
+  const spaced = field.replace(/_/g, " ").trim();
+  return spaced ? spaced.charAt(0).toUpperCase() + spaced.slice(1) : "";
+}
+
+/**
+ * FastAPI's ``detail`` field arrives in two shapes: a plain string for
+ * a hand-thrown ``HTTPException(detail="…")``, and an **array** of
+ * ``{loc, msg, type, …}`` objects for a Pydantic 422 request-body
+ * validation failure. The old code did ``json.detail as string`` and
+ * threw the result straight into the UI — for the array shape that
+ * stringifies to the infamous ``"[object Object]"`` (e.g. an
+ * over-length ``scenario_prompt`` rendered a useless red blob in the
+ * setup wizard). Normalise both shapes here, at the single boundary
+ * every ``api.*`` call funnels through, so no call site has to know
+ * the difference.
+ *
+ * For the array shape each entry becomes ``"<Field>: <msg>"`` with the
+ * field humanised (see ``_humanizeLoc``). Multiple errors join with
+ * ``"; "``. Entry count and per-message length are clamped so a
+ * pathological 422 body can't build a multi-KB alert string (defence in
+ * depth — the real backend can't currently produce one). Anything we
+ * can't parse falls back to the HTTP status.
+ */
+function _formatErrorDetail(detail: unknown, status: number): string {
+  if (typeof detail === "string" && detail.trim().length > 0) return detail;
+  if (Array.isArray(detail)) {
+    const parts = detail
+      .slice(0, 10)
+      .map((entry): string => {
+        if (entry && typeof entry === "object") {
+          const e = entry as { loc?: unknown; msg?: unknown };
+          const field = Array.isArray(e.loc) ? _humanizeLoc(e.loc) : "";
+          const rawMsg = typeof e.msg === "string" ? e.msg : "";
+          const msg = rawMsg.length > 200 ? `${rawMsg.slice(0, 200)}…` : rawMsg;
+          return field && msg ? `${field}: ${msg}` : msg || field;
+        }
+        return typeof entry === "string" ? entry : "";
+      })
+      .filter((s) => s.length > 0);
+    if (parts.length > 0) return parts.join("; ");
+  }
+  return `${status}`;
+}
+
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
   const safePath = _scrub(path);
   console.debug(`[api] ${method} ${safePath}`, body ?? "");
@@ -291,7 +354,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     let detail = `${res.status}`;
     try {
       const json = await res.json();
-      detail = (json.detail as string) ?? detail;
+      detail = _formatErrorDetail(json.detail, res.status);
     } catch {
       /* ignore */
     }

--- a/frontend/src/components/setup/SetupWizard.tsx
+++ b/frontend/src/components/setup/SetupWizard.tsx
@@ -16,6 +16,11 @@ import {
 } from "../../api/client";
 import { Eyebrow } from "../brand/Eyebrow";
 import { StatusChip } from "../brand/StatusChip";
+import {
+  composeScenarioPrompt,
+  SCENARIO_PROMPT_MAX_CHARS,
+  type SetupParts,
+} from "./scenarioPrompt";
 import { WizardRail } from "./WizardRail";
 import type { WizardStepId } from "./wizardSteps";
 
@@ -24,12 +29,13 @@ import type { WizardStepId } from "./wizardSteps";
  * controlled form over these fields. Each is the operator's free-text
  * answer to one of the wizard's first three pages.
  */
-export interface SetupParts {
-  scenario: string;
-  team: string;
-  environment: string;
-  constraints: string;
-}
+// ``SetupParts`` / ``composeScenarioPrompt`` / ``SCENARIO_PROMPT_MAX_CHARS``
+// live in ``./scenarioPrompt`` (a component-free module) so their value
+// exports don't trip ``react-refresh/only-export-components`` on this
+// component file. Re-export the *type* here so existing
+// ``import { type SetupParts } from ".../SetupWizard"`` call sites keep
+// working (a type-only re-export is invisible to Fast Refresh).
+export type { SetupParts } from "./scenarioPrompt";
 
 /**
  * One row in the step-3 roles list. ``builtin`` rows are the
@@ -447,6 +453,34 @@ function IntroStepBody(props: IntroBodyProps) {
     },
   };
   const t = titles[props.step];
+  // Gate the active primary button (NEXT on steps 1-2, ROLL SESSION on
+  // step 3) when the composed brief overruns the backend cap. We count
+  // the *composed* string — the exact value shipped as
+  // ``scenario_prompt`` — so the gate matches what the server
+  // validates byte-for-byte (headers + separators included). Catching
+  // it on the forward button means the operator can't even reach the
+  // submit step over-limit; the per-step <BriefBudget/> shows the
+  // running total so the wall is visible while they type, not a
+  // surprise 422 at the end.
+  const composedLen = composeScenarioPrompt(props.setupParts).length;
+  const briefOver = composedLen > SCENARIO_PROMPT_MAX_CHARS;
+  const noActiveInvitee =
+    props.step === 3 && activeInviteeCount(props.setupRoleSlots) === 0;
+  const primaryDisabled = briefOver || noActiveInvitee;
+  // The brief sections + the <BriefBudget/> counter only live on steps
+  // 1-2. A creator can still land on step 3 over-cap by jumping via the
+  // rail, where ROLL SESSION is correctly disabled but there's no brief
+  // field to fix — so on step 3 the reason names *where* to edit instead
+  // of an un-actionable "trim N to continue".
+  const trimAmount = (composedLen - SCENARIO_PROMPT_MAX_CHARS).toLocaleString();
+  const briefSizeReason = `Brief is ${composedLen.toLocaleString()} / ${SCENARIO_PROMPT_MAX_CHARS.toLocaleString()} characters — trim ${trimAmount}`;
+  const primaryDisabledReason = briefOver
+    ? props.step === 3
+      ? `${briefSizeReason}. Edit a brief section on step 1 or 2.`
+      : `${briefSizeReason} to continue.`
+    : noActiveInvitee
+      ? "Activate at least one invitee role before rolling."
+      : undefined;
   return (
     <>
       <header style={{ display: "flex", flexDirection: "column", gap: 6 }}>
@@ -511,20 +545,14 @@ function IntroStepBody(props: IntroBodyProps) {
           busy={props.busy}
           busyMessage={props.busyMessage}
           devMode={props.devMode}
-          // Step 3's primary CTA is gated on ≥1 active invitee. The
-          // creator counts as one of the two seats ``start_session``
-          // requires; we just need at least one invitee active so
-          // the lobby's gate clears without a second-trip retry.
-          submitDisabled={
-            props.step === 3 &&
-            activeInviteeCount(props.setupRoleSlots) === 0
-          }
-          submitDisabledReason={
-            props.step === 3 &&
-            activeInviteeCount(props.setupRoleSlots) === 0
-              ? "Activate at least one invitee role before rolling."
-              : undefined
-          }
+          // Gates the active primary button (NEXT on steps 1-2, ROLL
+          // SESSION on step 3). Two reasons, in priority order: the
+          // composed brief overran the cap (any step), or step 3 has no
+          // active invitee (the creator counts as one of the two seats
+          // ``start_session`` needs, so we only require ≥1 invitee here
+          // so the lobby's gate clears without a second-trip retry).
+          primaryDisabled={primaryDisabled}
+          primaryDisabledReason={primaryDisabledReason}
         />
       </form>
     </>
@@ -538,8 +566,8 @@ function NavRow({
   busy,
   busyMessage,
   devMode,
-  submitDisabled = false,
-  submitDisabledReason,
+  primaryDisabled = false,
+  primaryDisabledReason,
 }: {
   step: 1 | 2 | 3;
   onBack: () => void;
@@ -547,11 +575,12 @@ function NavRow({
   busy: boolean;
   busyMessage: string | null;
   devMode: boolean;
-  /** Step-3 only: disable the ROLL SESSION button and show the
-   *  reason inline. Used to gate "no active invitees" before the
-   *  setup turn fires. */
-  submitDisabled?: boolean;
-  submitDisabledReason?: string;
+  /** Disable the active primary button — NEXT on steps 1-2, ROLL
+   *  SESSION on step 3 — and show ``primaryDisabledReason`` inline.
+   *  Gates "brief over the cap" (any step) and "no active invitees"
+   *  (step 3) before the request fires. */
+  primaryDisabled?: boolean;
+  primaryDisabledReason?: string;
 }) {
   // The primary CTA is type="button" on steps 1-2 (it just advances
   // the wizard) and type="submit" on step 3 (where it actually
@@ -616,7 +645,7 @@ function NavRow({
       {busyMessage ? (
         <StatusChip label="WORKING" value={busyMessage} tone="signal" />
       ) : null}
-      {submitDisabledReason ? (
+      {primaryDisabledReason ? (
         <span
           role="status"
           className="mono"
@@ -626,16 +655,16 @@ function NavRow({
             letterSpacing: "0.04em",
           }}
         >
-          {submitDisabledReason}
+          {primaryDisabledReason}
         </span>
       ) : null}
       <div style={{ flex: 1 }} />
       {step === 3 ? (
         <button
           type="submit"
-          disabled={busy || submitDisabled}
-          aria-disabled={busy || submitDisabled}
-          title={submitDisabledReason}
+          disabled={busy || primaryDisabled}
+          aria-disabled={busy || primaryDisabled}
+          title={primaryDisabledReason}
           className="mono"
           style={{
             background: "var(--signal)",
@@ -646,8 +675,8 @@ function NavRow({
             fontSize: 11,
             fontWeight: 700,
             letterSpacing: "0.18em",
-            cursor: busy ? "not-allowed" : "pointer",
-            opacity: busy ? 0.6 : 1,
+            cursor: busy || primaryDisabled ? "not-allowed" : "pointer",
+            opacity: busy || primaryDisabled ? 0.6 : 1,
           }}
         >
           {primaryLabel}
@@ -656,7 +685,9 @@ function NavRow({
         <button
           type="button"
           onClick={onNext}
-          disabled={busy}
+          disabled={busy || primaryDisabled}
+          aria-disabled={busy || primaryDisabled}
+          title={primaryDisabledReason}
           className="mono"
           style={{
             background: "var(--signal)",
@@ -667,8 +698,8 @@ function NavRow({
             fontSize: 11,
             fontWeight: 700,
             letterSpacing: "0.18em",
-            cursor: busy ? "not-allowed" : "pointer",
-            opacity: busy ? 0.6 : 1,
+            cursor: busy || primaryDisabled ? "not-allowed" : "pointer",
+            opacity: busy || primaryDisabled ? 0.6 : 1,
           }}
         >
           {primaryLabel}
@@ -710,6 +741,7 @@ function Step1Body(props: IntroBodyProps) {
         onChange={(v) => props.setSetupParts((p) => ({ ...p, team: v }))}
         placeholder="Roles, seniority, on-call posture."
       />
+      <BriefBudget parts={props.setupParts} />
     </>
   );
 }
@@ -747,6 +779,7 @@ function Step2Body(props: IntroBodyProps) {
         }
         placeholder="Hard NOs, learning objectives, things to skip."
       />
+      <BriefBudget parts={props.setupParts} />
     </>
   );
 }
@@ -1239,6 +1272,9 @@ function Step3Body(props: IntroBodyProps) {
             value={props.creatorLabel}
             onChange={props.setCreatorLabel}
             placeholder="Your role label (e.g. CISO)"
+            // Matches the backend's ``creator_label`` ``max_length=64``
+            // so a verbose label can't last-click-422 on ROLL SESSION.
+            maxLength={64}
           />
           <MonoInput
             label="DISPLAY NAME"
@@ -1246,6 +1282,7 @@ function Step3Body(props: IntroBodyProps) {
             value={props.creatorDisplayName}
             onChange={props.setCreatorDisplayName}
             placeholder="Your display name"
+            maxLength={64}
           />
         </div>
       </fieldset>
@@ -1329,6 +1366,8 @@ function Step3Body(props: IntroBodyProps) {
               }
             }}
             placeholder="Add custom role (e.g. Threat Intel)"
+            // Matches the backend's invitee ``label`` ``max_length=64``.
+            maxLength={64}
             style={{
               flex: 1,
               background: "var(--ink-900)",
@@ -1829,6 +1868,59 @@ function WizardScenarioPicker() {
   );
 }
 
+/**
+ * Live character budget for the composed brief. Reads the same
+ * ``composeScenarioPrompt`` the wizard ships and the server validates,
+ * so the number the operator watches is byte-for-byte what
+ * ``scenario_prompt`` will be (headers + separators included).
+ * Rendered on steps 1 & 2 (the brief sections); the count goes
+ * ``warn`` past 90% and ``crit`` once over, mirroring the NavRow gate
+ * that disables the forward / ROLL SESSION button at the same
+ * threshold. Without this the cap was invisible until the server
+ * bounced the create with a 422.
+ */
+function BriefBudget({ parts }: { parts: SetupParts }) {
+  // ``.length`` counts UTF-16 code units; the backend's Pydantic
+  // ``max_length`` counts Unicode code points. UTF-16 units are always
+  // ≥ code points, so for astral chars (emoji) this counter reads a
+  // touch HIGH — i.e. the gate errs strict and can never let through a
+  // brief the server would 422. That conservative direction is exactly
+  // what we want; matching code-point semantics here would reopen the
+  // surprise-422 path this change closes.
+  const len = composeScenarioPrompt(parts).length;
+  const over = len > SCENARIO_PROMPT_MAX_CHARS;
+  const near = !over && len > SCENARIO_PROMPT_MAX_CHARS * 0.9;
+  // ``--ink-300`` (not ``--ink-400``) for the normal state: ink-400 on
+  // the ink-900 form bg is 3.37:1 — below WCAG AA for this 10px text.
+  const color = over ? "var(--crit)" : near ? "var(--warn)" : "var(--ink-300)";
+  return (
+    // Purely visual budget hint — deliberately NOT an aria-live region.
+    // A character counter that re-announces on every keystroke is hostile
+    // to screen-reader users; the over-limit state is announced once via
+    // the NavRow reason's ``role="status"`` instead.
+    <div
+      className="mono"
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "baseline",
+        gap: 8,
+        fontSize: 10,
+        letterSpacing: "0.16em",
+        color,
+      }}
+    >
+      <span>BRIEF LENGTH (ALL SECTIONS)</span>
+      <span>
+        {len.toLocaleString()} / {SCENARIO_PROMPT_MAX_CHARS.toLocaleString()}
+        {over
+          ? ` · TRIM ${(len - SCENARIO_PROMPT_MAX_CHARS).toLocaleString()}`
+          : ""}
+      </span>
+    </div>
+  );
+}
+
 function BriefField({
   label,
   value,
@@ -1888,12 +1980,14 @@ function MonoInput({
   onChange,
   placeholder,
   required,
+  maxLength,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
   required?: boolean;
+  maxLength?: number;
 }) {
   return (
     <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
@@ -1917,6 +2011,7 @@ function MonoInput({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         required={required}
+        maxLength={maxLength}
         style={{
           background: "var(--ink-900)",
           border: "1px solid var(--ink-600)",

--- a/frontend/src/components/setup/scenarioPrompt.ts
+++ b/frontend/src/components/setup/scenarioPrompt.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared, component-free logic for the setup wizard's scenario brief.
+ *
+ * Lives in its own module (not in ``SetupWizard.tsx``) so the value
+ * exports below don't trip ``react-refresh/only-export-components`` —
+ * a component file may only export components for Fast Refresh to work.
+ * Both ``SetupWizard`` (live counter + submit gate) and ``Facilitator``
+ * (the actual ``createSession`` call) import from here so there's a
+ * single source of truth for how the four sections become the wire
+ * ``scenario_prompt`` and what the cap is.
+ */
+
+/**
+ * The four short text sections the creator fills on wizard steps 1-2.
+ * Each maps to one ``BriefField`` textarea.
+ */
+export interface SetupParts {
+  scenario: string;
+  team: string;
+  environment: string;
+  constraints: string;
+}
+
+/**
+ * Hard cap (characters) on the composed ``scenario_prompt`` — the four
+ * setup sections joined with headers. Must stay in sync with the
+ * backend's ``CreateSessionBody.scenario_prompt`` ``max_length`` in
+ * ``backend/app/api/routes.py`` and the cap stated in the README's
+ * "Drafting a brief with your work's LLM" prompt template. The wizard
+ * shows a live counter against this and disables the forward / ROLL
+ * SESSION button when a brief exceeds it, so an operator sees the
+ * limit while composing instead of round-tripping a 422 from the
+ * server (which previously surfaced as an unrecoverable
+ * ``[object Object]`` blob).
+ */
+export const SCENARIO_PROMPT_MAX_CHARS = 16000;
+
+/**
+ * Combine the four setup sections into the single ``scenario_prompt``
+ * string the backend accepts. Empty sections are dropped entirely so
+ * the AI never sees a bare header it has to interpret. This is the
+ * exact string the wizard counts against ``SCENARIO_PROMPT_MAX_CHARS``
+ * and that ``Facilitator`` ships as ``scenario_prompt`` — counting
+ * anything else (e.g. the raw sum of section lengths) would drift from
+ * what the server actually validates, since the headers + blank-line
+ * separators add real characters.
+ */
+export function composeScenarioPrompt(parts: SetupParts): string {
+  const sections: [string, string][] = [
+    ["SCENARIO BRIEF", parts.scenario],
+    ["TEAM", parts.team],
+    ["ENVIRONMENT", parts.environment],
+    ["CONSTRAINTS / AVOID", parts.constraints],
+  ];
+  return sections
+    .filter(([, body]) => body.trim().length > 0)
+    .map(([title, body]) => `${title}\n${body.trim()}`)
+    .join("\n\n");
+}

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -36,6 +36,7 @@ import { CollapsibleRailPanel } from "../components/brand/CollapsibleRailPanel";
 import { HudGauges } from "../components/brand/HudGauges";
 import { TurnStateRail } from "../components/brand/TurnStateRail";
 import { SetupWizard, type SetupRoleSlot } from "../components/setup/SetupWizard";
+import { composeScenarioPrompt } from "../components/setup/scenarioPrompt";
 import { InviteGate } from "../components/InviteGate";
 import {
   clearStoredInviteCode,
@@ -105,25 +106,6 @@ const DEV_SETUP_PREFILL = {
     "(jurisdictional differences). Keep regulator framing US-state-AG " +
     "+ FFIEC / OCC. Do NOT ask the team to invent attacker attribution.",
 };
-
-/**
- * Combine the four setup sections into a single seed string the backend
- * already knows how to handle (``scenario_prompt``). Sections that the
- * operator left blank are dropped entirely so the AI doesn't see empty
- * headers it has to interpret.
- */
-function _composeScenarioPrompt(parts: typeof DEV_SETUP_PREFILL): string {
-  const sections: [string, string][] = [
-    ["SCENARIO BRIEF", parts.scenario],
-    ["TEAM", parts.team],
-    ["ENVIRONMENT", parts.environment],
-    ["CONSTRAINTS / AVOID", parts.constraints],
-  ];
-  return sections
-    .filter(([, body]) => body.trim().length > 0)
-    .map(([title, body]) => `${title}\n${body.trim()}`)
-    .join("\n\n");
-}
 
 export function Facilitator() {
   const [state, setState] = useState<CreatorState | null>(null);
@@ -693,7 +675,7 @@ export function Facilitator() {
         .map((s) => ({ label: s.label.trim() }))
         .filter((r) => r.label.length > 0);
       const created = await api.createSession({
-        scenario_prompt: _composeScenarioPrompt(setupParts),
+        scenario_prompt: composeScenarioPrompt(setupParts),
         creator_label: creatorLabel,
         creator_display_name: creatorDisplayName,
         invitee_roles: inviteeRoles,


### PR DESCRIPTION
## Problem

A creator pasted a realistic **~10,600-char** incident brief into the new-session wizard and got an unrecoverable red **`[object Object]`** on `ROLL SESSION` (captured in a HAR). Two failures stacked:

1. The **8,000-char cap** on the composed `scenario_prompt` (the four setup sections joined with headers) was too tight for a genuinely detailed exercise.
2. When the backend returned its 422, the `detail` is a Pydantic validation **array** — the api-client did `json.detail as string`, which stringifies an array to `"[object Object]"`. The user saw a blob with no idea what to fix.

## Fix — defence at every layer

| Layer | Change |
|---|---|
| `frontend/src/api/client.ts` | New `_formatErrorDetail` parses **both** `detail` shapes (string + the Pydantic array) at the single boundary every `api.*` call funnels through → kills `[object Object]` for **all** endpoints. Field names are humanised (`creator_label` → "Creator label"); entry count + message length are clamped (defence-in-depth). |
| `backend/app/api/routes.py` | `scenario_prompt` `max_length` **8000 → 16000**. It rides in the cached (`cache_control: ephemeral`) system block, so the headroom is paid once at cache creation, not per turn. |
| `frontend/.../scenarioPrompt.ts` (new) + `SetupWizard.tsx` | Component-free module owns the cap + `composeScenarioPrompt` (single source of truth; the duplicate in `Facilitator` is deleted). Wizard shows a live **"BRIEF LENGTH X / 16,000"** counter on steps 1–2 and gates the forward / ROLL SESSION button when the brief overruns, with an inline trim reason — the wall is visible while composing, never a surprise 422. |
| `README.md` | "Drafting a brief with your work's LLM" prompt template + prose now state every wire constraint (16k brief, 64-char role labels/names, ≤32 roles, 15–180 min) so a brief drafted by the operator's own LLM comes back compliant. |

## Sub-agent reviews

All five applicable reviews ran; every **HIGH** was addressed in this PR (Prompt Expert is N/A — no model-facing prompt/tool copy changed):

- **Product** — synced the replay-schema cap `app/devtools/scenario.py` 8000 → 16000 so a real 10–16k brief that creates via the API can also be recorded/replayed.
- **UI/UX** — counter colour `ink-400 → ink-300` (ink-400 failed WCAG AA contrast); step-3 ROLL SESSION (reachable over-cap via a rail jump) now names *where* to edit.
- **User-persona** — role inputs (creator label, display name, custom-role) get `maxLength=64`, matching the caps the README advertises, so a verbose LLM-proposed role label can't last-click-422; field-name humanisation makes any residual 422 readable.
- **Security** — approved (no XSS: rendered as escaped React text; cap is server-enforced). Optional LOW (message clamp) applied.
- **QA** — approved; added the suggested edge-case tests + a UTF-16-vs-code-point note (the counter errs strict, never looser than the server).

## Out of scope / carve-outs

- **Setup-form persistence on refresh** is owned by a separate session — untouched here.
- **No scenario-replay JSON added**: no new `SessionState` transition, turn-pump path, player-input gate, or `MessageKind`/tool/field — the only replay-relevant surface is the schema cap, synced above.
- **Live-LLM suite not required**: the diff is LLM-blind (a validation constant + frontend error handling + README); touches no `app/llm/`, `turn_*.py`, `submission_pipeline.py`, or prompt/tool copy.

## Test plan

- `apiClient.test.ts` — 422-array parsing with an explicit `[object Object]` regression guard, field humanisation, nested-loc + empty-array edges.
- `SetupWizard.test.tsx` — brief budget/gate/compose contract + role-input caps.
- `test_api_routes_gaps.py` — cap boundary (16000 → 200, 16001 → 422 with correct `loc`/`type`/`ctx`).
- ✅ Frontend **576 pass**, backend **1026 pass, 1 skipped**; `tsc` / `eslint` / `ruff` / `mypy` all clean.

https://claude.ai/code/session_01XgBoxLgekMB7vvyxhgBVBi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgBoxLgekMB7vvyxhgBVBi)_