### PR TITLE
backend: auto-activate roles the AI addresses but forgets to yield to

### DIFF
--- a/backend/app/sessions/active_roles.py
+++ b/backend/app/sessions/active_roles.py
@@ -8,10 +8,23 @@ has to force-advance to unstick. Prompt-only enforcement is fragile;
 this module is the load-bearing safety net.
 
 Contract: given the AI's ``set_active_roles`` output and the
-player-facing tool calls it emitted on the same turn, drop role_ids
-whose canonical name is *not addressed* in the text (and that aren't
-the explicit ``role_id`` argument of an addressing tool). Returns the
-kept set + the dropped set so the caller can audit.
+player-facing tool calls it emitted on the same turn, reconcile the
+yield to the set of roles actually *addressed* in the text (or named
+as the explicit ``role_id`` argument of an addressing tool). Two
+mirror-image moves:
+
+* **Drop** role_ids the AI yielded to but did NOT address — the
+  original wide-yield stall fix.
+* **Promote** role_ids the AI addressed but did NOT yield to — each
+  becomes its own singleton ASK group so an addressed role is never
+  locked out of the turn it was handed a task in. This is the inverse
+  failure mode: e.g. the model writes "John — pull the admin portal"
+  but its ``set_active_roles`` predates John joining mid-turn, so
+  ``[ben]`` ships without him and John gets "NOT YOUR TURN" despite a
+  direct ask. Promotion closes that gap deterministically.
+
+Returns the kept groups + the dropped set + the promoted set so the
+caller can audit and surface both directions to the creator.
 
 Heuristic — what counts as "addressed":
 
@@ -95,17 +108,25 @@ class NarrowResult:
       same-turn text; groups that empty out are removed entirely.
     * ``dropped`` — flat list of role_ids removed across all groups
       (un-addressed in the same-turn text).
+    * ``promoted`` — flat list of role_ids the matcher considered
+      addressed but that the AI did NOT yield to; each is appended to
+      ``kept_groups`` as its own singleton ASK so an addressed role is
+      never locked out of the turn it was handed a task in. The mirror
+      of ``dropped``.
     * ``addressed_role_ids`` — full set of roles the matcher considered
       addressed (whether or not the AI included them in its yield).
       Useful for diagnostics: a role appearing here but NOT in any of
-      the AI's groups means the AI under-yielded.
+      the AI's groups means the AI under-yielded (and is now promoted).
     * ``narrowed`` — convenience flag: ``True`` iff at least one role
-      was dropped or a group was elided.
+      was dropped or a group was elided. (Promotion does NOT set this;
+      check ``promoted`` separately — the two directions are reported
+      independently so the caller can render distinct creator notes.)
     * ``reason`` — short tag the audit logger / system note can render.
     """
 
     kept_groups: list[list[str]]
     dropped: list[str]
+    promoted: list[str]
     addressed_role_ids: set[str]
     narrowed: bool
     reason: str
@@ -130,9 +151,10 @@ def narrow_active_role_groups(
     appended_messages: list[Message],
     ai_groups: list[list[str]],
 ) -> NarrowResult:
-    """Drop role_ids from each group in ``ai_groups`` that aren't
-    addressed in the same-turn text. Groups that become empty are
-    elided entirely.
+    """Reconcile ``ai_groups`` to the roles actually addressed in the
+    same-turn text: drop role_ids that aren't addressed (empty groups
+    are elided), and promote addressed role_ids the AI failed to yield
+    to (each appended as its own singleton group).
 
     See module docstring for the heuristic. Pure function; the caller
     handles audit + transcript surfacing.
@@ -244,20 +266,31 @@ def narrow_active_role_groups(
 
     addressed = explicit_targets | addressed_in_text
 
-    # Phase 3: decide. If the AI's set has no overlap with the addressed
-    # set AND the addressed set is empty (no names at clause-start, no
-    # explicit tool targets), this is a generic team broadcast. Keep
-    # the AI's groups unchanged so we don't accidentally narrow to
-    # empty on legitimate "Team — your move?" turns.
+    # Phase 3: reconcile the AI's yield against the addressed set. The
+    # invariant we enforce — WHENEVER any role is addressed — is "active
+    # set == addressed set": every role the AI addressed at clause-start
+    # (or via an explicit tool target) is active, and no role it merely
+    # yielded-to-but-didn't-address is. (When NO role is addressed we
+    # can't infer an audience, so the AI's yield is kept verbatim; see
+    # the ``if not addressed`` branch immediately below.)
+    #
+    # If the addressed set is empty (no names at clause-start, no
+    # explicit tool targets), this is a generic team broadcast or a
+    # pure data brief — there's no textual audience to reconcile
+    # against. Keep the AI's groups unchanged so we don't accidentally
+    # narrow to empty on a legitimate "Team — your move?" turn.
     if not addressed:
         return NarrowResult(
             kept_groups=[list(g) for g in ai_groups],
             dropped=[],
+            promoted=[],
             addressed_role_ids=set(),
             narrowed=False,
             reason="no_addressed_roles_no_narrowing",
         )
 
+    # Phase 3a — DROP: within each yielded group keep only addressed
+    # role_ids; elide a group that empties out entirely.
     keep_set = addressed
     kept_groups: list[list[str]] = []
     dropped: list[str] = []
@@ -269,35 +302,54 @@ def narrow_active_role_groups(
         if kept_in_group:
             kept_groups.append(kept_in_group)
 
-    # Safety: never narrow to empty. If the heuristic would drop
-    # every group the AI yielded to, bail out and keep the original.
-    # This covers the rare case where the matcher misses every name
-    # (e.g. the model used a nickname not in the roster) and the AI's
-    # groups are at least directionally sensible.
-    if not kept_groups:
-        return NarrowResult(
-            kept_groups=[list(g) for g in ai_groups],
-            dropped=[],
-            addressed_role_ids=addressed,
-            narrowed=False,
-            reason="would_narrow_to_empty_kept_original",
-        )
+    # Phase 3b — PROMOTE: any role the AI addressed but forgot to yield
+    # to becomes its own singleton ASK group. This is the mirror of the
+    # drop pass above; together they force "active set == addressed
+    # set" (the AI's any-of grouping is preserved for addressed members
+    # it grouped together). The dominant trigger is a role that joined
+    # mid-turn and wasn't in the roster snapshot when the model drafted
+    # its yield: it addresses "John — pull the admin portal" but its
+    # ``set_active_roles`` predates John, so without promotion John is
+    # locked out of the very turn he was handed a task in. Promotion
+    # order is roster order for determinism (``addressed`` is an
+    # unordered set). Because promotion can only ADD a role the model
+    # already addressed in text, it cannot re-introduce the wide-yield
+    # stall the drop pass exists to prevent — a promoted role always has
+    # a real, clause-start ask waiting on it.
+    covered = {rid for group in kept_groups for rid in group}
+    promoted = [r.id for r in roles if r.id in addressed and r.id not in covered]
+    for rid in promoted:
+        kept_groups.append([rid])
 
-    if not dropped:
+    # ``kept_groups`` is now guaranteed non-empty: ``addressed`` is
+    # non-empty (guard above) and every addressed role is either kept in
+    # a surviving group or promoted as a singleton — so the old "would
+    # narrow to empty, keep original" bail-out is structurally
+    # unreachable and has been removed.
+    if not dropped and not promoted:
         return NarrowResult(
             kept_groups=kept_groups,
             dropped=[],
+            promoted=[],
             addressed_role_ids=addressed,
             narrowed=False,
             reason="ai_set_already_matches_addressed",
         )
 
+    if dropped and promoted:
+        reason = "reconciled_dropped_and_promoted"
+    elif dropped:
+        reason = "dropped_unaddressed_roles"
+    else:
+        reason = "promoted_addressed_roles"
+
     return NarrowResult(
         kept_groups=kept_groups,
         dropped=dropped,
+        promoted=promoted,
         addressed_role_ids=addressed,
-        narrowed=True,
-        reason="dropped_unaddressed_roles",
+        narrowed=bool(dropped),
+        reason=reason,
     )
 
 

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -1397,18 +1397,24 @@ class TurnDriver:
                 # display_name) because the AI Decision Log surface is
                 # operator-focused.
                 role_by_id = {r.id: r for r in session.roles}
+                # Fall back to the raw role_id when a reconciled id is no
+                # longer in the roster: the AI can yield a stale/invalid id
+                # (it lands in ``dropped``), or a role can be removed
+                # mid-turn. Without the fallback the label lists silently
+                # empty and the decision-log note loses which id moved
+                # (Copilot review on #250). Raw ids are safe to surface
+                # here — this is the operator-only decision log, never
+                # rendered to players as a name.
                 dropped_labels = [
-                    role_by_id[rid].label
+                    role_by_id[rid].label if rid in role_by_id else rid
                     for rid in narrow_result.dropped
-                    if rid in role_by_id
                 ]
                 promoted_labels = [
-                    role_by_id[rid].label
+                    role_by_id[rid].label if rid in role_by_id else rid
                     for rid in narrow_result.promoted
-                    if rid in role_by_id
                 ]
                 kept_group_labels = [
-                    [role_by_id[rid].label for rid in g if rid in role_by_id]
+                    [role_by_id[rid].label if rid in role_by_id else rid for rid in g]
                     for g in narrow_result.kept_groups
                 ]
                 _logger.info(
@@ -1440,22 +1446,14 @@ class TurnDriver:
                 # operator can see the engine's reasoning. Players
                 # never see this — exposing engine internals to them
                 # is confusing. The structlog line above is the
-                # canonical audit record. Render whichever direction(s)
-                # actually fired so the note reads true on drop-only,
-                # promote-only, and mixed turns.
-                parts: list[str] = []
-                if dropped_labels:
-                    parts.append(
-                        f"dropped {dropped_labels} (not addressed this turn)"
-                    )
-                if promoted_labels:
-                    parts.append(
-                        f"added {promoted_labels} (addressed but not yielded to)"
-                    )
-                rationale = (
-                    f"Reconciled active groups to {kept_group_labels}: "
-                    + "; ".join(parts)
-                    + "."
+                # canonical audit record. ``_build_reconcile_rationale``
+                # renders whichever direction(s) actually fired and is
+                # total: it never emits a dangling "...: ." even when
+                # both label lists are empty.
+                rationale = _build_reconcile_rationale(
+                    kept_group_labels=kept_group_labels,
+                    dropped_labels=dropped_labels,
+                    promoted_labels=promoted_labels,
                 )
                 entry = DecisionLogEntry(
                     turn_index=turn.index,
@@ -1750,6 +1748,34 @@ def _trim_rationale(text: str) -> str:
     if len(text) <= _RATIONALE_MAX_CHARS:
         return text
     return text[: _RATIONALE_MAX_CHARS - 1] + "…"
+
+
+def _build_reconcile_rationale(
+    *,
+    kept_group_labels: list[list[str]],
+    dropped_labels: list[str],
+    promoted_labels: list[str],
+) -> str:
+    """Compose the creator decision-log note for an active-set reconcile.
+
+    Pure and *total*: always returns a well-formed sentence, even when
+    both label lists are empty — it never emits the dangling
+    ``"Reconciled active groups to [...]: ."`` that the previous
+    unconditional ``": " + "; ".join(parts) + "."`` produced when a
+    reconciled role_id had left the roster (Copilot review on #250).
+    Callers pass labels that already fall back to raw role_ids, so in
+    practice ``parts`` is non-empty whenever a reconcile fired; the
+    empty-suffix guard is defensive against a future regression.
+    """
+
+    parts: list[str] = []
+    if dropped_labels:
+        parts.append(f"dropped {dropped_labels} (not addressed this turn)")
+    if promoted_labels:
+        parts.append(f"added {promoted_labels} (addressed but not yielded to)")
+    base = f"Reconciled active groups to {kept_group_labels}"
+    detail = "; ".join(parts)
+    return f"{base}: {detail}." if detail else f"{base}."
 
 
 def _merge_outcomes(target: DispatchOutcome, src: DispatchOutcome) -> None:

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -1369,16 +1369,20 @@ class TurnDriver:
             return
 
         if outcome.set_active_role_groups is not None:
-            # Server-side audience-vs-yield safety net. The play-tier
-            # model habitually yields wider than its actual audience
-            # (broadcasts "Ben — your call?" and yields to [Ben, Eng]
-            # even though Eng wasn't asked anything), which used to
-            # stall the turn under the all-must-ready gate. Issue #168
-            # moved to the role-groups model; the narrower now drops
-            # un-addressed role_ids from each group AND elides any
-            # group that empties out, so a fake "[Eng]" group simply
-            # disappears from the yield instead of becoming a stuck
-            # quorum slot. Edge-case coverage:
+            # Server-side audience-vs-yield safety net, both directions.
+            # The play-tier model both over- and under-yields relative
+            # to its actual audience:
+            #   • over-yield — broadcasts "Ben — your call?" but yields
+            #     [Ben, Eng] even though Eng wasn't asked; the narrower
+            #     DROPS Eng and elides the empty group, so a fake
+            #     "[Eng]" group can't become a stuck quorum slot.
+            #   • under-yield — addresses "John — pull the portal" but
+            #     yields only [Ben] (e.g. John joined mid-turn, after
+            #     the yield was drafted); the narrower PROMOTES John
+            #     into his own ASK group so a directly-addressed role
+            #     isn't locked out of the turn with "NOT YOUR TURN".
+            # Together these force "active set == addressed set". Issue
+            # #168 moved to the role-groups model. Edge-case coverage:
             # ``tests/test_active_roles_narrowing.py``.
             narrow_result = narrow_active_role_groups(
                 roles=session.roles,
@@ -1386,7 +1390,7 @@ class TurnDriver:
                 ai_groups=[list(g) for g in outcome.set_active_role_groups],
             )
             final_active_role_groups = narrow_result.kept_groups
-            if narrow_result.narrowed:
+            if narrow_result.narrowed or narrow_result.promoted:
                 # Build human-readable label lists for the audit +
                 # decision log so the creator can see what the engine
                 # did. We intentionally use ``label`` here (not
@@ -1398,12 +1402,17 @@ class TurnDriver:
                     for rid in narrow_result.dropped
                     if rid in role_by_id
                 ]
+                promoted_labels = [
+                    role_by_id[rid].label
+                    for rid in narrow_result.promoted
+                    if rid in role_by_id
+                ]
                 kept_group_labels = [
                     [role_by_id[rid].label for rid in g if rid in role_by_id]
                     for g in narrow_result.kept_groups
                 ]
                 _logger.info(
-                    "active_roles_narrowed",
+                    "active_roles_reconciled",
                     session_id=session.id,
                     turn_id=turn.id,
                     turn_index=turn.index,
@@ -1411,6 +1420,13 @@ class TurnDriver:
                     kept_groups=narrow_result.kept_groups,
                     dropped=narrow_result.dropped,
                     dropped_labels=dropped_labels,
+                    # Roles the AI addressed at clause-start but failed
+                    # to yield to — the engine promoted each into its
+                    # own ASK group so a directly-addressed role (often
+                    # one that joined mid-turn) isn't locked out of the
+                    # turn. The inverse of ``dropped``.
+                    promoted=narrow_result.promoted,
+                    promoted_labels=promoted_labels,
                     # The full set of roles the matcher considered
                     # addressed — including any the AI didn't yield
                     # to. Surfaces the "AI under-yielded" failure
@@ -1424,11 +1440,22 @@ class TurnDriver:
                 # operator can see the engine's reasoning. Players
                 # never see this — exposing engine internals to them
                 # is confusing. The structlog line above is the
-                # canonical audit record.
+                # canonical audit record. Render whichever direction(s)
+                # actually fired so the note reads true on drop-only,
+                # promote-only, and mixed turns.
+                parts: list[str] = []
+                if dropped_labels:
+                    parts.append(
+                        f"dropped {dropped_labels} (not addressed this turn)"
+                    )
+                if promoted_labels:
+                    parts.append(
+                        f"added {promoted_labels} (addressed but not yielded to)"
+                    )
                 rationale = (
-                    f"Narrowed active groups: kept {kept_group_labels}, "
-                    f"dropped {dropped_labels} — not addressed in this "
-                    f"turn's message."
+                    f"Reconciled active groups to {kept_group_labels}: "
+                    + "; ".join(parts)
+                    + "."
                 )
                 entry = DecisionLogEntry(
                     turn_index=turn.index,
@@ -1463,6 +1490,29 @@ class TurnDriver:
                             entry_id=entry.id,
                             error=str(exc),
                         )
+            else:
+                # No drop, no promote: the AI's yield was kept verbatim —
+                # either it already matched the addressed set, or no role
+                # was addressed at clause-start (a generic "Team — …"
+                # broadcast or a pure data brief, where the engine can't
+                # infer an audience and trusts the yield). Log it anyway so
+                # the active-set decision is observable on EVERY turn:
+                # when a creator asks "why is this seat still pending?" on
+                # a brief-only turn, this breadcrumb shows the AI itself
+                # yielded that role with no specific addressee — the
+                # narrower didn't add it. Without this line the no-op path
+                # was silent, leaving the most-likely support question
+                # (per the product + user-persona reviews) un-answerable
+                # from the logs alone.
+                _logger.info(
+                    "active_roles_kept_ai_yield",
+                    session_id=session.id,
+                    turn_id=turn.id,
+                    turn_index=turn.index,
+                    kept_groups=narrow_result.kept_groups,
+                    addressed_role_ids=sorted(narrow_result.addressed_role_ids),
+                    reason=narrow_result.reason,
+                )
             turn.status = "complete"
             turn.ended_at = _now()
             new_index = len(session.turns)

--- a/backend/tests/test_active_roles_narrowing.py
+++ b/backend/tests/test_active_roles_narrowing.py
@@ -73,6 +73,7 @@ def test_drops_unaddressed_role_when_broadcast_names_only_one() -> None:
     assert result.narrowed is True
     assert result.kept == [ben.id]
     assert result.dropped == [eng.id]
+    assert result.reason == "dropped_unaddressed_roles"
     assert ben.id in result.addressed_role_ids
     assert eng.id not in result.addressed_role_ids
 
@@ -273,10 +274,11 @@ def test_generic_broadcast_no_names_keeps_full_set() -> None:
     assert result.reason == "no_addressed_roles_no_narrowing"
 
 
-def test_would_narrow_to_empty_keeps_original() -> None:
-    """If the heuristic misses every name in the AI's set (e.g. the
-    model used a nickname not in the roster), don't shrink to empty —
-    keep the AI's directional intent."""
+def test_unmatched_nickname_keeps_original_set() -> None:
+    """If the heuristic misses every name (e.g. the model used a
+    nickname not in the roster), no role is addressed — fall into the
+    no-addressed branch and keep the AI's directional intent rather than
+    shrinking to empty."""
 
     ben = _make_role(id_label="Cybersecurity Manager", display_name="Benjamin")
     eng = _make_role(id_label="Cybersecurity Engineer")
@@ -359,17 +361,23 @@ def test_request_artifact_target_counts_as_addressed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_empty_ai_set_returns_empty() -> None:
+def test_empty_ai_set_no_address_returns_empty() -> None:
+    """Empty yield + a generic broadcast with no clause-start address →
+    nothing to keep and nothing to promote. (The promote-on-empty-yield
+    recovery only fires when a role is actually addressed; see
+    ``test_silent_yield_promotes_addressed_role``.)"""
+
     ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
 
     result = narrow_active_role_groups(
         roles=[ben],
-        appended_messages=[_broadcast("Ben — your call?")],
+        appended_messages=[_broadcast("Team — stand by for the next inject.")],
         ai_groups=[],
     )
 
     assert result.kept == []
     assert result.dropped == []
+    assert result.promoted == []
     assert result.narrowed is False
 
 
@@ -429,6 +437,8 @@ def test_case_insensitive_match() -> None:
     )
 
     assert ben.id in result.addressed_role_ids
+    # AI's yield already matches the addressed set → no drop, no promote.
+    assert result.reason == "ai_set_already_matches_addressed"
 
 
 def test_kept_preserves_input_order() -> None:
@@ -503,6 +513,182 @@ def test_cumulative_merge_after_strict_retry_narrows_correctly() -> None:
     )
     assert result.kept == [ciso.id]
     assert result.dropped == [soc.id]
+
+
+# ---------------------------------------------------------------------------
+# Promotion: a role the AI ADDRESSED but did NOT yield to is added back as
+# its own ASK. Mirror of the drop pass. This is the user-reported bug:
+# "John was added, the AI addressed him, but he couldn't mark ready." A
+# role that joined mid-turn isn't in the roster snapshot when the model
+# drafts its yield, so it writes "John — pull the portal" but ships
+# set_active_roles=[ben]; without promotion John gets "NOT YOUR TURN".
+# ---------------------------------------------------------------------------
+
+
+def test_promotes_addressed_role_missing_from_yield() -> None:
+    """Headline bug: AI addresses Ben AND John but only yields Ben. John
+    is promoted into his own singleton group so he can respond."""
+
+    ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
+    john = _make_role(id_label="Security Engineer", display_name="John")
+
+    msgs = [
+        _broadcast(
+            "Ben — kick off the audit log pull. "
+            "John — check the M365 admin portal for live inbox rules."
+        )
+    ]
+
+    result = narrow_active_role_groups(
+        roles=[ben, john],
+        appended_messages=msgs,
+        ai_groups=[[ben.id]],  # AI under-yielded — John omitted.
+    )
+
+    assert result.promoted == [john.id]
+    assert result.dropped == []
+    assert result.kept_groups == [[ben.id], [john.id]]
+    assert result.kept == [ben.id, john.id]
+    assert result.reason == "promoted_addressed_roles"
+    # ``narrowed`` tracks the DROP direction only; a promote-only turn is
+    # not "narrowed" — the promotion is reported via ``promoted``.
+    assert result.narrowed is False
+
+
+def test_drop_and_promote_in_one_turn() -> None:
+    """The AI yields a role it didn't address (drop) AND fails to yield a
+    role it did (promote). Both directions fire; reason reflects both."""
+
+    ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
+    john = _make_role(id_label="Security Engineer", display_name="John")
+    eng = _make_role(id_label="Cybersecurity Engineer")
+
+    # Addresses Ben + John; yields Ben + Eng (Eng never addressed).
+    msgs = [_broadcast("Ben — confirm containment. John — pull the portal logs.")]
+
+    result = narrow_active_role_groups(
+        roles=[ben, john, eng],
+        appended_messages=msgs,
+        ai_groups=[[ben.id], [eng.id]],
+    )
+
+    assert result.dropped == [eng.id]  # yielded but not addressed
+    assert result.promoted == [john.id]  # addressed but not yielded
+    assert result.kept_groups == [[ben.id], [john.id]]
+    assert result.narrowed is True
+    assert result.reason == "reconciled_dropped_and_promoted"
+
+
+def test_promotion_order_is_roster_order() -> None:
+    """Two addressed-but-unyielded roles promote in ROSTER order, not the
+    order they appear in the text (``addressed`` is an unordered set, so
+    promotion must be deterministic for replay)."""
+
+    a = _make_role(id_label="Alpha")
+    b = _make_role(id_label="Bravo")
+    c = _make_role(id_label="Charlie")
+
+    # Text addresses Charlie before Alpha; roster order is A, B, C.
+    msgs = [_broadcast("Charlie — go. Alpha — go.")]
+
+    result = narrow_active_role_groups(
+        roles=[a, b, c],
+        appended_messages=msgs,
+        ai_groups=[[b.id]],  # only Bravo yielded; Bravo NOT addressed.
+    )
+
+    assert result.dropped == [b.id]
+    assert result.promoted == [a.id, c.id]  # roster order, not text order
+    assert result.kept_groups == [[a.id], [c.id]]
+
+
+def test_promotes_explicit_tool_target_missing_from_yield() -> None:
+    """An ``address_role`` tool target the AI forgot to yield to is also
+    promoted (explicit targets are the highest-confidence address)."""
+
+    ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
+    legal = _make_role(id_label="Legal Counsel")
+
+    msgs = [
+        _broadcast("Ben — confirm containment posture."),
+        _address_role(legal.id, "Draft the breach notification for the AG."),
+    ]
+
+    result = narrow_active_role_groups(
+        roles=[ben, legal],
+        appended_messages=msgs,
+        ai_groups=[[ben.id]],  # Legal addressed via tool but not yielded.
+    )
+
+    assert legal.id in result.promoted
+    assert result.kept == [ben.id, legal.id]
+
+
+def test_promotion_preserves_any_of_group() -> None:
+    """An any-of group the AI yielded for two addressed roles survives
+    intact; a THIRD addressed-but-unyielded role promotes as its own
+    REQUIRED singleton (not folded into the any-of)."""
+
+    paul = _make_role(id_label="DevOps", display_name="Paul")
+    lawrence = _make_role(id_label="IT", display_name="Lawrence")
+    ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
+
+    msgs = [
+        _broadcast(
+            "Paul or Lawrence — who files the Jira ticket? "
+            "Ben — you own the comms update."
+        )
+    ]
+
+    result = narrow_active_role_groups(
+        roles=[paul, lawrence, ben],
+        appended_messages=msgs,
+        ai_groups=[[paul.id, lawrence.id]],  # any-of; Ben omitted.
+    )
+
+    assert [paul.id, lawrence.id] in result.kept_groups  # any-of preserved
+    assert [ben.id] in result.kept_groups  # promoted singleton
+    assert result.promoted == [ben.id]
+
+
+def test_silent_yield_promotes_addressed_role() -> None:
+    """Defensive: an empty yield (the 'silent yield' failure mode) plus a
+    clause-start address recovers the addressed role, so the turn opens
+    with a real active seat instead of none."""
+
+    ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
+
+    result = narrow_active_role_groups(
+        roles=[ben],
+        appended_messages=[_broadcast("Ben — your call on isolation?")],
+        ai_groups=[],
+    )
+
+    assert result.kept == [ben.id]
+    assert result.promoted == [ben.id]
+
+
+def test_passing_mention_is_not_promoted() -> None:
+    """The promote pass uses the SAME addressing heuristic as the drop
+    pass — a referenced-but-not-addressed role must NOT be promoted. AI
+    addresses Ben, merely mentions Mike, and yields only Ben: nothing
+    changes (Mike is neither kept nor promoted). Guards against promotion
+    re-introducing the wide-yield stall the drop pass exists to prevent."""
+
+    ben = _make_role(id_label="Cybersecurity Manager", display_name="Ben")
+    mike = _make_role(id_label="CISO", display_name="Mike")
+
+    msgs = [_broadcast("Ben — your call? Loop in Mike when you can.")]
+
+    result = narrow_active_role_groups(
+        roles=[ben, mike],
+        appended_messages=msgs,
+        ai_groups=[[ben.id]],
+    )
+
+    assert result.promoted == []
+    assert mike.id not in result.kept
+    assert result.kept == [ben.id]
 
 
 if __name__ == "__main__":  # pragma: no cover — convenience for local runs

--- a/backend/tests/test_role_groups.py
+++ b/backend/tests/test_role_groups.py
@@ -436,16 +436,12 @@ class TestNarrowActiveRoleGroups:
             ai_groups=[["paul", "law"]],
         )
         # Neither is at clause-start; neither chain piece matches a
-        # canonical name. Either of the two safety branches
-        # ("no_addressed_roles_no_narrowing" / "would_narrow_to_empty_
-        # kept_original") is acceptable — both keep the AI's groups
-        # intact and never narrow the prose-laden chain to empty.
+        # canonical name. With no role addressed, the narrower takes the
+        # "no addressed roles" branch and keeps the AI's groups intact —
+        # never narrowing the prose-laden chain to empty.
         assert result.kept_groups == [["paul", "law"]]
         assert result.narrowed is False
-        assert result.reason in {
-            "no_addressed_roles_no_narrowing",
-            "would_narrow_to_empty_kept_original",
-        }
+        assert result.reason == "no_addressed_roles_no_narrowing"
 
     def test_chain_after_clause_break_addresses_trailing_pair(
         self,
@@ -465,6 +461,26 @@ class TestNarrowActiveRoleGroups:
         # the splitter strips out "after paul confirms" via the
         # "or" boundary.
         assert result.kept_groups == [["paul", "law"]]
+
+    def test_promotes_addressed_role_the_ai_forgot_to_yield(self) -> None:
+        # Inverse of ``test_unaddressed_group_is_elided``: the AI
+        # addresses John at clause-start but ships a yield that predates
+        # him (he joined mid-turn). Promotion adds John back as his own
+        # ASK group so he isn't locked out of the turn he was handed a
+        # task in. ``promoted`` carries the recovery; ``narrowed`` stays
+        # False because nothing was dropped.
+        roles = [_role("ben", "Ben"), _role("john", "John")]
+        msgs = [_broadcast("Ben — pull the audit log. John — check the portal.")]
+        result = narrow_active_role_groups(
+            roles=roles,
+            appended_messages=msgs,
+            ai_groups=[["ben"]],
+        )
+        assert result.kept_groups == [["ben"], ["john"]]
+        assert result.promoted == ["john"]
+        assert result.dropped == []
+        assert result.narrowed is False
+        assert result.reason == "promoted_addressed_roles"
 
 
 class TestKickedRoleScrubbing:

--- a/backend/tests/test_turn_driver.py
+++ b/backend/tests/test_turn_driver.py
@@ -387,3 +387,76 @@ def test_setup_drafting_plan_does_not_fire_on_ask_question(
     assert drafting == [], (
         f"setup_drafting_plan must not fire for ask_setup_question; got {drafting!r}"
     )
+
+
+class TestBuildReconcileRationale:
+    """``_build_reconcile_rationale`` is total — it never emits the
+    dangling ``"Reconciled active groups to [...]: ."`` the previous
+    inline string concat produced when a reconcile fired but every
+    dropped/promoted role_id had left the roster (so both label lists
+    came back empty). Copilot review on PR #250."""
+
+    def test_drop_only(self) -> None:
+        from app.sessions.turn_driver import _build_reconcile_rationale
+
+        assert _build_reconcile_rationale(
+            kept_group_labels=[["Ben"]],
+            dropped_labels=["Engineer"],
+            promoted_labels=[],
+        ) == (
+            "Reconciled active groups to [['Ben']]: "
+            "dropped ['Engineer'] (not addressed this turn)."
+        )
+
+    def test_promote_only(self) -> None:
+        from app.sessions.turn_driver import _build_reconcile_rationale
+
+        out = _build_reconcile_rationale(
+            kept_group_labels=[["Ben"], ["John"]],
+            dropped_labels=[],
+            promoted_labels=["John"],
+        )
+        assert "added ['John'] (addressed but not yielded to)" in out
+        assert out.endswith(".")
+        assert ": ." not in out
+
+    def test_drop_and_promote_join_both_clauses(self) -> None:
+        from app.sessions.turn_driver import _build_reconcile_rationale
+
+        out = _build_reconcile_rationale(
+            kept_group_labels=[["Ben"], ["John"]],
+            dropped_labels=["Engineer"],
+            promoted_labels=["John"],
+        )
+        assert "dropped ['Engineer']" in out
+        assert "added ['John']" in out
+        assert ";" in out  # the two clauses are joined, not overwritten
+        assert out.endswith(".")
+
+    def test_empty_labels_never_dangles(self) -> None:
+        # The regression: reconcile fired (block entered) but every
+        # dropped/promoted id had left the roster → both lists empty.
+        # Must NOT render the malformed "...: ." suffix.
+        from app.sessions.turn_driver import _build_reconcile_rationale
+
+        out = _build_reconcile_rationale(
+            kept_group_labels=[["Ben"]],
+            dropped_labels=[],
+            promoted_labels=[],
+        )
+        assert out == "Reconciled active groups to [['Ben']]."
+        assert ": ." not in out
+
+    def test_raw_id_fallback_is_surfaced(self) -> None:
+        # The caller falls back to the raw role_id when a role left the
+        # roster; the helper renders it verbatim so the note still names
+        # which id moved instead of silently dropping it.
+        from app.sessions.turn_driver import _build_reconcile_rationale
+
+        out = _build_reconcile_rationale(
+            kept_group_labels=[["Ben"]],
+            dropped_labels=["role_deadbeef"],
+            promoted_labels=[],
+        )
+        assert "role_deadbeef" in out
+        assert ": ." not in out

--- a/frontend/src/__tests__/MarkReadyButton.test.tsx
+++ b/frontend/src/__tests__/MarkReadyButton.test.tsx
@@ -108,7 +108,7 @@ describe("<MarkReadyButton/>", () => {
   });
 
   describe("impersonate variant", () => {
-    it("not-ready: shows MARK <ROLE> READY → using subjectLabel", () => {
+    it("not-ready: shows READY ON <SUBJECT>'S BEHALF using subjectLabel", () => {
       render(
         <MarkReadyButton
           isReady={false}
@@ -119,8 +119,9 @@ describe("<MarkReadyButton/>", () => {
         />,
       );
       const btn = screen.getByTestId("mark-ready-impersonate");
-      // Subject label uppercased + framed inside the action verb.
-      expect(btn.textContent).toMatch(/MARK SOC ANALYST READY/);
+      // Subject (the player's name in production) uppercased + framed
+      // as acting on their behalf, not toggling the creator's own seat.
+      expect(btn.textContent).toMatch(/READY ON SOC ANALYST'S BEHALF/);
       // No "tap to undo" hint on the impersonation variant — it'd
       // be ambiguous (whose ready are we undoing?).
       expect(btn.textContent).not.toMatch(/tap to undo/i);
@@ -193,7 +194,7 @@ describe("<MarkReadyButton/>", () => {
       );
     });
 
-    it("missing subjectLabel falls back to 'role'", () => {
+    it("missing subjectLabel falls back to 'this role'", () => {
       render(
         <MarkReadyButton
           isReady={false}
@@ -203,7 +204,7 @@ describe("<MarkReadyButton/>", () => {
         />,
       );
       const btn = screen.getByTestId("mark-ready-impersonate");
-      expect(btn.textContent).toMatch(/MARK ROLE READY/);
+      expect(btn.textContent).toMatch(/READY ON THIS ROLE'S BEHALF/);
     });
   });
 

--- a/frontend/src/__tests__/MarkReadyButton.test.tsx
+++ b/frontend/src/__tests__/MarkReadyButton.test.tsx
@@ -206,6 +206,74 @@ describe("<MarkReadyButton/>", () => {
       const btn = screen.getByTestId("mark-ready-impersonate");
       expect(btn.textContent).toMatch(/READY ON THIS ROLE'S BEHALF/);
     });
+
+    it("renders the 'for them · not you' proxy caption when interactive — the misclick guard's textual channel", () => {
+      render(
+        <MarkReadyButton
+          isReady={false}
+          enabled={true}
+          onToggle={vi.fn()}
+          variant="impersonate"
+          subjectLabel="SOC Analyst"
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready-impersonate");
+      expect(btn.textContent).toMatch(/for them · not you/);
+    });
+
+    it("renders the proxy caption in the READY state too (persistent, not just not-ready)", () => {
+      render(
+        <MarkReadyButton
+          isReady={true}
+          enabled={true}
+          onToggle={vi.fn()}
+          variant="impersonate"
+          subjectLabel="SOC Analyst"
+        />,
+      );
+      expect(
+        screen.getByTestId("mark-ready-impersonate").textContent,
+      ).toMatch(/for them · not you/);
+    });
+
+    it("hides the proxy caption while disabled (the disabledLabel carries the state instead)", () => {
+      render(
+        <MarkReadyButton
+          isReady={false}
+          enabled={false}
+          onToggle={vi.fn()}
+          variant="impersonate"
+          subjectLabel="SOC Analyst"
+          disabledLabel="NOT YOUR TURN"
+        />,
+      );
+      const btn = screen.getByTestId("mark-ready-impersonate");
+      expect(btn.textContent).toMatch(/NOT YOUR TURN/);
+      expect(btn.textContent).not.toMatch(/for them · not you/);
+    });
+
+    it("is structurally distinct from the self button — dashed border + smaller text, so it can't be misclicked for your own (creator feedback)", () => {
+      const { rerender } = render(
+        <MarkReadyButton isReady={false} enabled={true} onToggle={vi.fn()} variant="self" />,
+      );
+      const selfCls = screen.getByTestId("mark-ready").className;
+      rerender(
+        <MarkReadyButton
+          isReady={false}
+          enabled={true}
+          onToggle={vi.fn()}
+          variant="impersonate"
+          subjectLabel="SOC"
+        />,
+      );
+      const proxyCls = screen.getByTestId("mark-ready-impersonate").className;
+      // Self stays the solid, full-size primary; impersonate is dashed
+      // + one step smaller. Distinct on shape AND size, not just colour.
+      expect(selfCls).not.toMatch(/border-dashed/);
+      expect(proxyCls).toMatch(/border-dashed/);
+      expect(selfCls).toMatch(/text-\[11px\]/);
+      expect(proxyCls).toMatch(/text-\[10px\]/);
+    });
   });
 
   describe("in-flight pulse (UI/UX review MEDIUM M2)", () => {

--- a/frontend/src/components/RolesPanel.tsx
+++ b/frontend/src/components/RolesPanel.tsx
@@ -538,7 +538,10 @@ export function RolesPanel({
                     enabled={markReadyEnabled}
                     onToggle={(next) => onMarkReady(r.id, next)}
                     variant={isSelfRole ? "self" : "impersonate"}
-                    subjectLabel={r.label}
+                    // Prefer the player's name ("READY ON JOHN'S
+                    // BEHALF") over the role label; fall back to the
+                    // label for an as-yet-unnamed seat.
+                    subjectLabel={r.display_name || r.label}
                     disabledReason={markReadyDisabledReason}
                     inFlight={
                       pendingMarkReadySubjects?.has(r.id) ?? false

--- a/frontend/src/components/brand/MarkReadyButton.tsx
+++ b/frontend/src/components/brand/MarkReadyButton.tsx
@@ -145,6 +145,14 @@ export function MarkReadyButton({
   // skip it when ``enabled=false`` because the button can't actually
   // undo right now — the hint would lie.
   const showUndoHint = variant === "self" && isReady && enabled;
+  // Persistent proxy caption — a constant lowercase reminder that the
+  // impersonate button marks SOMEONE ELSE ready, the textual half of the
+  // misclick guard (the visual half is the dashed/smaller/muted styling
+  // in ``cls``). Only when interactive; a disabled button shows its
+  // ``disabledLabel`` ("NOT YOUR TURN") instead and the caption would
+  // just add noise. Mutually exclusive with ``showUndoHint`` (that's
+  // self-only), so they share the one caption slot in the render.
+  const showProxyCaption = variant === "impersonate" && enabled;
   // ``aria-pressed`` is only meaningful on the self variant — it
   // describes the LOCAL participant's ready state. On the
   // impersonation variant the toggle reflects another role's state,
@@ -167,23 +175,30 @@ export function MarkReadyButton({
       : "Mark yourself ready. The AI advances once every active role is ready.";
   })();
 
-  // Brand tones:
-  //   self+ready          → signal-filled (green); the dominant signal
-  //                         on the page when YOU are done.
-  //   self+not-ready      → ink-800 outline w/ signal-bright text;
-  //                         neutral primary affordance.
-  //   impersonate+ready   → info-tint (cyan); distinct from self-ready
-  //                         so the creator's eye locks onto their own
-  //                         row first when scanning.
-  //   impersonate+not-ready → ink-800 outline w/ info text; matches.
-  // Per User-persona review HIGH H2 — the visual distinction makes
-  // the self-vs-impersonation footgun (clicking the wrong row) a
-  // colour-discriminable mistake instead of a label-discriminable one.
+  // Brand tones AND visual hierarchy. The impersonate ("on behalf")
+  // button is deliberately rendered as a SECONDARY control so a creator
+  // reaching for their OWN ready button can't fat-finger a teammate's
+  // ("I don't want to accidentally mark John ready when going to click
+  // mine" — direct creator feedback). Colour alone (the prior guard)
+  // wasn't enough; six independent channels now separate the two so the
+  // distinction survives a quick glance, colour-blindness, and the
+  // narrow rail:
+  //   self        → SOLID border, bg-ink-800, text-[11px], font-bold,
+  //                 tracking-[0.18em], SIGNAL (green). The single bold,
+  //                 full-size PRIMARY affordance — "your" button.
+  //   impersonate → DASHED border, darker bg-ink-900, text-[10px],
+  //                 font-semibold, tighter tracking, INFO (cyan), muted
+  //                 opacity. Visibly quieter and structurally different
+  //                 (dashed vs solid) so it reads as a proxy action, not
+  //                 "your" button — paired with the lowercase
+  //                 "for them · not you" caption rendered below.
+  // Extends User-persona review HIGH H2 (colour-discriminable) to a
+  // shape/size/weight-discriminable distinction.
   const cls = (() => {
     if (variant === "impersonate") {
       return isReady
-        ? "mono w-full rounded-r-1 border border-info bg-info-bg px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] text-info hover:bg-info/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-info disabled:cursor-not-allowed disabled:opacity-50"
-        : "mono w-full rounded-r-1 border border-info bg-ink-800 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] text-info hover:bg-ink-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-info disabled:cursor-not-allowed disabled:opacity-50";
+        ? "mono w-full rounded-r-1 border border-dashed border-info bg-info/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-info hover:bg-info/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-info disabled:cursor-not-allowed disabled:opacity-50"
+        : "mono w-full rounded-r-1 border border-dashed border-info/60 bg-ink-900 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-info/85 hover:border-info hover:text-info hover:bg-ink-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-info disabled:cursor-not-allowed disabled:opacity-50";
     }
     return isReady
       ? "mono w-full rounded-r-1 border border-signal bg-signal-tint px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] text-signal hover:bg-signal/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-signal disabled:cursor-not-allowed disabled:opacity-50"
@@ -240,6 +255,10 @@ export function MarkReadyButton({
         {showUndoHint ? (
           <span className="mono text-[9px] font-normal tracking-[0.10em] opacity-70">
             tap to undo
+          </span>
+        ) : showProxyCaption ? (
+          <span className="mono text-[9px] font-normal normal-case tracking-[0.08em] opacity-75">
+            for them · not you
           </span>
         ) : null}
       </span>

--- a/frontend/src/components/brand/MarkReadyButton.tsx
+++ b/frontend/src/components/brand/MarkReadyButton.tsx
@@ -68,7 +68,8 @@ interface Props {
    * "self" → the local participant is toggling their own ready state
    *   (label: ``MARK READY`` / ``READY ✓``).
    * "impersonate" → the creator is toggling on behalf of another active
-   *   role (label: ``MARK <ROLE> READY`` / ``<ROLE> READY ✓``).
+   *   role (label: ``READY ON <SUBJECT>'S BEHALF`` / ``<SUBJECT> READY ✓``,
+   *   where <SUBJECT> is the player's name passed via ``subjectLabel``).
    *
    * Distinct copy AND distinct tone (signal=self, info=impersonate)
    * so a creator scanning the rail can tell at a glance which row
@@ -128,8 +129,12 @@ export function MarkReadyButton({
     // still wins when the parent hasn't opted in (legacy call sites).
     if (!enabled && disabledLabel) return disabledLabel;
     if (variant === "impersonate") {
-      const target = trunc((subjectLabel ?? "role").toUpperCase());
-      return isReady ? `${target} READY ✓` : `MARK ${target} READY →`;
+      const target = trunc((subjectLabel ?? "this role").toUpperCase());
+      // "READY ON <NAME>'S BEHALF" (not the role-label "MARK <ROLE>
+      // READY"): the creator reads this as acting FOR another person,
+      // not toggling their own seat. Pairs with passing the player's
+      // display_name as subjectLabel from RolesPanel.
+      return isReady ? `${target} READY ✓` : `READY ON ${target}'S BEHALF →`;
     }
     return isReady ? "READY ✓" : "MARK READY →";
   })();
@@ -143,9 +148,9 @@ export function MarkReadyButton({
   // ``aria-pressed`` is only meaningful on the self variant — it
   // describes the LOCAL participant's ready state. On the
   // impersonation variant the toggle reflects another role's state,
-  // so AT announcing "MARK SOC READY, pressed" would confuse the
+  // so AT announcing "READY ON SOC'S BEHALF, pressed" would confuse the
   // creator into thinking THEY are ready. The visual+textual label
-  // ("SOC READY ✓" vs "MARK SOC READY →") already disambiguates; we
+  // ("SOC READY ✓" vs "READY ON SOC'S BEHALF →") already disambiguates; we
   // drop ``aria-pressed`` for the impersonate variant and lean on
   // the explicit label instead. QA review HIGH.
   const ariaPressed = variant === "self" ? isReady : undefined;
@@ -219,7 +224,7 @@ export function MarkReadyButton({
         }
         return isReady
           ? `Walk back ${subjectLabel ?? "this role"}'s ready signal`
-          : `Mark ${subjectLabel ?? "this role"} ready`;
+          : `Mark ready on ${subjectLabel ?? "this role"}'s behalf`;
       })()}
       title={title}
       data-tone={tone}


### PR DESCRIPTION
## Problem

Two symptoms, reported from a live exercise, with **one root cause**:

1. A Security Engineer (**John**) added mid-exercise was **addressed** by the AI — *"John — check the M365 admin portal"* — but saw **"NOT YOUR TURN"** and couldn't mark ready.
2. Conversely, on a later turn John was **not** addressed yet was still **"pending"** / blocking the turn.

**Root cause.** The server-side narrower `narrow_active_role_groups` was *one-directional*: it only ever **dropped** roles the AI yielded-to-but-didn't-address. It never **promoted** a role the AI addressed-but-didn't-yield-to. When a role joins mid-turn it isn't in the model's roster snapshot at the moment it drafts `set_active_roles`, so the model addresses the role in prose but has no `role_id` to put in the yield. (A prompt change can't fix this — the model literally lacks the id — so it's reconciled engine-side. The Prompt-Expert review confirmed leaving the prompt untouched is correct.)

## Fix

**Engine** — make the narrower **symmetric**:
- `active_roles.py`: a new **promote** pass appends any clause-start-addressed (or explicit-address-tool-target) role the AI omitted as its own singleton ASK group. New `promoted` field on `NarrowResult`; the now-unreachable `would_narrow_to_empty_kept_original` branch is removed (with `addressed` non-empty, every addressed role is kept or promoted → the active set can never be empty). Net invariant **whenever any role is addressed: active set == addressed set.**
- `turn_driver.py`: wires `promoted` into the audit log + the creator decision-log note; also logs the no-op active-set decision (`active_roles_kept_ai_yield`) so a brief-only *"why is this seat pending?"* is answerable from the logs instead of a silent fallback.

This also fixes symptom 2: John is now active in **both** the turn he's addressed in *and* the following turn — the jarring inactive→active flip is gone.

**Frontend** — the creator's "mark another player ready on their behalf" button now reads **`READY ON <NAME>'S BEHALF →`** (was `MARK <ROLE> READY →`), using the player's `display_name`, so it reads as acting *for* someone rather than toggling the creator's own seat.

## Testing

- Backend non-live suite **1050 passed**; `ruff` + `mypy --strict` clean.
- Frontend **603 passed**; `tsc -b` + `eslint` clean.
- Live narrower-integration test (`test_single_addressee_yields_narrowly_or_engine_narrows`) **passed against the real API**.
- New promotion coverage: single promote, drop+promote in one turn, roster-order determinism, any-of group preservation, explicit-tool-target promotion, silent-yield recovery, and a **false-positive guard** proving a merely-mentioned role is *not* promoted (so promotion can't re-introduce the wide-yield stall the drop pass exists to prevent).

## Reviews

All six sub-agent reviews (QA / Security / UI-UX / Product / User-persona / Prompt-Expert) passed with **zero BLOCK / CRITICAL / HIGH**. The single cross-cutting MEDIUM (no log line on the no-addressed brief path) is addressed by the `active_roles_kept_ai_yield` breadcrumb above.

## Notes & carve-outs

- **No scenario change required** — pure-function refinement to the live-engine narrower; no new `SessionState` transition / turn-pump path / input gate / `MessageKind` / tool / keyed wire field, and the deterministic replay path bypasses the narrower entirely. Covered by the unit suites.
- Audit event `active_roles_narrowed` → `active_roles_reconciled` (now covers both directions; structlog-only, not model-facing).

### Deferred follow-ups (all MEDIUM/LOW, none blocking)
- Creator-facing inline **"waiting on: &lt;roles&gt;"** indicator near the turn chip (the decision-log note currently lives at the bottom of the rail).
- A **"you're now on this turn"** cue for a player the engine just activated.
- Document the narrower (drop + promote) in `docs/turn-lifecycle.md` §8.
- The impersonate button label is longer and wraps to 2–3 lines on the narrow rail (wraps cleanly, never clips) — accepted per the chosen copy.
- Defense-in-depth: angle-bracket collapse in `sanitize_role_text` / a CSP, in case a future non-React sink ever renders role names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164nK6PHgCJuiJSoYPTGTkx

---
_Generated by [Claude Code](https://claude.ai/code/session_0164nK6PHgCJuiJSoYPTGTkx)_