### PR TITLE
backend: cost/abuse hardening — LLM concurrency cap, turn limit, setup budget (audit PR1)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -829,13 +829,25 @@ def register_api_routes(app: FastAPI) -> None:
         except AuthorizationError as exc:
             raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
 
+        # Stale tab / already-finalized setup (raced finalize / skip /
+        # start): return the consistent ``/setup/reply`` shape instead of
+        # 500ing on ``append_setup_message``'s SETUP guard below. Single
+        # response contract — ``setup_budget_exhausted`` is moot here but
+        # always present (False), matching the frontend ``SetupReplyResult``
+        # type. Copilot review on PR #253.
+        session = await manager.get_session(session_id)
+        if session.state != SessionState.SETUP:
+            return {
+                "ok": True,
+                "plan_proposed": session.plan is not None,
+                "diagnostics": [],
+                "setup_budget_exhausted": False,
+            }
+
         await manager.append_setup_message(
             session_id=session_id, speaker="creator", content=body.content
         )
         driver = TurnDriver(manager=manager)
-        session = await manager.get_session(session_id)
-        if session.state != SessionState.SETUP:
-            return {"ok": True, "state": session.state.value}
         # Snapshot the audit "high-water mark" before the LLM call so
         # we can return *only* the diagnostics emitted by THIS reply
         # (older ones from previous replies stay invisible to this

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -860,10 +860,12 @@ def register_api_routes(app: FastAPI) -> None:
             for evt in new_audit
             if evt.kind in {"tool_use_rejected", "llm_truncated"}
         ]
+        setup_budget = manager.settings().max_setup_calls_per_session
         return {
             "ok": True,
             "plan_proposed": after.plan is not None,
             "diagnostics": diagnostics,
+            "setup_budget_exhausted": after.setup_call_count >= setup_budget,
         }
 
     @router.post("/sessions/{session_id}/setup/skip")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -148,6 +148,32 @@ class Settings(BaseSettings):
         default=600.0, alias="LLM_TIMEOUT_S", gt=0.0
     )
 
+    # ---- LLM concurrency governor (cost/abuse H2) ----------------------
+    # Global ceiling on simultaneous *heavy* LLM calls (play / setup /
+    # aar) across ALL sessions against the single provider key. Without
+    # it, several concurrent sessions each driving turns + interjects +
+    # a background Opus AAR fan out into many simultaneous upstream
+    # calls — spiking spend and tripping the provider's *account-level*
+    # rate limit (collateral 429s on the operator's other usage). The
+    # guardrail tier runs in a SEPARATE lane of the same size so cheap,
+    # latency-critical input screening never queues behind a long Opus
+    # AAR (head-of-line blocking). A call that can't get a slot waits —
+    # the player keeps seeing "AI is thinking"; see
+    # ``LLM_ACQUIRE_TIMEOUT_S`` for the bound. Set 0 to disable the cap
+    # entirely (the historical unbounded behavior).
+    llm_max_concurrency: int = Field(
+        default=4, alias="LLM_MAX_CONCURRENCY", ge=0
+    )
+    # Max seconds a queued LLM call waits for a concurrency slot before
+    # giving up and surfacing a retryable ``overloaded`` upstream error
+    # (the turn ends gracefully with the existing creator banner rather
+    # than hanging the per-session lock). Sized well above a typical
+    # play call so transient bursts absorb invisibly; only a sustained
+    # overload trips it. Only consulted when ``LLM_MAX_CONCURRENCY > 0``.
+    llm_acquire_timeout_s: float = Field(
+        default=30.0, alias="LLM_ACQUIRE_TIMEOUT_S", gt=0.0
+    )
+
     # ---- Per-tier sampling tunables ------------------------------------
     # Each tier has independent ``max_tokens``, ``temperature`` and
     # ``top_p`` knobs. ``None`` means "use the SDK default".
@@ -245,6 +271,19 @@ class Settings(BaseSettings):
     # → ``finalize_setup`` in one response cycle; the cap prevents an
     # infinite loop if the model never yields. Default 4. Upper bound 20.
     max_setup_turns: int = Field(default=4, alias="MAX_SETUP_TURNS", ge=1, le=20)
+    # Per-session ceiling on the TOTAL number of setup-tier LLM calls
+    # across all ``/setup/reply`` invocations (cost/abuse M3).
+    # ``MAX_SETUP_TURNS`` caps the chained-tool loop *within one reply*;
+    # this caps how many replies a creator can drive before the plan is
+    # finalized, so a creator token (which an anonymous caller obtains
+    # for free from ``POST /sessions`` today) can't hammer
+    # ``/setup/reply`` to burn the setup tier's large (12k-token) output
+    # budget indefinitely. On exhaustion the route refuses further setup
+    # turns and prompts the operator to finalize or skip. Generous
+    # default so a real intake dialogue never hits it.
+    max_setup_calls_per_session: int = Field(
+        default=12, alias="MAX_SETUP_CALLS_PER_SESSION", ge=1
+    )
     # Hard cap on the byte length of a participant submission (player
     # message). Mirrors the per-call backend cap that previously lived as
     # a magic ``[:2000]`` slice; tunable so operators with chatty teams

--- a/backend/app/llm/clients/litellm_client.py
+++ b/backend/app/llm/clients/litellm_client.py
@@ -512,7 +512,10 @@ class LiteLLMChatClient(ChatClient):
     """LiteLLM-backed ``ChatClient``. acomplete lands in Phase 2; astream in Phase 3."""
 
     def __init__(self, *, settings: Settings) -> None:
-        super().__init__()
+        super().__init__(
+            max_concurrency=settings.llm_max_concurrency,
+            acquire_timeout_s=settings.llm_acquire_timeout_s,
+        )
         # Re-harden in case a third party imported ``litellm`` after our
         # module load and re-populated a callback list (e.g. an extension
         # that calls ``litellm.success_callback.append("langfuse")``).
@@ -808,7 +811,8 @@ class LiteLLMChatClient(ChatClient):
         )
         started = time.monotonic()
         try:
-            response = await litellm.acompletion(**kwargs)
+            async with self._concurrency_slot(tier=tier, session_id=session_id):
+                response = await litellm.acompletion(**kwargs)
         except Exception as exc:
             _logger.warning(
                 "llm_call_failed",
@@ -927,6 +931,18 @@ class LiteLLMChatClient(ChatClient):
         )
         started = time.monotonic()
 
+        # Acquire a heavy-lane concurrency slot held for the whole stream
+        # duration (cost/abuse H2). Done after ``_begin_call`` so the
+        # ``ai_thinking`` indicator covers any queue wait. Guarded so an
+        # acquire-timeout still ends the call (``sem_slot`` would be unbound
+        # in the main ``finally`` otherwise); released there once the
+        # network stream is drained.
+        try:
+            sem_slot = await self._acquire_slot(tier=tier, session_id=session_id)
+        except BaseException:
+            self._end_call(session_id, call)
+            raise
+
         chunks: list[Any] = []
         text_buffer: list[str] = []
         chunk_warn_logged = False
@@ -1034,6 +1050,8 @@ class LiteLLMChatClient(ChatClient):
                     raise classified from exc
                 raise
         finally:
+            if sem_slot is not None:
+                sem_slot.release()
             self._end_call(session_id, call)
 
         # Reconstruct the final response from the chunks. ``messages``

--- a/backend/app/llm/protocol.py
+++ b/backend/app/llm/protocol.py
@@ -36,16 +36,25 @@ import secrets
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from ..logging_setup import get_logger
+from .errors import UpstreamLLMError
 
 if TYPE_CHECKING:
     from ..config import ModelTier
     from ..ws.connection_manager import ConnectionManager
 
 _logger = get_logger("llm.protocol")
+
+# Concurrency-governor tunables (cost/abuse H2). Not env-exposed — these
+# are observability/UX thresholds, not capacity knobs (capacity is
+# ``LLM_MAX_CONCURRENCY`` / ``LLM_ACQUIRE_TIMEOUT_S``).
+_QUEUE_LOG_FLOOR_MS = 5  # below this a call effectively didn't queue
+_QUEUE_SATURATION_WARN_MS = 1000  # wait ≥ this → WARNING + creator notice
+_DEGRADED_NOTIFY_THROTTLE_S = 5.0  # min seconds between creator backend_status pings
 
 
 @dataclass
@@ -104,7 +113,12 @@ class ChatClient(ABC):
     Abstract: the four API methods every backend must supply.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_concurrency: int | None = None,
+        acquire_timeout_s: float | None = None,
+    ) -> None:
         # In-flight tracker: session_id -> list of InFlightCall (in case the
         # session manager dispatches the AAR while a guardrail call is also
         # active; rare but possible).
@@ -115,6 +129,26 @@ class ChatClient(ABC):
         # skip the WS broadcast — non-fatal (calls still track via
         # ``_in_flight`` for the polled ``/activity`` endpoint).
         self._connections: ConnectionManager | None = None
+        # Concurrency governor (cost/abuse H2). Two lanes so the cheap,
+        # latency-critical guardrail never queues behind a long Opus AAR
+        # in the heavy (play/setup/aar) lane. ``None``/0 disables the cap
+        # — the default for bare ``ChatClient`` subclasses in tests, which
+        # must not serialize on a shared semaphore. ``LiteLLMChatClient``
+        # passes the configured size. Constructed without a running loop
+        # (asyncio.Semaphore binds lazily on first await in 3.10+).
+        self._acquire_timeout_s = acquire_timeout_s
+        if max_concurrency and max_concurrency > 0:
+            self._heavy_sem: asyncio.Semaphore | None = asyncio.Semaphore(
+                max_concurrency
+            )
+            self._guardrail_sem: asyncio.Semaphore | None = asyncio.Semaphore(
+                max_concurrency
+            )
+        else:
+            self._heavy_sem = None
+            self._guardrail_sem = None
+        # Per-session throttle for the creator ``backend_status`` notice.
+        self._last_degraded_notify: dict[str, float] = {}
 
     # Lifecycle / wiring -----------------------------------------------------
 
@@ -190,6 +224,127 @@ class ChatClient(ABC):
                 call_id=call.call_id,
                 tier=call.tier,
                 active=active,
+                error=str(exc),
+            )
+
+    # Concurrency governor ---------------------------------------------------
+
+    async def _acquire_slot(
+        self, *, tier: ModelTier, session_id: str | None
+    ) -> asyncio.Semaphore | None:
+        """Acquire a global concurrency slot for one upstream call
+        (cost/abuse H2); returns the semaphore to ``release()`` when done,
+        or ``None`` when capping is disabled.
+
+        Heavy tiers (play / setup / aar) share one lane; the guardrail
+        gets its own lane of the same size so cheap, latency-critical
+        input screening never queues behind a long Opus AAR. A call that
+        finds its lane full WAITS — the ``ai_thinking`` indicator, begun
+        by the caller *before* this acquire, keeps the player informed, so
+        a brief queue looks like "AI thinking," not a stall. If no slot
+        frees within ``acquire_timeout_s`` it raises a retryable
+        ``UpstreamLLMError(overloaded)`` so the turn ends gracefully via
+        the existing creator banner rather than hanging the per-session
+        lock. No-op (returns ``None``) when the cap is disabled
+        (``LLM_MAX_CONCURRENCY=0`` or a bare test subclass).
+        """
+
+        sem = self._guardrail_sem if tier == "guardrail" else self._heavy_sem
+        if sem is None:
+            return None
+        t0 = time.monotonic()
+        try:
+            if self._acquire_timeout_s is not None:
+                await asyncio.wait_for(sem.acquire(), timeout=self._acquire_timeout_s)
+            else:
+                await sem.acquire()
+        except TimeoutError as exc:
+            waited_ms = int((time.monotonic() - t0) * 1000)
+            _logger.warning(
+                "llm_acquire_timeout",
+                tier=tier,
+                session_id=session_id,
+                waited_ms=waited_ms,
+                timeout_s=self._acquire_timeout_s,
+            )
+            raise UpstreamLLMError(
+                category="overloaded",
+                status_code=None,
+                request_id=None,
+                retry_hint_seconds=None,
+                message=(
+                    f"local LLM concurrency cap: no slot within "
+                    f"{self._acquire_timeout_s}s (tier={tier})"
+                ),
+            ) from exc
+        waited_ms = int((time.monotonic() - t0) * 1000)
+        if waited_ms > _QUEUE_LOG_FLOOR_MS:
+            _logger.debug(
+                "llm_call_queued",
+                tier=tier,
+                session_id=session_id,
+                waited_ms=waited_ms,
+            )
+            if waited_ms >= _QUEUE_SATURATION_WARN_MS:
+                _logger.warning(
+                    "llm_concurrency_saturated",
+                    tier=tier,
+                    session_id=session_id,
+                    waited_ms=waited_ms,
+                )
+                self._notify_backend_degraded(session_id)
+        return sem
+
+    @asynccontextmanager
+    async def _concurrency_slot(
+        self, *, tier: ModelTier, session_id: str | None
+    ) -> AsyncIterator[None]:
+        """Context-manager form of ``_acquire_slot`` for the non-streamed
+        path (``acomplete``). The streaming path manages the slot
+        explicitly because it can't wrap its yield-bearing loop in a
+        single ``async with`` without re-indenting the whole body.
+        """
+
+        sem = await self._acquire_slot(tier=tier, session_id=session_id)
+        try:
+            yield
+        finally:
+            if sem is not None:
+                sem.release()
+
+    def _notify_backend_degraded(self, session_id: str | None) -> None:
+        """Fire-and-forget, creator-only, throttled ``backend_status``
+        degraded notice (cost/abuse H2).
+
+        Low-information by design — no counts, no tiers, no internals:
+        just "heavy load, responses may be delayed" so the creator
+        understands the lag without leaking capacity details. Players keep
+        seeing the normal "AI is thinking" indicator. Throttled per
+        session so a sustained burst doesn't spam the creator's socket;
+        swallows + logs any failure so a flaky WS layer never breaks the
+        LLM call.
+        """
+
+        if not session_id or self._connections is None:
+            return
+        now = time.monotonic()
+        last = self._last_degraded_notify.get(session_id, 0.0)
+        if now - last < _DEGRADED_NOTIFY_THROTTLE_S:
+            return
+        self._last_degraded_notify[session_id] = now
+        event: dict[str, Any] = {
+            "type": "backend_status",
+            "status": "degraded",
+            "message": "Heavy load — responses may be delayed.",
+        }
+        try:
+            asyncio.get_running_loop().create_task(
+                self._connections.broadcast_to_creator(session_id, event)
+            )
+        except Exception as exc:
+            _logger.warning(
+                "backend_status_notify_failed",
+                session_id=session_id,
                 error=str(exc),
             )
 

--- a/backend/app/sessions/models.py
+++ b/backend/app/sessions/models.py
@@ -521,6 +521,19 @@ class Session(BaseModel):
     # and tests can flip it manually.
     ai_paused: bool = False
 
+    # Cost/abuse C2: set True when the session reaches
+    # ``MAX_TURNS_PER_SESSION``. Once set, the play loop stops opening /
+    # driving new turns (the unbounded play-tier-LLM-cost path) and the
+    # UI prompts the creator to end the session → AAR. Not an auto-end —
+    # the creator still clicks "End"; a session that hit the cap stays
+    # capped.
+    turn_limit_reached: bool = False
+    # Cost/abuse M3: running count of setup-tier LLM calls made across
+    # all ``/setup/reply`` invocations for this session. Capped at
+    # ``MAX_SETUP_CALLS_PER_SESSION``; once reached, ``run_setup_turn``
+    # stops calling the model and the creator must finalize or skip.
+    setup_call_count: int = 0
+
     aar_markdown: str | None = None
     aar_status: AARStatus = "pending"
     aar_error: str | None = None

--- a/backend/app/sessions/models.py
+++ b/backend/app/sessions/models.py
@@ -528,6 +528,12 @@ class Session(BaseModel):
     # the creator still clicks "End"; a session that hit the cap stays
     # capped.
     turn_limit_reached: bool = False
+    # Cost/abuse C2 (soft warning): set True the first time a freshly-
+    # opened turn's index crosses ``AI_TURN_SOFT_WARN_PCT`` of
+    # ``MAX_TURNS_PER_SESSION``. Gates the one-time
+    # ``turn_limit_approaching`` WS nudge so the creator + players get a
+    # single "start wrapping up" notice rather than one per turn.
+    turn_limit_warned: bool = False
     # Cost/abuse M3: running count of setup-tier LLM calls made across
     # all ``/setup/reply`` invocations for this session. Capped at
     # ``MAX_SETUP_CALLS_PER_SESSION``; once reached, ``run_setup_turn``

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -23,6 +23,7 @@ directive factories in ``turn_validator.py``.
 
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime
 from typing import Any
 
@@ -926,6 +927,22 @@ class TurnDriver:
                 f"got {session.state.value!r}"
             )
 
+        # Cost/abuse C2: once the session has parked at
+        # ``MAX_TURNS_PER_SESSION`` (``_park_turn_limit_reached`` flipped
+        # the flag), refuse the interject's play-tier ``astream`` call.
+        # Without this an ``@facilitator``-ing player could drive
+        # unbounded play-tier spend past the cap — the entry guard in
+        # ``run_play_turn`` only covers the advancing turn, not the
+        # side-channel. A general per-turn interject rate cap is a
+        # separate concern; this gate is *only* the turn-limit park.
+        if session.turn_limit_reached:
+            _logger.info(
+                "interject_skipped_turn_limit_reached",
+                session_id=session.id,
+                turn_index=turn.index,
+            )
+            return session
+
         from ..llm.prompts import INTERJECT_NOTE
 
         dispatcher = self._manager.dispatcher()
@@ -1544,6 +1561,7 @@ class TurnDriver:
                     "progress_pct": compute_progress_pct(session),
                 },
             )
+            await self._maybe_warn_turn_limit(session, new_turn.index)
         else:
             # No yielding tool fired AND no end_session — the turn engine
             # stays in AI_PROCESSING. Intentional: the run_play_turn caller
@@ -1552,6 +1570,44 @@ class TurnDriver:
             # without a flicker) or mark the turn errored if both attempts
             # have been exhausted.
             await self._manager._repo.save(session)
+
+    async def _maybe_warn_turn_limit(
+        self, session: Session, new_index: int
+    ) -> None:
+        """Cost/abuse C2 (soft warning): fire a one-time
+        ``turn_limit_approaching`` nudge when a freshly-opened turn first
+        crosses ``AI_TURN_SOFT_WARN_PCT`` of the cap.
+
+        Idempotent via ``session.turn_limit_warned`` — only the first
+        crossing broadcasts; later turns up to the hard cap stay quiet so
+        the creator + players see a single "start wrapping up" notice.
+        """
+
+        if session.turn_limit_warned:
+            return
+        settings = self._manager.settings()
+        max_turns = settings.max_turns_per_session
+        threshold = math.ceil(max_turns * settings.ai_turn_soft_warn_pct / 100)
+        if new_index < threshold:
+            return
+        session.turn_limit_warned = True
+        turns_remaining = max_turns - new_index
+        _logger.info(
+            "turn_limit_approaching",
+            session_id=session.id,
+            new_index=new_index,
+            turns_remaining=turns_remaining,
+            max_turns=max_turns,
+        )
+        await self._manager._repo.save(session)
+        await self._manager.connections().broadcast(
+            session.id,
+            {
+                "type": "turn_limit_approaching",
+                "turns_remaining": turns_remaining,
+                "max_turns": max_turns,
+            },
+        )
 
     async def _park_turn_limit_reached(
         self, session: Session, turn: Turn

--- a/backend/app/sessions/turn_driver.py
+++ b/backend/app/sessions/turn_driver.py
@@ -272,7 +272,23 @@ class TurnDriver:
             # ``MAX_SETUP_TURNS``. Lifting it lets a model that wants to
             # ``ask_setup_question`` → ``propose_scenario_plan`` →
             # ``finalize_setup`` in one cycle do so without a premature break.
+            setup_budget = self._manager.settings().max_setup_calls_per_session
             for _ in range(self._manager.settings().max_setup_turns):
+                if session.setup_call_count >= setup_budget:
+                    # Cost/abuse M3: per-session setup-call budget spent.
+                    # Stop making setup-tier calls; the route surfaces
+                    # ``setup_budget_exhausted`` so the creator UI prompts
+                    # "finalize the draft or skip setup". ``MAX_SETUP_TURNS``
+                    # caps the chained loop within one reply; this caps the
+                    # number of replies.
+                    _logger.warning(
+                        "setup_call_budget_reached",
+                        session_id=session.id,
+                        count=session.setup_call_count,
+                        budget=setup_budget,
+                    )
+                    break
+                session.setup_call_count += 1
                 messages = _setup_messages(session)
                 # Setup uses ``astream`` (not ``acomplete``) specifically
                 # so the ``tool_use_start`` event can fire as soon as the
@@ -412,6 +428,22 @@ class TurnDriver:
         """
 
         assert_state("play", session.state)
+
+        # Cost/abuse C2: never make a play-tier LLM call for a turn at or
+        # beyond ``MAX_TURNS_PER_SESSION``. The advance-point guard in
+        # ``_apply_play_outcome`` normally prevents such a turn from
+        # opening at all; this entry guard catches force-advance /
+        # recovery openers that created one directly. Park (no auto-end)
+        # and prompt the creator to end → AAR.
+        max_turns = self._manager.settings().max_turns_per_session
+        if turn.index >= max_turns:
+            _logger.info(
+                "turn_limit_reached_block_play_call",
+                session_id=session.id,
+                turn_index=turn.index,
+                max_turns=max_turns,
+            )
+            return await self._park_turn_limit_reached(session, turn)
 
         dispatcher = self._manager.dispatcher()
         registry = self._manager.registry()
@@ -1466,6 +1498,19 @@ class TurnDriver:
             turn.status = "complete"
             turn.ended_at = _now()
             new_index = len(session.turns)
+            if new_index >= self._manager.settings().max_turns_per_session:
+                # Cost/abuse C2: opening this turn would exceed the cap.
+                # The AI's just-delivered response stands; park instead of
+                # opening a new turn (the unbounded play-LLM-cost path) and
+                # prompt the creator to end → AAR. No auto-end.
+                _logger.info(
+                    "turn_limit_reached_skip_open",
+                    session_id=session.id,
+                    new_index=new_index,
+                    max_turns=self._manager.settings().max_turns_per_session,
+                )
+                await self._park_turn_limit_reached(session, turn)
+                return
             new_turn = Turn(
                 index=new_index,
                 active_role_groups=final_active_role_groups,
@@ -1507,6 +1552,57 @@ class TurnDriver:
             # without a flicker) or mark the turn errored if both attempts
             # have been exhausted.
             await self._manager._repo.save(session)
+
+    async def _park_turn_limit_reached(
+        self, session: Session, turn: Turn
+    ) -> Session:
+        """Cost/abuse C2: the session reached ``MAX_TURNS_PER_SESSION``.
+
+        Stop driving play turns (the unbounded play-tier-LLM-cost path)
+        without auto-ending: complete the current turn, open no new turn,
+        flag the session, and prompt the creator to end → AAR. Idempotent
+        — a repeat call re-broadcasts the nudge but appends no duplicate
+        SYSTEM line and makes no LLM call.
+        """
+
+        max_turns = self._manager.settings().max_turns_per_session
+        if turn.status != "complete":
+            turn.status = "complete"
+            turn.ended_at = _now()
+        already = session.turn_limit_reached
+        session.turn_limit_reached = True
+        # Park in AWAITING_PLAYERS with no fresh turn — players have
+        # nothing to answer; the only forward action is the creator
+        # ending the session. (The advance / force-advance paths likewise
+        # set state directly rather than via assert_transition.)
+        if session.state == SessionState.AI_PROCESSING:
+            session.state = SessionState.AWAITING_PLAYERS
+        if not already:
+            session.messages.append(
+                Message(
+                    kind=MessageKind.SYSTEM,
+                    body=(
+                        f"Turn limit reached ({max_turns} turns). End the "
+                        "session to generate the after-action report."
+                    ),
+                    turn_id=turn.id,
+                )
+            )
+        await self._manager._repo.save(session)
+        await self._manager.connections().broadcast(
+            session.id,
+            {"type": "turn_limit_reached", "max_turns": max_turns},
+        )
+        await self._manager.connections().broadcast(
+            session.id,
+            {
+                "type": "state_changed",
+                "state": session.state.value,
+                "turn_index": turn.index,
+                "progress_pct": compute_progress_pct(session),
+            },
+        )
+        return session
 
     async def _apply_cost(self, session_id: str, result: LLMResult) -> None:
         await self._manager.add_cost(

--- a/backend/app/ws/connection_manager.py
+++ b/backend/app/ws/connection_manager.py
@@ -114,6 +114,28 @@ class ConnectionManager:
         for conn in recipients:
             await self._enqueue(conn, event)
 
+    async def broadcast_to_creator(
+        self, session_id: str, event: dict[str, Any]
+    ) -> None:
+        """Fan out an event to the creator's connection(s) only.
+
+        Used for creator-scoped operational signals — currently the
+        ``backend_status`` degraded notice the LLM concurrency governor
+        emits when calls start queuing (cost/abuse H2). Never recorded in
+        the replay buffer: it's an ephemeral live-load signal, stale the
+        moment the burst clears, and the client self-expires the chip.
+        No-ops silently when the creator has no open tab. Targets by the
+        connection's ``is_creator`` flag so callers (e.g. the LLM client)
+        don't need the creator's ``role_id``.
+        """
+
+        async with self._lock:
+            recipients = [
+                c for c in self._connections.get(session_id, ()) if c.is_creator
+            ]
+        for conn in recipients:
+            await self._enqueue(conn, event)
+
     async def disconnect_role(
         self,
         session_id: str,

--- a/backend/scenarios/turn_limit_stop_2role.json
+++ b/backend/scenarios/turn_limit_stop_2role.json
@@ -1,0 +1,84 @@
+{
+  "meta": {
+    "name": "Turn-limit stop — 2 role",
+    "description": "Cost/abuse C2 regression scenario. A CISO + SOC Analyst exercise that keeps trading turns until MAX_TURNS_PER_SESSION is reached. At the cap the engine PARKS (no auto-end): it makes no further play-tier LLM call, opens no new turn, sets session.turn_limit_reached=True, appends a SYSTEM 'Turn limit reached' line, broadcasts a turn_limit_reached WS event, and lands in AWAITING_PLAYERS so the creator must click End -> AAR. Runs in engine mode so run_play_turn / _apply_play_outcome (where the entry + advance-point guards live) actually execute. The companion test (backend/tests/scenarios/test_turn_limit_scenario.py) sets a low MAX_TURNS_PER_SESSION and asserts the park. Deterministic mode cannot express this park because the deterministic runner injects recorded AI messages and opens turns directly, bypassing the guarded engine paths (see CLAUDE.md 'Known fragility seams #1 - lifecycle order').",
+    "tags": [
+      "regression",
+      "2role",
+      "cost-abuse",
+      "turn-limit",
+      "C2"
+    ]
+  },
+  "scenario_prompt": "Ransomware via vendor portal — finance laptops impacted at 03:14 Wed. Long-running exercise used to verify the turn-limit park.",
+  "creator_label": "CISO",
+  "creator_display_name": "Alex (CISO)",
+  "skip_setup": true,
+  "replay_mode": "engine",
+  "roster": [
+    {
+      "label": "SOC Analyst",
+      "display_name": "Bo (SOC)",
+      "kind": "player"
+    }
+  ],
+  "setup_replies": [],
+  "play_turns": [
+    {
+      "submissions": [
+        {
+          "role_label": "CISO",
+          "content": "Isolate the affected laptops via Defender. Pull IR Lead in. Start the regulator-notification clock.",
+          "ready_after": true
+        },
+        {
+          "role_label": "SOC Analyst",
+          "content": "Acknowledged — disabling the vendor account and pulling the Defender event timeline now.",
+          "ready_after": true
+        }
+      ],
+      "active_role_label_groups": [
+        ["CISO"],
+        ["SOC Analyst"]
+      ]
+    },
+    {
+      "submissions": [
+        {
+          "role_label": "CISO",
+          "content": "Stage a Comms draft for legal review. Notify the board chair via the secure channel.",
+          "ready_after": true
+        },
+        {
+          "role_label": "SOC Analyst",
+          "content": "Initial scope: 3 finance laptops behind the vendor portal. No lateral movement seen yet.",
+          "ready_after": true
+        }
+      ],
+      "active_role_label_groups": [
+        ["CISO"],
+        ["SOC Analyst"]
+      ]
+    },
+    {
+      "submissions": [
+        {
+          "role_label": "CISO",
+          "content": "Containment verified. Move to recovery planning. Document the timeline for the AAR.",
+          "ready_after": true
+        },
+        {
+          "role_label": "SOC Analyst",
+          "content": "Recovery plan: re-image laptops from clean backups, rotate VPN creds, audit vendor-portal access logs.",
+          "ready_after": true
+        }
+      ],
+      "active_role_label_groups": [
+        ["CISO"],
+        ["SOC Analyst"]
+      ]
+    }
+  ],
+  "end_reason": "turn-limit stop regression",
+  "mock_llm_script": null
+}

--- a/backend/tests/scenarios/test_turn_limit_scenario.py
+++ b/backend/tests/scenarios/test_turn_limit_scenario.py
@@ -1,0 +1,170 @@
+"""Scenario coverage for the cost/abuse C2 turn-limit PARK (lifecycle
+rule: a new turn-pump path MUST add/update a scenario in
+``backend/scenarios/``).
+
+The shipped ``turn_limit_stop_2role.json`` documents a long-running
+2-role exercise that should hit ``MAX_TURNS_PER_SESSION`` and PARK. This
+test loads + validates that file, then drives it to the cap and asserts
+the engine-side park: no further play call, no new turn, the flag, the
+SYSTEM line, and the ``turn_limit_reached`` WS event.
+
+Why we drive turns directly through the manager / TurnDriver rather than
+``ScenarioRunner.run()``: the park is an *engine-side* behavior that only
+fires inside ``run_play_turn`` / ``_apply_play_outcome`` (the guarded
+paths). Deterministic replay can't express it (the deterministic runner
+injects recorded AI messages and opens turns directly, bypassing those
+guards — CLAUDE.md "Known fragility seams #1"). Engine-mode
+``ScenarioRunner`` *does* call ``run_play_turn``, but the repo's
+mock-LLM play scripts don't reliably keep both roles active across many
+turns (documented at ``test_discussion_then_ready_scenario_runs``), so
+we open each turn explicitly with both roles — the same pragmatic shape
+that test uses — and let the real guards trip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.devtools.runner import ScenarioRunner
+from app.devtools.scenario import Scenario
+from app.sessions.models import MessageKind, SessionState, Turn
+from app.sessions.turn_driver import TurnDriver
+from tests.mock_chat_client import (
+    install_mock_chat_client,
+    llm_result,
+    text_block,
+    tool_block,
+)
+
+_SCENARIO_PATH = (
+    Path(__file__).resolve().parents[2] / "scenarios" / "turn_limit_stop_2role.json"
+)
+
+
+def test_turn_limit_scenario_file_is_valid_and_engine_mode() -> None:
+    """The shipped JSON must be valid Pydantic and declare engine mode
+    (deterministic mode can't exercise the engine-side park)."""
+
+    scenario = Scenario.model_validate(json.loads(_SCENARIO_PATH.read_text()))
+    assert scenario.replay_mode == "engine"
+    assert scenario.skip_setup is True
+    # More scripted play turns than the cap the test imposes, so the
+    # park is reached before the script is exhausted.
+    assert len(scenario.play_turns) >= 3
+    # Every turn the runner would OPEN must carry role-groups.
+    for turn in scenario.play_turns:
+        assert turn.active_role_label_groups, "each turn needs role-groups"
+
+
+def _always_yield_play_script(*role_ids: str, n: int = 12) -> list:
+    """``n`` play responses that each broadcast + re-yield (never end),
+    so the play loop would run forever absent the turn cap."""
+
+    out = []
+    for i in range(n):
+        active = role_ids[i % len(role_ids)]
+        out.append(
+            llm_result(
+                text_block(f"Beat {i}: continue the exercise."),
+                tool_block("broadcast", {"message": f"Update {i}"}),
+                tool_block("set_active_roles", {"role_groups": [[active]]}),
+                stop_reason="tool_use",
+            )
+        )
+    return out
+
+
+@pytest.mark.asyncio
+async def test_turn_limit_scenario_parks_at_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Low cap so the scripted 3-turn exercise trips the park before
+    # exhausting its turns. Cap=2 → turns 0,1 run; opening turn 2 parks.
+    # IMPORTANT: the env override must land BEFORE the app (and its
+    # SessionManager, which captures ``Settings`` at construction) is
+    # built — so we build a fresh app here rather than using the shared
+    # ``client`` fixture, whose manager already snapshotted the default
+    # cap of 40.
+    from app.main import create_app
+
+    monkeypatch.setenv("MAX_TURNS_PER_SESSION", "2")
+    monkeypatch.setenv("LLM_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("LLM_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("LLM_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("LLM_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    reset_settings_cache()
+
+    scenario = Scenario.model_validate(json.loads(_SCENARIO_PATH.read_text()))
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        assert client.app.state.manager.settings().max_turns_per_session == 2
+        await _drive_scenario_to_cap(client, scenario)
+
+
+async def _drive_scenario_to_cap(client: TestClient, scenario: Scenario) -> None:
+    manager = client.app.state.manager
+    runner = ScenarioRunner(manager, scenario)
+    await runner.create_session()
+    sid = runner.progress.session_id
+    assert sid is not None
+    creator_id = runner.role_label_to_id["creator"]
+    soc_id = runner.role_label_to_id["SOC Analyst"]
+
+    # Install a play script that always re-yields, then walk turns.
+    mock = install_mock_chat_client(
+        client, scripts={"play": _always_yield_play_script(creator_id, soc_id)}
+    )
+    await runner._skip_setup()
+    await manager.start_session(session_id=sid)
+
+    async def _open_turn(index: int) -> Turn:
+        session = await manager.get_session(sid)
+        turn = Turn(
+            index=index,
+            active_role_groups=[[creator_id], [soc_id]],
+            status="awaiting",
+        )
+        session.turns.append(turn)
+        session.state = SessionState.AWAITING_PLAYERS
+        await manager._repo.save(session)
+        return turn
+
+    # Drive turn 0 (under the cap) through the real engine path so the
+    # play call fires and the outcome applies normally.
+    turn0 = await _open_turn(0)
+    session = await manager.get_session(sid)
+    session.state = SessionState.AI_PROCESSING
+    await TurnDriver(manager=manager).run_play_turn(session=session, turn=turn0)
+
+    play_calls_before_cap = sum(1 for c in mock.calls if c["tier"] == "play")
+    assert play_calls_before_cap >= 1, "turn under the cap should call the model"
+
+    # Now drive a turn AT the cap (index == MAX_TURNS_PER_SESSION). The
+    # entry guard must park without a play call.
+    over_cap = await _open_turn(2)
+    session = await manager.get_session(sid)
+    session.state = SessionState.AI_PROCESSING
+    result = await TurnDriver(manager=manager).run_play_turn(
+        session=session, turn=over_cap
+    )
+
+    play_calls_after_cap = sum(1 for c in mock.calls if c["tier"] == "play")
+
+    # No additional play-tier LLM call for the at-cap turn.
+    assert play_calls_after_cap == play_calls_before_cap
+    # Parked, not ended.
+    assert result.turn_limit_reached is True
+    assert result.state == SessionState.AWAITING_PLAYERS
+    # SYSTEM "turn limit reached" line present (the cap is 2).
+    sys_msgs = [m for m in result.messages if m.kind == MessageKind.SYSTEM]
+    assert any("Turn limit reached (2 turns)" in m.body for m in sys_msgs)
+    # No new turn was opened past the at-cap turn.
+    assert result.turns[-1] is over_cap

--- a/backend/tests/test_connection_manager_broadcast_creator.py
+++ b/backend/tests/test_connection_manager_broadcast_creator.py
@@ -1,0 +1,84 @@
+"""``ConnectionManager.broadcast_to_creator`` — creator-only fan-out.
+
+Added for cost/abuse H2: the LLM concurrency governor's degraded
+``backend_status`` notice goes to the creator's tab(s) only, targeted by
+the connection's ``is_creator`` flag (so the caller needs no role_id).
+Non-creator connections must never receive it, and it must NOT enter the
+replay buffer (it's an ephemeral live-load signal).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.ws.connection_manager import ConnectionManager
+
+
+def _drain(conn) -> list[dict]:
+    out: list[dict] = []
+    while True:
+        try:
+            out.append(conn.queue.get_nowait())
+        except asyncio.QueueEmpty:
+            return out
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_creator_only_creator_connections_receive() -> None:
+    cm = ConnectionManager()
+    creator = await cm.register(session_id="s1", role_id="r-creator", is_creator=True)
+    player = await cm.register(session_id="s1", role_id="r-player", is_creator=False)
+
+    event = {"type": "backend_status", "status": "degraded", "message": "Heavy load"}
+    await cm.broadcast_to_creator("s1", event)
+
+    assert _drain(creator) == [event]
+    assert _drain(player) == [], "non-creator must not receive creator-only event"
+
+    await cm.unregister(creator)
+    await cm.unregister(player)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_creator_reaches_all_creator_tabs() -> None:
+    """A creator with two open tabs gets the notice on both."""
+
+    cm = ConnectionManager()
+    tab_a = await cm.register(session_id="s1", role_id="r-creator", is_creator=True)
+    tab_b = await cm.register(session_id="s1", role_id="r-creator", is_creator=True)
+
+    event = {"type": "backend_status", "status": "degraded"}
+    await cm.broadcast_to_creator("s1", event)
+
+    assert _drain(tab_a) == [event]
+    assert _drain(tab_b) == [event]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_creator_noop_when_no_creator_tab() -> None:
+    """No open creator tab → silent no-op (player queue stays empty)."""
+
+    cm = ConnectionManager()
+    player = await cm.register(session_id="s1", role_id="r-player", is_creator=False)
+    await cm.broadcast_to_creator("s1", {"type": "backend_status"})
+    assert _drain(player) == []
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_creator_is_not_recorded_in_replay() -> None:
+    """The notice is ephemeral: a creator tab that connects AFTER the
+    burst must not be handed a stale degraded notice from the replay
+    buffer."""
+
+    cm = ConnectionManager()
+    early = await cm.register(session_id="s1", role_id="r-creator", is_creator=True)
+    await cm.broadcast_to_creator("s1", {"type": "backend_status", "status": "degraded"})
+    # The early tab saw it live.
+    assert _drain(early)
+
+    # A late-joining creator tab replays the buffer on register; the
+    # ephemeral notice must NOT be there.
+    late = await cm.register(session_id="s1", role_id="r-creator", is_creator=True)
+    assert _drain(late) == [], "creator-only notice must not be replayed"

--- a/backend/tests/test_llm_concurrency_governor.py
+++ b/backend/tests/test_llm_concurrency_governor.py
@@ -1,0 +1,243 @@
+"""Cost/abuse H2 — global LLM concurrency governor.
+
+``ChatClient.__init__(max_concurrency, acquire_timeout_s)`` builds two
+independent ``asyncio.Semaphore`` lanes — a heavy lane shared by the
+play / setup / aar tiers and a separate guardrail lane, each of size
+``max_concurrency`` (both ``None`` when the cap is 0/None).
+``_acquire_slot`` acquires the right lane, returns the semaphore (or
+``None``), and on timeout raises ``UpstreamLLMError(category="overloaded")``.
+``_notify_backend_degraded`` fans a creator-only, per-session-throttled
+``backend_status`` notice via ``ConnectionManager.broadcast_to_creator``.
+
+These tests run against a *minimal* concrete ``ChatClient`` subclass —
+no litellm, no real provider. The four abstractmethods are implemented
+trivially because the governor lives entirely in the base class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from app.config import ModelTier
+from app.llm.errors import UpstreamLLMError
+from app.llm.protocol import ChatClient, LLMResult
+
+
+class _MinimalChatClient(ChatClient):
+    """Smallest legal ``ChatClient`` — exercises only the base-class
+    concurrency governor. The four abstractmethods are stubbed; the
+    governor (``_acquire_slot`` / ``_concurrency_slot`` /
+    ``_notify_backend_degraded``) is inherited unchanged."""
+
+    def model_for(self, tier: ModelTier) -> str:
+        return f"minimal-{tier}"
+
+    async def aclose(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    async def acomplete(self, **kwargs: Any) -> LLMResult:  # pragma: no cover
+        raise NotImplementedError
+
+    def astream(self, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_serializes_at_concurrency_one() -> None:
+    """With ``max_concurrency=1`` the second heavy acquire BLOCKS until
+    the first releases — the whole point of the cap."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=None)
+
+    sem1 = await client._acquire_slot(tier="play", session_id="s1")
+    assert sem1 is not None
+
+    # A second heavy acquire (setup shares the heavy lane) must not
+    # complete while the only permit is held.
+    second = asyncio.ensure_future(
+        client._acquire_slot(tier="setup", session_id="s1")
+    )
+    await asyncio.sleep(0.02)
+    assert not second.done(), "second heavy acquire should block on a full lane"
+
+    # Releasing the first permit lets the queued acquire through.
+    sem1.release()
+    sem2 = await asyncio.wait_for(second, timeout=1.0)
+    assert sem2 is not None
+    sem2.release()
+
+
+@pytest.mark.asyncio
+async def test_guardrail_uses_a_separate_lane() -> None:
+    """A saturated heavy lane must NOT block a guardrail acquire and
+    vice-versa — the two lanes are independent."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=None)
+
+    # Saturate the heavy lane.
+    heavy = await client._acquire_slot(tier="play", session_id="s1")
+    assert heavy is not None
+
+    # Guardrail acquires immediately despite the heavy lane being full.
+    guard = await asyncio.wait_for(
+        client._acquire_slot(tier="guardrail", session_id="s1"), timeout=1.0
+    )
+    assert guard is not None
+
+    # Now saturate the guardrail lane and confirm the heavy lane is
+    # still independently reachable once we free the heavy permit.
+    heavy.release()
+    heavy2 = await asyncio.wait_for(
+        client._acquire_slot(tier="aar", session_id="s1"), timeout=1.0
+    )
+    assert heavy2 is not None
+    # The single guardrail permit is still held, so a 2nd guardrail
+    # acquire blocks — proving the guardrail lane is its own size-1 lane.
+    second_guard = asyncio.ensure_future(
+        client._acquire_slot(tier="guardrail", session_id="s1")
+    )
+    await asyncio.sleep(0.02)
+    assert not second_guard.done()
+
+    guard.release()
+    sg = await asyncio.wait_for(second_guard, timeout=1.0)
+    assert sg is not None
+    sg.release()
+    heavy2.release()
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_max_concurrency_zero() -> None:
+    """``max_concurrency=0`` disables capping entirely: both lanes are
+    ``None``, ``_acquire_slot`` returns ``None`` and never blocks even
+    when called many times without releasing."""
+
+    client = _MinimalChatClient(max_concurrency=0, acquire_timeout_s=0.01)
+    assert client._heavy_sem is None
+    assert client._guardrail_sem is None
+
+    for _ in range(5):
+        slot = await asyncio.wait_for(
+            client._acquire_slot(tier="play", session_id="s1"), timeout=1.0
+        )
+        assert slot is None
+    # Guardrail tier is equally uncapped.
+    assert await client._acquire_slot(tier="guardrail", session_id="s1") is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_timeout_raises_overloaded() -> None:
+    """Holding the only permit and racing a tiny ``acquire_timeout_s``
+    surfaces a retryable ``UpstreamLLMError(category="overloaded")`` so
+    the turn ends gracefully instead of hanging the per-session lock."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=0.05)
+    held = await client._acquire_slot(tier="play", session_id="s1")
+    assert held is not None
+    try:
+        with pytest.raises(UpstreamLLMError) as ei:
+            await client._acquire_slot(tier="play", session_id="s1")
+        assert ei.value.category == "overloaded"
+    finally:
+        held.release()
+
+
+@pytest.mark.asyncio
+async def test_concurrency_slot_cm_releases_on_exit() -> None:
+    """``_concurrency_slot`` is the async-CM wrapper for the non-streamed
+    path: it acquires on enter and releases on exit so the next caller
+    can proceed."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=0.2)
+
+    async with client._concurrency_slot(tier="play", session_id="s1"):
+        # Lane is saturated inside the block — a bare acquire times out.
+        with pytest.raises(UpstreamLLMError):
+            await client._acquire_slot(tier="play", session_id="s1")
+
+    # After the CM exits the permit is back; acquire succeeds.
+    slot = await asyncio.wait_for(
+        client._acquire_slot(tier="play", session_id="s1"), timeout=1.0
+    )
+    assert slot is not None
+    slot.release()
+
+
+@pytest.mark.asyncio
+async def test_concurrency_slot_disabled_is_noop_cm() -> None:
+    """When capping is disabled the CM is a no-op and never blocks."""
+
+    client = _MinimalChatClient(max_concurrency=0, acquire_timeout_s=0.01)
+    async with client._concurrency_slot(tier="play", session_id="s1"):
+        # Re-entering while "inside" must not block — no lane exists.
+        async with client._concurrency_slot(tier="play", session_id="s1"):
+            pass
+
+
+class _FakeConnections:
+    """Captures ``broadcast_to_creator`` calls. ``_notify_backend_degraded``
+    only ever uses this one method (creator-only fan-out)."""
+
+    def __init__(self) -> None:
+        self.creator_events: list[tuple[str, dict[str, Any]]] = []
+
+    async def broadcast_to_creator(
+        self, session_id: str, event: dict[str, Any]
+    ) -> None:
+        self.creator_events.append((session_id, event))
+
+
+@pytest.mark.asyncio
+async def test_notify_backend_degraded_targets_creator() -> None:
+    """``_notify_backend_degraded`` fans a degraded ``backend_status``
+    notice to the creator only (via ``broadcast_to_creator``)."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=None)
+    fake = _FakeConnections()
+    client.set_connections(fake)  # type: ignore[arg-type]
+
+    client._notify_backend_degraded("s1")
+    # Fire-and-forget: let the scheduled task run.
+    await asyncio.sleep(0)
+
+    assert len(fake.creator_events) == 1
+    sid, event = fake.creator_events[0]
+    assert sid == "s1"
+    assert event["type"] == "backend_status"
+    assert event["status"] == "degraded"
+    # Low-information by design — no counts/tiers/internals leaked.
+    assert set(event) == {"type", "status", "message"}
+
+
+@pytest.mark.asyncio
+async def test_notify_backend_degraded_throttled_per_session() -> None:
+    """A burst of notices for the same session collapses to ONE within
+    the throttle window; a different session is unaffected."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=None)
+    fake = _FakeConnections()
+    client.set_connections(fake)  # type: ignore[arg-type]
+
+    for _ in range(4):
+        client._notify_backend_degraded("s1")
+    client._notify_backend_degraded("s2")
+    await asyncio.sleep(0)
+
+    by_session = [sid for sid, _ in fake.creator_events]
+    assert by_session.count("s1") == 1, "s1 burst should throttle to one notice"
+    assert by_session.count("s2") == 1, "distinct session has its own throttle"
+
+
+@pytest.mark.asyncio
+async def test_notify_backend_degraded_noop_without_connections() -> None:
+    """No wired connection manager → silent no-op (never raises)."""
+
+    client = _MinimalChatClient(max_concurrency=1, acquire_timeout_s=None)
+    # No set_connections() call.
+    client._notify_backend_degraded("s1")
+    client._notify_backend_degraded(None)
+    await asyncio.sleep(0)  # nothing scheduled; must not raise

--- a/backend/tests/test_setup_call_budget.py
+++ b/backend/tests/test_setup_call_budget.py
@@ -187,3 +187,34 @@ def test_setup_reply_not_exhausted_with_headroom(monkeypatch) -> None:
         assert body["setup_budget_exhausted"] is False
     finally:
         client.__exit__(None, None, None)
+
+
+def test_setup_reply_short_circuit_has_consistent_shape(monkeypatch) -> None:
+    """When setup is already finished (state != SETUP), ``/setup/reply``
+    short-circuits but still returns the SAME shape as the normal path —
+    ``setup_budget_exhausted`` is always present (False) so the frontend
+    ``SetupReplyResult`` contract holds on both branches. Copilot review
+    on PR #253."""
+
+    client = _make_client(monkeypatch, budget=12)
+    try:
+        ses = _create_session(client)
+        sid, token = ses["sid"], ses["token"]
+
+        # Leave SETUP via the skip shortcut (no LLM call) → state != SETUP.
+        client.post(f"/api/sessions/{sid}/setup/skip?token={token}")
+        snap = client.get(f"/api/sessions/{sid}?token={token}").json()
+        assert snap["state"] != "SETUP"
+
+        body = client.post(
+            f"/api/sessions/{sid}/setup/reply?token={token}",
+            json={"content": "late reply after setup finished"},
+        ).json()
+        # Single consistent contract: the field the frontend type requires
+        # is present even on the short-circuit branch.
+        assert body["ok"] is True
+        assert body["setup_budget_exhausted"] is False
+        assert "plan_proposed" in body
+        assert "diagnostics" in body
+    finally:
+        client.__exit__(None, None, None)

--- a/backend/tests/test_setup_call_budget.py
+++ b/backend/tests/test_setup_call_budget.py
@@ -1,0 +1,189 @@
+"""Cost/abuse M3 — per-session setup-call budget.
+
+``Session.setup_call_count`` increments once per setup-tier model call.
+Once it reaches ``MAX_SETUP_CALLS_PER_SESSION`` ``run_setup_turn`` stops
+calling the model entirely, and ``POST /setup/reply`` returns
+``setup_budget_exhausted: true``. This stops a creator token from
+hammering ``/setup/reply`` to burn the setup tier's large output budget.
+
+The initial setup turn fires synchronously inside ``POST /api/sessions``
+(unless skipped), so creating a non-skipped session already burns one
+setup call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.main import create_app
+from app.sessions.models import Session, SessionState
+from app.sessions.turn_driver import TurnDriver
+from tests.conftest import default_settings_body
+from tests.mock_chat_client import (
+    install_mock_chat_client,
+    llm_result,
+    text_block,
+    tool_block,
+)
+
+
+def _setup_script(n: int) -> list[Any]:
+    """``n`` setup-tier responses, each an ``ask_setup_question`` (a
+    yielding setup tool, so ``run_setup_turn`` returns after one call)."""
+
+    return [
+        llm_result(
+            text_block("Tell me more."),
+            tool_block(
+                "ask_setup_question",
+                {"topic": "scope", "question": f"Q{i}?"},
+            ),
+            stop_reason="tool_use",
+        )
+        for i in range(n)
+    ]
+
+
+def _make_client(monkeypatch, *, budget: int) -> TestClient:
+    monkeypatch.setenv("LLM_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("LLM_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("LLM_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("LLM_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    monkeypatch.setenv("MAX_SETUP_CALLS_PER_SESSION", str(budget))
+    reset_settings_cache()
+    app = create_app()
+    c = TestClient(app)
+    c.__enter__()
+    install_mock_chat_client(c, scripts={"setup": _setup_script(10)})
+    return c
+
+
+def _create_session(client: TestClient) -> dict[str, Any]:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Ransomware via vendor portal",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+            **default_settings_body(),
+        },
+    )
+    created = resp.json()
+    return {"sid": created["session_id"], "token": created["creator_token"]}
+
+
+@pytest.mark.asyncio
+async def test_setup_call_count_increments_per_setup_call(monkeypatch) -> None:
+    """Each setup-tier model call bumps ``setup_call_count`` by exactly
+    one. With a generous budget, create (1 call) + one ``/setup/reply``
+    (1 call) leaves the count at 2. The sync TestClient calls complete
+    fully before each await, so reading the manager afterwards is safe
+    (same pattern as ``test_turn_driver`` interject test)."""
+
+    client = _make_client(monkeypatch, budget=12)
+    try:
+        ses = _create_session(client)
+        sid, token = ses["sid"], ses["token"]
+        manager = client.app.state.manager
+        mock = client.app.state.llm
+
+        # The synchronous initial setup turn burned exactly one call.
+        snap = client.get(f"/api/sessions/{sid}?token={token}").json()
+        assert snap["state"] == "SETUP"
+        s1 = await manager.get_session(sid)
+        assert s1.setup_call_count == 1
+        assert sum(1 for c in mock.calls if c["tier"] == "setup") == 1
+
+        client.post(
+            f"/api/sessions/{sid}/setup/reply?token={token}",
+            json={"content": "We're a hospital network."},
+        )
+        s2 = await manager.get_session(sid)
+        assert s2.setup_call_count == 2
+        assert sum(1 for c in mock.calls if c["tier"] == "setup") == 2
+    finally:
+        client.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_run_setup_turn_makes_no_call_once_budget_spent(monkeypatch) -> None:
+    """Once ``setup_call_count`` reaches the budget, ``run_setup_turn``
+    short-circuits and makes NO further setup-tier model call."""
+
+    client = _make_client(monkeypatch, budget=1)
+    try:
+        ses = _create_session(client)
+        sid = ses["sid"]
+        manager = client.app.state.manager
+        mock = client.app.state.llm
+
+        # Budget is 1; the create-time setup turn already spent it.
+        session = await manager.get_session(sid)
+        assert session.setup_call_count == 1
+        assert session.state == SessionState.SETUP
+
+        calls_before = sum(1 for c in mock.calls if c["tier"] == "setup")
+        await TurnDriver(manager=manager).run_setup_turn(session=session)
+        calls_after = sum(1 for c in mock.calls if c["tier"] == "setup")
+
+        assert calls_after == calls_before, "no setup call once budget spent"
+        # Count is unchanged (not incremented past the budget).
+        refreshed = await manager.get_session(sid)
+        assert refreshed.setup_call_count == 1
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_setup_reply_response_flags_budget_exhausted(monkeypatch) -> None:
+    """``POST /setup/reply`` carries ``setup_budget_exhausted: true`` the
+    moment the count reaches the budget, so the creator UI can prompt
+    "finalize or skip". With budget=2: create burns 1, the first reply
+    burns the 2nd → exhausted=true on that reply."""
+
+    client = _make_client(monkeypatch, budget=2)
+    try:
+        ses = _create_session(client)
+        sid, token = ses["sid"], ses["token"]
+
+        body = client.post(
+            f"/api/sessions/{sid}/setup/reply?token={token}",
+            json={"content": "Hospital network, EU patients."},
+        ).json()
+
+        assert body["ok"] is True
+        assert body["setup_budget_exhausted"] is True
+
+        # A subsequent reply still reports exhausted and makes no new call.
+        mock = client.app.state.llm
+        calls_before = sum(1 for c in mock.calls if c["tier"] == "setup")
+        body2 = client.post(
+            f"/api/sessions/{sid}/setup/reply?token={token}",
+            json={"content": "Anything else?"},
+        ).json()
+        calls_after = sum(1 for c in mock.calls if c["tier"] == "setup")
+        assert body2["setup_budget_exhausted"] is True
+        assert calls_after == calls_before
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_setup_reply_not_exhausted_with_headroom(monkeypatch) -> None:
+    """With ample budget the flag stays false on an early reply."""
+
+    client = _make_client(monkeypatch, budget=12)
+    try:
+        ses = _create_session(client)
+        sid, token = ses["sid"], ses["token"]
+        body = client.post(
+            f"/api/sessions/{sid}/setup/reply?token={token}",
+            json={"content": "Manufacturing, OT-heavy."},
+        ).json()
+        assert body["setup_budget_exhausted"] is False
+    finally:
+        client.__exit__(None, None, None)

--- a/backend/tests/test_setup_call_budget.py
+++ b/backend/tests/test_setup_call_budget.py
@@ -20,7 +20,7 @@ from fastapi.testclient import TestClient
 
 from app.config import reset_settings_cache
 from app.main import create_app
-from app.sessions.models import Session, SessionState
+from app.sessions.models import SessionState
 from app.sessions.turn_driver import TurnDriver
 from tests.conftest import default_settings_body
 from tests.mock_chat_client import (

--- a/backend/tests/test_turn_limit_enforcement.py
+++ b/backend/tests/test_turn_limit_enforcement.py
@@ -1,0 +1,220 @@
+"""Cost/abuse C2 — ``MAX_TURNS_PER_SESSION`` enforcement.
+
+When a play turn at/over the cap would be DRIVEN or OPENED:
+  * NO play-tier LLM call is made,
+  * no new turn opens,
+  * ``session.turn_limit_reached`` flips True,
+  * a ``turn_limit_reached`` WS event + a SYSTEM message are emitted,
+  * state lands in AWAITING_PLAYERS (no auto-end).
+Repeat ``_park_turn_limit_reached`` calls are idempotent — they
+re-broadcast the nudge but append no duplicate SYSTEM line.
+
+The entry guard lives in ``run_play_turn`` (turn.index >= cap) and the
+advance-point guard in ``_apply_play_outcome`` (would-open index >= cap);
+both funnel through ``_park_turn_limit_reached``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.main import create_app
+from app.sessions.models import Message, MessageKind, Session, SessionState, Turn
+from app.sessions.turn_driver import TurnDriver
+from tests.conftest import default_settings_body
+from tests.mock_chat_client import install_mock_chat_client, setup_then_play_script
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_MODEL_PLAY", "mock-play")
+    monkeypatch.setenv("LLM_MODEL_SETUP", "mock-setup")
+    monkeypatch.setenv("LLM_MODEL_AAR", "mock-aar")
+    monkeypatch.setenv("LLM_MODEL_GUARDRAIL", "mock-guardrail")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    # Low cap so the entry/advance guards trip in a short scripted run.
+    monkeypatch.setenv("MAX_TURNS_PER_SESSION", "2")
+    reset_settings_cache()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as c:
+        install_mock_chat_client(c)
+        yield c
+
+
+def _seat_two(client: TestClient) -> dict[str, Any]:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_prompt": "Ransomware via vendor portal",
+            "creator_label": "CISO",
+            "creator_display_name": "Alex",
+            **default_settings_body(),
+        },
+    )
+    created = resp.json()
+    sid = created["session_id"]
+    creator_token = created["creator_token"]
+    creator_role_id = created["creator_role_id"]
+    r = client.post(
+        f"/api/sessions/{sid}/roles?token={creator_token}",
+        json={"label": "Player_1", "display_name": "P1"},
+    )
+    other = r.json()
+    return {
+        "sid": sid,
+        "creator_token": creator_token,
+        "creator_role_id": creator_role_id,
+        "other_token": other["token"],
+        "other_role_id": other["role_id"],
+    }
+
+
+def _drive_to_play(client: TestClient, seats: dict[str, Any]) -> Any:
+    role_ids = [seats["creator_role_id"], seats["other_role_id"]]
+    scripts = setup_then_play_script(role_ids=role_ids, extension_tool="")
+    mock = install_mock_chat_client(client, scripts)
+    client.post(f"/api/sessions/{seats['sid']}/setup/skip?token={seats['creator_token']}")
+    client.post(f"/api/sessions/{seats['sid']}/start?token={seats['creator_token']}")
+    return mock
+
+
+# --------------------------------------------------------------------------
+# Direct unit tests for ``_park_turn_limit_reached`` against a stub manager.
+# --------------------------------------------------------------------------
+
+
+class _Settings:
+    def __init__(self, max_turns: int) -> None:
+        self.max_turns_per_session = max_turns
+
+
+class _RecConnections:
+    """Captures broadcasts so the test can assert the ``turn_limit_reached``
+    WS event fired."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def broadcast(
+        self, session_id: str, event: dict[str, Any], *, record: bool = True
+    ) -> None:
+        self.events.append(event)
+
+
+class _Repo:
+    def __init__(self) -> None:
+        self.saves = 0
+
+    async def save(self, session: Session) -> None:
+        self.saves += 1
+
+
+class _ParkStubManager:
+    """Minimal manager exposing only what ``_park_turn_limit_reached`` uses:
+    ``settings()``, ``connections()``, ``_repo``."""
+
+    def __init__(self, max_turns: int) -> None:
+        self._settings = _Settings(max_turns)
+        self._conns = _RecConnections()
+        self._repo = _Repo()
+
+    def settings(self) -> _Settings:
+        return self._settings
+
+    def connections(self) -> _RecConnections:
+        return self._conns
+
+
+@pytest.mark.asyncio
+async def test_park_sets_flag_emits_event_and_system_message() -> None:
+    mgr = _ParkStubManager(max_turns=2)
+    driver = TurnDriver(manager=mgr)  # type: ignore[arg-type]
+    session = Session(scenario_prompt="x")
+    session.state = SessionState.AI_PROCESSING
+    turn = Turn(index=2, active_role_groups=[])
+    session.turns.append(turn)
+
+    await driver._park_turn_limit_reached(session, turn)
+
+    # Flag set, parked in AWAITING_PLAYERS (no auto-end).
+    assert session.turn_limit_reached is True
+    assert session.state == SessionState.AWAITING_PLAYERS
+    # SYSTEM message appended once with the cap in the body.
+    sys_msgs = [m for m in session.messages if m.kind == MessageKind.SYSTEM]
+    assert len(sys_msgs) == 1
+    assert "Turn limit reached (2 turns)" in sys_msgs[0].body
+    # WS event broadcast carrying the cap.
+    limit_events = [e for e in mgr._conns.events if e.get("type") == "turn_limit_reached"]
+    assert len(limit_events) == 1
+    assert limit_events[0]["max_turns"] == 2
+    # A state_changed broadcast accompanies the park.
+    assert any(e.get("type") == "state_changed" for e in mgr._conns.events)
+
+
+@pytest.mark.asyncio
+async def test_park_is_idempotent_no_duplicate_system_line() -> None:
+    mgr = _ParkStubManager(max_turns=2)
+    driver = TurnDriver(manager=mgr)  # type: ignore[arg-type]
+    session = Session(scenario_prompt="x")
+    session.state = SessionState.AI_PROCESSING
+    turn = Turn(index=2, active_role_groups=[])
+    session.turns.append(turn)
+
+    await driver._park_turn_limit_reached(session, turn)
+    await driver._park_turn_limit_reached(session, turn)
+
+    # Exactly one SYSTEM line despite two park calls.
+    sys_msgs = [m for m in session.messages if m.kind == MessageKind.SYSTEM]
+    assert len(sys_msgs) == 1
+    # The nudge re-broadcasts though (so a late client still learns).
+    limit_events = [e for e in mgr._conns.events if e.get("type") == "turn_limit_reached"]
+    assert len(limit_events) == 2
+
+
+# --------------------------------------------------------------------------
+# Integration: ``run_play_turn`` entry guard makes NO play LLM call when the
+# turn is already at/over the cap.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_play_turn_entry_guard_makes_no_llm_call_at_cap(
+    client: TestClient,
+) -> None:
+    seats = _seat_two(client)
+    mock = _drive_to_play(client, seats)
+    sid = seats["sid"]
+
+    manager = client.app.state.manager
+    session = await manager.get_session(sid)
+    # Cap is 2 (MAX_TURNS_PER_SESSION). Inject an over-cap turn directly
+    # and drive it — simulates a force-advance/recovery opener that created
+    # a turn past the cap. The entry guard must park, not call the model.
+    over_cap_turn = Turn(index=2, active_role_groups=[[seats["other_role_id"]]])
+    session.turns.append(over_cap_turn)
+    session.state = SessionState.AI_PROCESSING
+
+    play_calls_before = sum(1 for c in mock.calls if c["tier"] == "play")
+    result = await TurnDriver(manager=manager).run_play_turn(
+        session=session, turn=over_cap_turn
+    )
+    play_calls_after = sum(1 for c in mock.calls if c["tier"] == "play")
+
+    # No new play-tier LLM call.
+    assert play_calls_after == play_calls_before
+    # Parked: flag set, AWAITING_PLAYERS, SYSTEM line present, no new turn.
+    assert result.turn_limit_reached is True
+    assert result.state == SessionState.AWAITING_PLAYERS
+    assert any(m.kind == MessageKind.SYSTEM for m in result.messages)
+    # The over-cap turn was NOT followed by a freshly-opened turn.
+    assert result.turns[-1] is over_cap_turn

--- a/backend/tests/test_turn_limit_enforcement.py
+++ b/backend/tests/test_turn_limit_enforcement.py
@@ -23,7 +23,7 @@ from fastapi.testclient import TestClient
 
 from app.config import reset_settings_cache
 from app.main import create_app
-from app.sessions.models import Message, MessageKind, Session, SessionState, Turn
+from app.sessions.models import MessageKind, Session, SessionState, Turn
 from app.sessions.turn_driver import TurnDriver
 from tests.conftest import default_settings_body
 from tests.mock_chat_client import install_mock_chat_client, setup_then_play_script

--- a/backend/tests/test_turn_limit_enforcement.py
+++ b/backend/tests/test_turn_limit_enforcement.py
@@ -26,7 +26,12 @@ from app.main import create_app
 from app.sessions.models import MessageKind, Session, SessionState, Turn
 from app.sessions.turn_driver import TurnDriver
 from tests.conftest import default_settings_body
-from tests.mock_chat_client import install_mock_chat_client, setup_then_play_script
+from tests.mock_chat_client import (
+    install_mock_chat_client,
+    llm_result,
+    setup_then_play_script,
+    tool_block,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -218,3 +223,150 @@ async def test_run_play_turn_entry_guard_makes_no_llm_call_at_cap(
     assert any(m.kind == MessageKind.SYSTEM for m in result.messages)
     # The over-cap turn was NOT followed by a freshly-opened turn.
     assert result.turns[-1] is over_cap_turn
+
+
+# --------------------------------------------------------------------------
+# Integration: ``run_interject`` honours the park — an ``@facilitator``-ing
+# player can't drive unbounded play-tier calls past the cap.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_interject_makes_no_llm_call_after_park(
+    client: TestClient,
+) -> None:
+    seats = _seat_two(client)
+    mock = _drive_to_play(client, seats)
+    sid = seats["sid"]
+
+    manager = client.app.state.manager
+    session = await manager.get_session(sid)
+    # Simulate the session having parked at the cap. The interject path
+    # makes a full play-tier ``astream`` call with NO advance-point guard
+    # of its own; the only thing standing between a repeat-``@facilitator``
+    # griefer and unbounded play spend is the ``turn_limit_reached`` gate.
+    session.state = SessionState.AWAITING_PLAYERS
+    session.turn_limit_reached = True
+    turn = session.current_turn
+    assert turn is not None
+
+    play_calls_before = sum(1 for c in mock.calls if c["tier"] == "play")
+    result = await TurnDriver(manager=manager).run_interject(
+        session=session, turn=turn, for_role_id=seats["other_role_id"]
+    )
+    play_calls_after = sum(1 for c in mock.calls if c["tier"] == "play")
+
+    # ZERO play-tier LLM calls — the guard returned before any astream.
+    assert play_calls_after == play_calls_before
+    assert result is session
+
+
+# --------------------------------------------------------------------------
+# Integration: the advance-point guard in ``_apply_play_outcome`` parks when
+# the (cap-1)th yielding turn would open a turn at the cap — exercising the
+# guard via the real drive path, not just the entry guard.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advance_guard_parks_when_opening_turn_at_cap(
+    client: TestClient,
+) -> None:
+    seats = _seat_two(client)
+    mock = _drive_to_play(client, seats)
+    sid = seats["sid"]
+
+    manager = client.app.state.manager
+    session = await manager.get_session(sid)
+    # After ``/start`` the session sits at turn index 1 (cap is 2) in
+    # AWAITING_PLAYERS. Drive that turn through a YIELDING play script:
+    # the AI yields with ``set_active_roles``, so ``_apply_play_outcome``
+    # reaches its advance point with ``new_index == 2 == cap`` and must
+    # PARK instead of opening turn 2 (the unbounded-cost path).
+    turn = session.current_turn
+    assert turn is not None
+    assert turn.index == 1
+
+    install_mock_chat_client(
+        client,
+        {
+            "play": [
+                llm_result(
+                    tool_block("broadcast", {"message": "Status check."}),
+                    tool_block(
+                        "set_active_roles",
+                        {"role_groups": [[seats["other_role_id"]]]},
+                    ),
+                    stop_reason="tool_use",
+                )
+            ]
+        },
+    )
+    mock = client.app.state.llm
+    session.state = SessionState.AI_PROCESSING
+
+    play_calls_before = sum(1 for c in mock.calls if c["tier"] == "play")
+    result = await TurnDriver(manager=manager).run_play_turn(
+        session=session, turn=turn
+    )
+    play_calls_after = sum(1 for c in mock.calls if c["tier"] == "play")
+
+    # Exactly one play call (this turn's drive); the parked advance opened
+    # NO further turn, so no second call.
+    assert play_calls_after == play_calls_before + 1
+    # Parked at the advance point: flag set, AWAITING_PLAYERS, no turn at
+    # index 2 ever opened.
+    assert result.turn_limit_reached is True
+    assert result.state == SessionState.AWAITING_PLAYERS
+    assert all(t.index < 2 for t in result.turns)
+
+
+# --------------------------------------------------------------------------
+# Soft warning: ``turn_limit_approaching`` fires exactly once when a freshly-
+# opened turn first crosses ``AI_TURN_SOFT_WARN_PCT`` of the cap.
+# --------------------------------------------------------------------------
+
+
+class _WarnConnections(_RecConnections):
+    """Adds ``send_to_role`` so the full ``_apply_play_outcome`` advance
+    path (which broadcasts a creator-only decision log) doesn't blow up."""
+
+    async def send_to_role(
+        self, session_id: str, role_id: str, event: dict[str, Any]
+    ) -> None:  # pragma: no cover - not asserted on
+        pass
+
+
+@pytest.mark.asyncio
+async def test_soft_warn_fires_once_when_crossing_threshold() -> None:
+    # Cap 10, warn at 80% → threshold turn index 8. Opening turn 8 fires
+    # the nudge; opening turn 9 must NOT re-fire (idempotent via the flag).
+    mgr = _ParkStubManager(max_turns=10)
+    mgr._conns = _WarnConnections()  # type: ignore[assignment]
+    mgr._settings.ai_turn_soft_warn_pct = 80  # type: ignore[attr-defined]
+    driver = TurnDriver(manager=mgr)  # type: ignore[arg-type]
+    session = Session(scenario_prompt="x")
+
+    # Below threshold (index 7): no event.
+    await driver._maybe_warn_turn_limit(session, 7)
+    assert session.turn_limit_warned is False
+    assert not [
+        e for e in mgr._conns.events if e.get("type") == "turn_limit_approaching"
+    ]
+
+    # First crossing (index 8): one event with turns_remaining = 10 - 8.
+    await driver._maybe_warn_turn_limit(session, 8)
+    assert session.turn_limit_warned is True
+    warn_events = [
+        e for e in mgr._conns.events if e.get("type") == "turn_limit_approaching"
+    ]
+    assert len(warn_events) == 1
+    assert warn_events[0]["turns_remaining"] == 2
+    assert warn_events[0]["max_turns"] == 10
+
+    # Next opened turn (index 9): flag already set → no second event.
+    await driver._maybe_warn_turn_limit(session, 9)
+    warn_events = [
+        e for e in mgr._conns.events if e.get("type") == "turn_limit_approaching"
+    ]
+    assert len(warn_events) == 1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,8 @@ rationale for each default lives in `backend/app/config.py`
 
 | Var | Default | Effect |
 |---|---|---|
+| `LLM_MAX_CONCURRENCY` | `4` | Max simultaneous heavy LLM calls (play / setup / aar) against the key (cost/abuse H2). The guardrail tier runs in a **separate lane of the same size**, so the effective max in-flight ≈ 2×N. Set `0` to disable the cap. |
+| `LLM_ACQUIRE_TIMEOUT_S` | `30` | Max seconds a queued call waits for a concurrency slot before surfacing a retryable "overloaded" error. Only consulted when `LLM_MAX_CONCURRENCY > 0`. |
 | `LLM_STRICT_RETRY_MAX` | `2` | Per-turn recovery budget shared across all turn-validator violations (`missing_drive` + `missing_yield`). Default 2 covers the worst case (turn missing both) — drive recovery + yield recovery each consume one slot. Lift to `3+` for flakier models; set to `0` to disable recovery entirely (turns errored on first invalid response). |
 | `LLM_RECOVERY_DRIVE_REQUIRED` | `true` | When true, every yielding play turn must include a `broadcast` or `address_role`; missing-DRIVE spawns a recovery LLM call narrowed to `broadcast`. Set false to revert to the pre-validator "yield-only" rule (emergency kill-switch). |
 | `LLM_RECOVERY_DRIVE_SOFT_ON_OPEN_QUESTION` | `false` | Legacy carve-out kill-switch. When true, missing-DRIVE is downgraded to a warning if the most-recent un-replied player message ends in `?`. The original intent was "players are mid-discussion on the AI's open ask, so the AI yielding silently is fine," but the predicate (player's trailing `?`) actually matches the *opposite* case — a player asking the AI a direct question, exactly when DRIVE is mandatory. Default flipped to `false`; the current product design also doesn't include player-to-player discussion, so the carve-out's premise doesn't apply. Retained as an emergency rollback only — do not re-enable in production without also adding direction classification. **Deep dive in [`turn-lifecycle.md`](turn-lifecycle.md).** A startup warning fires (`legacy_carve_out_enabled` log line) if the flag is enabled. |
@@ -101,8 +103,9 @@ rationale for each default lives in `backend/app/config.py`
 |---|---|---|
 | `MAX_SESSIONS` | `10` | Hard cap on concurrent in-memory sessions |
 | `MAX_ROLES_PER_SESSION` | `24` | Hard cap on roles in a single session |
-| `MAX_TURNS_PER_SESSION` | `40` | Soft warning at 80%, hard stop at limit |
-| `AI_TURN_SOFT_WARN_PCT` | `80` | Threshold for the wrap-up nudge in the system prompt |
+| `MAX_TURNS_PER_SESSION` | `40` | Hard cap on play turns (cost/abuse C2). On reaching it the session **parks** — no further play-tier LLM call is made, a one-time `turn_limit_reached` banner asks the creator to End → AAR. Not an auto-end; the creator still clicks End. |
+| `AI_TURN_SOFT_WARN_PCT` | `80` | Percent of `MAX_TURNS_PER_SESSION` at which a one-time `turn_limit_approaching` "N turns left — start wrapping up" notice fires (creator + players). Also informs the wrap-up nudge in the system prompt. |
+| `MAX_SETUP_CALLS_PER_SESSION` | `12` | Per-session ceiling on total setup-tier LLM calls across all `/setup/reply` invocations (cost/abuse M3). On exhaustion the setup route refuses further turns and prompts the operator to finalize or skip. |
 | `MAX_CRITICAL_INJECTS_PER_5_TURNS` | `1` | Rate limit on `inject_critical_event` |
 | `EXPORT_RETENTION_MIN` | `60` | Minutes to keep an ENDED session's export available (covers AAR markdown, structured AAR JSON, **and the shared notepad** — `notepad/export.md` is reachable for the same window). |
 | `WS_HEARTBEAT_S` | `20` | WebSocket heartbeat interval |

--- a/frontend/src/__tests__/BackendStatusChip.test.tsx
+++ b/frontend/src/__tests__/BackendStatusChip.test.tsx
@@ -38,6 +38,9 @@ describe("BackendStatusChip", () => {
     const chip = screen.getByTestId("backend-status-chip");
     expect(chip).toBeInTheDocument();
     expect(chip).toHaveTextContent(/Heavy load — responses may be delayed\./);
+    // Label reads "SYSTEM" (not "BACKEND" — that read like infra-down).
+    expect(chip).toHaveTextContent(/SYSTEM/);
+    expect(chip).not.toHaveTextContent(/BACKEND/);
   });
 
   it("is non-blocking — pointer events pass through the chip", () => {

--- a/frontend/src/__tests__/BackendStatusChip.test.tsx
+++ b/frontend/src/__tests__/BackendStatusChip.test.tsx
@@ -1,0 +1,89 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BackendStatusChip,
+  BACKEND_STATUS_TTL_MS,
+} from "../components/BackendStatusChip";
+
+/**
+ * Signal 1 — creator-only ``backend_status`` degraded chip.
+ *
+ * Pins the load-bearing behaviors: renders the message subtly, is
+ * non-blocking (pointer-events:none), self-expires after the TTL, and
+ * re-arms its timer on a fresh nonce even when the message repeats.
+ */
+
+describe("BackendStatusChip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("renders nothing before any event (nonce 0, null message)", () => {
+    render(<BackendStatusChip message={null} nonce={0} />);
+    expect(screen.queryByTestId("backend-status-chip")).not.toBeInTheDocument();
+  });
+
+  it("shows the message when an event arrives (nonce > 0)", () => {
+    render(
+      <BackendStatusChip
+        message="Heavy load — responses may be delayed."
+        nonce={1}
+      />,
+    );
+    const chip = screen.getByTestId("backend-status-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent(/Heavy load — responses may be delayed\./);
+  });
+
+  it("is non-blocking — pointer events pass through the chip", () => {
+    render(<BackendStatusChip message="Degraded." nonce={1} />);
+    const chip = screen.getByTestId("backend-status-chip");
+    expect(chip).toHaveStyle({ pointerEvents: "none" });
+  });
+
+  it("self-expires after the TTL", () => {
+    render(<BackendStatusChip message="Degraded." nonce={1} />);
+    expect(screen.getByTestId("backend-status-chip")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(BACKEND_STATUS_TTL_MS + 50);
+    });
+    expect(screen.queryByTestId("backend-status-chip")).not.toBeInTheDocument();
+  });
+
+  it("re-arms the auto-clear on a fresh nonce even with the same message", () => {
+    const { rerender } = render(
+      <BackendStatusChip message="Degraded." nonce={1} />,
+    );
+    // Let most of the first window elapse, then a new (identical-text)
+    // frame lands with a bumped nonce.
+    act(() => {
+      vi.advanceTimersByTime(BACKEND_STATUS_TTL_MS - 1000);
+    });
+    rerender(<BackendStatusChip message="Degraded." nonce={2} />);
+    // Past the ORIGINAL deadline — still visible because the nonce
+    // re-armed the timer.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByTestId("backend-status-chip")).toBeInTheDocument();
+    // Past the NEW deadline — now gone.
+    act(() => {
+      vi.advanceTimersByTime(BACKEND_STATUS_TTL_MS);
+    });
+    expect(screen.queryByTestId("backend-status-chip")).not.toBeInTheDocument();
+  });
+
+  it("honors a custom ttlMs override", () => {
+    render(<BackendStatusChip message="Degraded." nonce={1} ttlMs={500} />);
+    expect(screen.getByTestId("backend-status-chip")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(screen.queryByTestId("backend-status-chip")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -466,6 +466,7 @@ const baseProps = {
   wsStatus: "open" as const,
   godMode: false,
   turnIndex: null,
+  maxTurns: null,
   rationaleCount: 0,
   connectionCount: null,
   lastEventAt: null,
@@ -594,6 +595,22 @@ describe("BottomActionBar — phase CTAs (issue #62)", () => {
     expect(screen.getByText("Rationale: 7")).toBeInTheDocument();
     expect(screen.getByText("Tabs: 5")).toBeInTheDocument();
     expect(screen.getByText("Cost: $0.0234")).toBeInTheDocument();
+  });
+
+  it("shows the turn cap as 'T#N / MAX' when maxTurns is known", async () => {
+    render(
+      <BottomActionBar
+        {...baseProps}
+        phase="play"
+        playerCount={3}
+        hasFinalizedPlan={true}
+        aarStatus={null}
+        turnIndex={7}
+        maxTurns={40}
+      />,
+    );
+    // Badge reads the cap so an operator can self-pace before the park.
+    expect(screen.getByText(/T#7\s*\/\s*40/)).toBeInTheDocument();
   });
 
   it("renders dash placeholders when telemetry is null", async () => {

--- a/frontend/src/__tests__/Facilitator.looksReady.test.tsx
+++ b/frontend/src/__tests__/Facilitator.looksReady.test.tsx
@@ -154,6 +154,7 @@ describe("Facilitator — handleLooksReady doesn't auto-finalize (regression)", 
       ok: true,
       plan_proposed: true,
       diagnostics: [],
+      setup_budget_exhausted: false,
     });
     const finalizeSpy = vi.spyOn(api, "setupFinalize");
 

--- a/frontend/src/__tests__/Play.turnLimit.test.tsx
+++ b/frontend/src/__tests__/Play.turnLimit.test.tsx
@@ -1,0 +1,153 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerEvent } from "../lib/ws";
+
+/**
+ * Signal 2 (integration) — the broadcast ``turn_limit_reached`` WS event
+ * drives the informational banner on the player surface.
+ *
+ * Captures the page's ``onEvent`` callback through a WsClient mock, then
+ * fires the event and asserts the banner appears. The player (non-creator)
+ * variant must NOT show an End button.
+ */
+
+const EVENT_CALLBACKS: Array<(e: ServerEvent) => void> = [];
+
+vi.mock("../lib/ws", () => {
+  class FakeWsClient {
+    private _onStatus: (s: string) => void;
+    constructor(opts: {
+      onStatus: (s: string) => void;
+      onEvent: (e: ServerEvent) => void;
+    }) {
+      this._onStatus = opts.onStatus;
+      EVENT_CALLBACKS.push(opts.onEvent);
+    }
+    connect() {
+      this._onStatus("open");
+    }
+    send() {
+      /* noop */
+    }
+    subscribe() {
+      return () => {};
+    }
+    close() {
+      /* noop */
+    }
+  }
+  return { WsClient: FakeWsClient };
+});
+
+// SharedNotepad pulls in tiptap (DOM-fussy in jsdom). Stub it out.
+vi.mock("../components/SharedNotepad", () => ({
+  SharedNotepad: () => <div data-testid="shared-notepad-stub" />,
+}));
+
+import { api, type SessionSnapshot, DEFAULT_SESSION_FEATURES } from "../api/client";
+import { Play } from "../pages/Play";
+
+function playSnapshot(): SessionSnapshot {
+  return {
+    id: "s-test",
+    state: "AWAITING_PLAYERS",
+    created_at: "2026-06-24T00:00:00Z",
+    scenario_prompt: "Ransomware via vendor portal",
+    plan_title: "Ransomware",
+    plan_summary: "Detection at 03:14.",
+    settings: {
+      difficulty: "standard",
+      duration_minutes: 60,
+      features: { ...DEFAULT_SESSION_FEATURES },
+    },
+    plan: {
+      title: "Ransomware",
+      executive_summary: "Detection at 03:14.",
+      key_objectives: ["containment"],
+      narrative_arc: [{ beat: 1, label: "Detection", expected_actors: ["SOC"] }],
+      injects: [],
+      guardrails: [],
+      success_criteria: [],
+      out_of_scope: [],
+    },
+    roles: [
+      {
+        id: "role-soc",
+        label: "SOC",
+        display_name: "Bo",
+        kind: "player",
+        is_creator: false,
+        token_version: 1,
+      },
+      {
+        id: "role-creator",
+        label: "CISO",
+        display_name: "Alex",
+        kind: "player",
+        is_creator: true,
+        token_version: 1,
+      },
+    ],
+    current_turn: {
+      index: 0,
+      active_role_groups: [["role-soc"]],
+      active_role_ids: ["role-soc"],
+      submitted_role_ids: [],
+      status: "open",
+    },
+    messages: [],
+    setup_notes: null,
+    cost: null,
+    aar_status: null,
+    workstreams: [],
+  };
+}
+
+function socToken(): string {
+  const payload = btoa(JSON.stringify({ role_id: "role-soc" }))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  return `${payload}.sig`;
+}
+
+beforeEach(() => {
+  EVENT_CALLBACKS.length = 0;
+  window.localStorage.setItem("atf-display-name:s-test", "Bo");
+  vi.spyOn(api, "getSession").mockImplementation(async () => playSnapshot());
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+function fire(evt: ServerEvent) {
+  act(() => {
+    for (const cb of EVENT_CALLBACKS) cb(evt);
+  });
+}
+
+describe("Play — turn_limit_reached banner (player)", () => {
+  it("shows the informational banner without an End button for a player", async () => {
+    render(<Play sessionId="s-test" token={socToken()} />);
+    // Wait for the snapshot to load (the transcript header renders).
+    await waitFor(() => {
+      expect(api.getSession).toHaveBeenCalled();
+    });
+
+    // No banner before the event.
+    expect(screen.queryByTestId("turn-limit-banner")).not.toBeInTheDocument();
+
+    fire({ type: "turn_limit_reached", max_turns: 10 });
+
+    const banner = await screen.findByTestId("turn-limit-banner");
+    expect(banner).toHaveTextContent(/Turn limit reached/i);
+    expect(banner).toHaveTextContent(/10 TURNS/);
+    // Player is not the creator → no End affordance, informational copy.
+    expect(
+      screen.queryByRole("button", { name: /END SESSION/i }),
+    ).not.toBeInTheDocument();
+    expect(banner).toHaveTextContent(/Your facilitator can end the session/i);
+  });
+});

--- a/frontend/src/__tests__/SetupView.budgetExhausted.test.tsx
+++ b/frontend/src/__tests__/SetupView.budgetExhausted.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SetupView } from "../pages/Facilitator";
+import {
+  DEFAULT_SESSION_FEATURES,
+  type ScenarioPlan,
+  type SessionSnapshot,
+} from "../api/client";
+
+/**
+ * Signal 3 — setup-budget-exhausted prompt.
+ *
+ * When the ``setup/reply`` response reports the setup-turn budget is
+ * spent, SetupView surfaces a clear "finalize or skip" prompt while
+ * keeping the existing Finalize (Looks ready / Approve) and Skip
+ * affordances reachable.
+ */
+
+function fakeSnapshot(plan: ScenarioPlan | null): SessionSnapshot {
+  return {
+    id: "session_test",
+    state: "SETUP",
+    created_at: "2026-06-24T00:00:00Z",
+    scenario_prompt: "test scenario",
+    plan_title: plan?.title ?? null,
+    plan_summary: plan?.executive_summary ?? null,
+    settings: {
+      difficulty: "standard",
+      duration_minutes: 60,
+      features: { ...DEFAULT_SESSION_FEATURES },
+    },
+    plan,
+    roles: [],
+    current_turn: null,
+    messages: [],
+    setup_notes: [
+      {
+        ts: "2026-06-24T00:00:01Z",
+        speaker: "ai",
+        content: "What's your industry?",
+        topic: null,
+        options: null,
+      },
+    ],
+    cost: null,
+    workstreams: [],
+  };
+}
+
+function fakePlan(): ScenarioPlan {
+  return {
+    title: "Operation Budget Wall",
+    executive_summary: "A ransomware exercise.",
+    key_objectives: ["Identify patient zero"],
+    guardrails: ["No real exploit code"],
+    success_criteria: ["Containment documented"],
+    out_of_scope: ["Insurance"],
+    narrative_arc: [{ beat: 1, label: "Detection", expected_actors: ["IR"] }],
+    injects: [{ trigger: "T+10", type: "info", summary: "ping" }],
+  };
+}
+
+function baseProps() {
+  return {
+    setupReply: "",
+    setSetupReply: vi.fn(),
+    onSubmit: vi.fn((e: React.FormEvent) => e.preventDefault()),
+    onLooksReady: vi.fn(),
+    onApprovePlan: vi.fn(),
+    onSkipSetup: vi.fn(),
+    onPickOption: vi.fn(),
+    busy: false,
+    busyMessage: null,
+    draftingPlan: false,
+  };
+}
+
+describe("SetupView — setup budget exhausted prompt", () => {
+  it("does NOT render the prompt by default", () => {
+    render(<SetupView snapshot={fakeSnapshot(null)} {...baseProps()} />);
+    expect(
+      screen.queryByTestId("setup-budget-exhausted"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the prompt when budgetExhausted is true (no plan yet)", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        budgetExhausted
+      />,
+    );
+    const prompt = screen.getByTestId("setup-budget-exhausted");
+    expect(prompt).toBeInTheDocument();
+    expect(prompt).toHaveTextContent(/reached the setup limit/i);
+    // The two ways out are named: finalize the plan (Looks ready) or skip.
+    expect(prompt).toHaveTextContent(/Looks ready/i);
+    expect(prompt).toHaveTextContent(/skip setup/i);
+  });
+
+  it("keeps the Finalize/Skip affordances reachable (no plan)", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        budgetExhausted
+      />,
+    );
+    // LOOKS READY (drafts the plan to finalize) + SKIP SETUP are both
+    // present and not disabled (busy=false).
+    const looksReady = screen.getByRole("button", {
+      name: /LOOKS READY — PROPOSE THE PLAN/i,
+    });
+    expect(looksReady).toBeEnabled();
+    const skip = screen.getByRole("button", { name: /SKIP SETUP/i });
+    expect(skip).toBeEnabled();
+  });
+
+  it("with a plan present, the prompt points to Approve + the Approve button stays reachable", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(fakePlan())}
+        {...baseProps()}
+        budgetExhausted
+      />,
+    );
+    const prompt = screen.getByTestId("setup-budget-exhausted");
+    expect(prompt).toHaveTextContent(/approve it on the panel/i);
+    // The plan-panel Approve button is still reachable.
+    expect(
+      screen.getByRole("button", { name: /APPROVE & START LOBBY/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses role=status (a state nudge, not an error)", () => {
+    render(
+      <SetupView
+        snapshot={fakeSnapshot(null)}
+        {...baseProps()}
+        budgetExhausted
+      />,
+    );
+    const prompt = screen.getByTestId("setup-budget-exhausted");
+    expect(prompt).toHaveAttribute("role", "status");
+  });
+});

--- a/frontend/src/__tests__/TurnLimitApproachingChip.test.tsx
+++ b/frontend/src/__tests__/TurnLimitApproachingChip.test.tsx
@@ -1,0 +1,61 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TurnLimitApproachingChip,
+  TURN_LIMIT_NOTICE_TTL_MS,
+} from "../components/TurnLimitApproachingChip";
+
+/**
+ * One-time ``turn_limit_approaching`` soft-warning chip (cost/abuse C2).
+ *
+ * Pins: renders nothing before the first event, surfaces a "N turns left"
+ * notice on a fresh nonce, is non-blocking (pointer-events:none), and
+ * self-expires after the TTL.
+ */
+
+describe("TurnLimitApproachingChip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("renders nothing before any event (nonce 0)", () => {
+    render(<TurnLimitApproachingChip turnsRemaining={8} nonce={0} />);
+    expect(
+      screen.queryByTestId("turn-limit-approaching-chip"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows 'N turns left' when an event arrives (nonce > 0)", () => {
+    render(<TurnLimitApproachingChip turnsRemaining={8} nonce={1} />);
+    const chip = screen.getByTestId("turn-limit-approaching-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent(/8 TURNS LEFT/);
+    expect(chip).toHaveTextContent(/Start wrapping up/);
+    // Non-blocking: never swallows a click meant for a control beneath it.
+    expect(chip).toHaveStyle({ pointerEvents: "none" });
+  });
+
+  it("uses the singular label when one turn remains", () => {
+    render(<TurnLimitApproachingChip turnsRemaining={1} nonce={1} />);
+    const chip = screen.getByTestId("turn-limit-approaching-chip");
+    expect(chip).toHaveTextContent(/1 TURN LEFT/);
+  });
+
+  it("self-expires after the TTL", () => {
+    render(<TurnLimitApproachingChip turnsRemaining={5} nonce={1} />);
+    expect(
+      screen.getByTestId("turn-limit-approaching-chip"),
+    ).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(TURN_LIMIT_NOTICE_TTL_MS + 50);
+    });
+    expect(
+      screen.queryByTestId("turn-limit-approaching-chip"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/TurnLimitBanner.test.tsx
+++ b/frontend/src/__tests__/TurnLimitBanner.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TurnLimitBanner } from "../components/TurnLimitBanner";
+
+/**
+ * Signal 2 — broadcast ``turn_limit_reached`` banner.
+ *
+ * Both creator and player see the banner; only the creator gets the
+ * prominent END SESSION action (the creator is who can end). Pins the
+ * copy, the max-turns surfacing, and the creator-only End affordance.
+ */
+
+describe("TurnLimitBanner", () => {
+  it("renders the turn-limit headline and the configured max", () => {
+    render(<TurnLimitBanner maxTurns={12} isCreator={false} />);
+    const banner = screen.getByTestId("turn-limit-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/Turn limit reached/i);
+    expect(banner).toHaveTextContent(/12 TURNS/);
+  });
+
+  it("creator variant shows a prominent END SESSION button wired to onEnd", () => {
+    const onEnd = vi.fn();
+    render(<TurnLimitBanner maxTurns={8} isCreator onEnd={onEnd} />);
+    const endBtn = screen.getByRole("button", { name: /END SESSION/i });
+    expect(endBtn).toBeInTheDocument();
+    fireEvent.click(endBtn);
+    expect(onEnd).toHaveBeenCalledOnce();
+    // Creator copy steers them to end the session.
+    expect(screen.getByTestId("turn-limit-banner")).toHaveTextContent(
+      /End the session to generate the after-action report/i,
+    );
+  });
+
+  it("player variant has no End button and reads as informational", () => {
+    render(<TurnLimitBanner maxTurns={8} isCreator={false} />);
+    expect(
+      screen.queryByRole("button", { name: /END SESSION/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("turn-limit-banner")).toHaveTextContent(
+      /Your facilitator can end the session/i,
+    );
+  });
+
+  it("announces assertively for accessibility", () => {
+    render(<TurnLimitBanner maxTurns={8} isCreator={false} />);
+    const banner = screen.getByTestId("turn-limit-banner");
+    expect(banner).toHaveAttribute("role", "alert");
+    expect(banner).toHaveAttribute("aria-live", "assertive");
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -221,6 +221,15 @@ export interface SetupReplyResult {
   plan_proposed?: boolean;
   /** Backend-side rejections / truncations that occurred during this reply. */
   diagnostics?: BackendDiagnostic[];
+  /**
+   * True once the session has consumed its setup-turn budget — the AI
+   * won't ask further clarifying questions, so the creator must
+   * finalize the plan (or skip setup) to proceed. The setup UI surfaces
+   * a clear prompt and keeps the Finalize / Skip affordances reachable.
+   * Always present on the wire (CLAUDE.md "no back-compat optional
+   * fields"); ``false`` until the budget is exhausted.
+   */
+  setup_budget_exhausted: boolean;
 }
 
 /** One scenario entry in the dev-tools picker. Mirrors the

--- a/frontend/src/components/BackendStatusChip.tsx
+++ b/frontend/src/components/BackendStatusChip.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { StatusChip } from "./brand/StatusChip";
+
+/**
+ * Creator-only, self-expiring "degraded / heavy load" indicator.
+ *
+ * Driven by the ``backend_status`` WS event (sent creator-only — players
+ * never receive it). The signal is low-information by design: a short
+ * human-readable message, no counts. The chip is deliberately subtle
+ * (brand ``warn``-tone ``StatusChip``) and NON-blocking — it never
+ * intercepts pointer events or claims a layout slot that would push
+ * controls around — and it auto-clears a few seconds after the last
+ * event so a transient blip doesn't leave a stale banner latched on.
+ *
+ * Visibility lifecycle is owned here rather than in the page: the parent
+ * passes the latest message plus a monotonic ``nonce`` (bumped on every
+ * ``backend_status`` frame). Each new nonce (re)arms an ~8 s timer; when
+ * it fires we hide. Re-arming on the message identity alone would miss
+ * back-to-back identical messages, so the nonce is the load-bearing
+ * trigger.
+ */
+
+/** Auto-clear delay after the most recent ``backend_status`` event. */
+export const BACKEND_STATUS_TTL_MS = 8000;
+
+interface Props {
+  /** Operator-facing copy from the latest event. ``null`` = never
+   *  received one this session (renders nothing). */
+  message: string | null;
+  /** Monotonic counter bumped by the page on every ``backend_status``
+   *  frame. Re-arms the auto-clear timer even when ``message`` repeats. */
+  nonce: number;
+  /** Override for the auto-clear delay (tests). */
+  ttlMs?: number;
+}
+
+export function BackendStatusChip({ message, nonce, ttlMs }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!message || nonce <= 0) {
+      // No event yet (or the page reset). Stay hidden; nothing to arm.
+      return;
+    }
+    setVisible(true);
+    const ttl = ttlMs ?? BACKEND_STATUS_TTL_MS;
+    const id = window.setTimeout(() => {
+      setVisible(false);
+    }, ttl);
+    return () => window.clearTimeout(id);
+    // ``nonce`` is the re-arm trigger; ``message`` is read for the truthy
+    // guard but a fresh frame always bumps ``nonce`` too.
+  }, [nonce, message, ttlMs]);
+
+  if (!visible || !message) return null;
+
+  return (
+    <div
+      // ``role="status"`` + polite: it's an ambient health nudge, not an
+      // interrupt. ``pointer-events: none`` guarantees the chip can never
+      // sit over and swallow a click meant for a control beneath it.
+      role="status"
+      aria-live="polite"
+      data-testid="backend-status-chip"
+      style={{ pointerEvents: "none" }}
+    >
+      <StatusChip
+        label="● BACKEND"
+        value={message}
+        tone="warn"
+        title={message}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/BackendStatusChip.tsx
+++ b/frontend/src/components/BackendStatusChip.tsx
@@ -65,7 +65,7 @@ export function BackendStatusChip({ message, nonce, ttlMs }: Props) {
       style={{ pointerEvents: "none" }}
     >
       <StatusChip
-        label="● BACKEND"
+        label="● SYSTEM"
         value={message}
         tone="warn"
         title={message}

--- a/frontend/src/components/TurnLimitApproachingChip.tsx
+++ b/frontend/src/components/TurnLimitApproachingChip.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { StatusChip } from "./brand/StatusChip";
+
+/**
+ * One-time "N turns left — start wrapping up" soft-warning notice.
+ *
+ * Driven by the broadcast ``turn_limit_approaching`` WS event (cost/abuse
+ * C2), which the engine fires at most once per session when a freshly-
+ * opened turn first crosses ``AI_TURN_SOFT_WARN_PCT`` of the cap. Shown
+ * to BOTH creator and players so everyone knows to wrap up before the
+ * hard cap parks the exercise.
+ *
+ * Deliberately subtle and NON-blocking (``pointer-events: none``, fixed
+ * to the bottom-right, never claims a layout slot) and self-expiring —
+ * same lifecycle contract as <BackendStatusChip>: the parent passes
+ * ``turnsRemaining`` plus a monotonic ``nonce`` (bumped on every frame);
+ * each new nonce (re)arms the auto-clear timer. ``info`` tone (an
+ * expected end-of-exercise milestone, not an error). Renders nothing
+ * until the first event (``nonce <= 0``).
+ */
+
+/** Auto-clear delay after the ``turn_limit_approaching`` event. */
+export const TURN_LIMIT_NOTICE_TTL_MS = 10000;
+
+interface Props {
+  /** Turns left when the warning fired. */
+  turnsRemaining: number;
+  /** Monotonic counter bumped by the page on every event. ``<= 0`` =
+   *  never fired this session (renders nothing). */
+  nonce: number;
+  /** Override for the auto-clear delay (tests). */
+  ttlMs?: number;
+}
+
+export function TurnLimitApproachingChip({
+  turnsRemaining,
+  nonce,
+  ttlMs,
+}: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (nonce <= 0) {
+      // No event yet (or the page reset). Stay hidden; nothing to arm.
+      return;
+    }
+    setVisible(true);
+    const ttl = ttlMs ?? TURN_LIMIT_NOTICE_TTL_MS;
+    const id = window.setTimeout(() => setVisible(false), ttl);
+    return () => window.clearTimeout(id);
+  }, [nonce, ttlMs]);
+
+  if (!visible) return null;
+
+  const label =
+    turnsRemaining === 1 ? "1 TURN LEFT" : `${turnsRemaining} TURNS LEFT`;
+
+  return (
+    <div
+      // Fixed, non-blocking, lifted clear of any bottom chrome (the
+      // 48 px sticky action bar on the creator surface) and stacked
+      // above the ``bottom: 56`` <BackendStatusChip> so the two never
+      // sit on top of each other in the rare moment both are live.
+      // Self-expires.
+      role="status"
+      aria-live="polite"
+      data-testid="turn-limit-approaching-chip"
+      style={{
+        position: "fixed",
+        right: 12,
+        bottom: 92,
+        zIndex: 30,
+        pointerEvents: "none",
+      }}
+    >
+      <StatusChip
+        label={`● ${label}`}
+        value="Start wrapping up"
+        tone="info"
+        title="Approaching the turn limit — wrap up soon."
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/TurnLimitBanner.tsx
+++ b/frontend/src/components/TurnLimitBanner.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+
+interface Props {
+  /** The session's configured turn cap (from the ``turn_limit_reached``
+   *  event). Surfaced so the operator sees *why* play stopped. */
+  maxTurns: number;
+  /** True when the local participant is the session creator. The creator
+   *  is the only role that can End the session, so only they get the
+   *  prominent End affordance; players see the same banner as
+   *  informational. */
+  isCreator: boolean;
+  /** End-session handler. Wired only for the creator; ignored otherwise. */
+  onEnd?: () => void;
+}
+
+/**
+ * Broadcast banner shown to every participant when the session hits its
+ * configured turn cap. The exercise can't advance further — the creator
+ * must End the session to generate the after-action report.
+ *
+ * Reuses the ``CriticalEventBanner`` chrome (sticky top, mono eyebrow,
+ * brand tokens) but in the ``info`` tone rather than ``crit``: a turn-cap
+ * is an expected end-of-exercise milestone, not an in-fiction emergency
+ * inject. Operator voice per ``design/handoff/BRAND.md`` — states the
+ * fact and the next action, no marketing softening.
+ *
+ * For the creator the primary affordance is END SESSION (focused on
+ * mount so a keyboard / screen-reader user lands on the action). Players
+ * get a one-line "your facilitator will wrap up" note instead.
+ */
+export function TurnLimitBanner({ maxTurns, isCreator, onEnd }: Props) {
+  const endRef = useRef<HTMLButtonElement | null>(null);
+
+  // Pull focus to the End button (creator only) so the recovery action
+  // is immediately reachable without tabbing through the page.
+  useEffect(() => {
+    if (isCreator) endRef.current?.focus();
+  }, [isCreator]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="turn-limit-banner"
+      className="sticky top-0 z-20 border-b-4 border-info bg-info-bg p-4 text-ink-050 backdrop-blur-sm"
+      style={{ background: "color-mix(in oklch, var(--info) 24%, var(--ink-900))" }}
+    >
+      <div className="mx-auto flex max-w-5xl items-start justify-between gap-4">
+        <div>
+          <p className="mono text-[11px] font-bold uppercase tracking-[0.22em] text-info">
+            ● TURN LIMIT · {maxTurns} TURNS
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-ink-050">
+            Turn limit reached.
+          </h2>
+          <p className="text-sm text-ink-100 opacity-90">
+            {isCreator
+              ? "End the session to generate the after-action report."
+              : "Your facilitator can end the session to generate the after-action report."}
+          </p>
+        </div>
+        {isCreator ? (
+          <button
+            ref={endRef}
+            type="button"
+            onClick={onEnd}
+            className="mono shrink-0 rounded-r-1 bg-signal px-4 py-2 text-[11px] font-bold uppercase tracking-[0.18em] text-ink-900 hover:bg-signal-bright focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-bright"
+          >
+            END SESSION →
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/brand/BottomActionBar.tsx
+++ b/frontend/src/components/brand/BottomActionBar.tsx
@@ -42,6 +42,10 @@ interface Props {
   aarStatus: string | null;
   busy: boolean;
   turnIndex: number | null;
+  /** Configured ``MAX_TURNS_PER_SESSION`` (from the ``cost_updated``
+   *  frame). When set, the ``T#`` badge shows "N / MAX" so the operator
+   *  can self-pace. Null until the first cost frame lands. */
+  maxTurns: number | null;
   rationaleCount: number;
   connectionCount: number | null;
   lastEventAt: number | null;
@@ -201,6 +205,9 @@ export function BottomActionBar(props: Props) {
 
       <span className="mono rounded-r-1 bg-ink-800 px-2 py-0.5 text-[10px] tabular-nums text-ink-200">
         T#{props.turnIndex ?? "—"}
+        {props.turnIndex != null && props.maxTurns != null
+          ? ` / ${props.maxTurns}`
+          : ""}
       </span>
       <span className="mono rounded-r-1 bg-ink-800 px-2 py-0.5 text-[10px] tabular-nums text-ink-200">
         {props.messageCount} msgs

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -294,8 +294,8 @@ export type ServerEvent =
       request_id?: string | null;
       retry_hint_seconds?: number | null;
     }
-  // Creator-only health signal. Sent (via ``send_to_role``) when the
-  // engine detects degraded upstream conditions (heavy load / slow
+  // Creator-only health signal. Sent (via ``broadcast_to_creator``) when
+  // the engine detects degraded upstream conditions (heavy load / slow
   // LLM responses). Players never receive it — it implies a wait the
   // player can't act on. Low-information by design: just a category +
   // a short human-readable message. The creator UI surfaces a subtle,
@@ -316,6 +316,18 @@ export type ServerEvent =
   // late-joining / reconnecting tab still learns the cap was reached.
   | {
       type: "turn_limit_reached";
+      max_turns: number;
+    }
+  // Broadcast to EVERY participant the first time a freshly-opened turn
+  // crosses ``AI_TURN_SOFT_WARN_PCT`` of ``max_turns`` (cost/abuse C2
+  // soft warning). Fires at most ONCE per session — the engine gates it
+  // behind ``session.turn_limit_warned``. Drives a brief, non-blocking
+  // "N turns left — start wrapping up" notice so the creator can self-
+  // pace before the hard cap parks the exercise. ``record=True`` so a
+  // late-joining tab still learns the session is near its cap.
+  | {
+      type: "turn_limit_approaching";
+      turns_remaining: number;
       max_turns: number;
     };
 
@@ -579,6 +591,10 @@ export class WsClient {
             safe.message = parsed.message;
             break;
           case "turn_limit_reached":
+            safe.max_turns = parsed.max_turns;
+            break;
+          case "turn_limit_approaching":
+            safe.turns_remaining = parsed.turns_remaining;
             safe.max_turns = parsed.max_turns;
             break;
           case "guardrail_blocked":

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -293,6 +293,30 @@ export type ServerEvent =
       status_code?: number | null;
       request_id?: string | null;
       retry_hint_seconds?: number | null;
+    }
+  // Creator-only health signal. Sent (via ``send_to_role``) when the
+  // engine detects degraded upstream conditions (heavy load / slow
+  // LLM responses). Players never receive it — it implies a wait the
+  // player can't act on. Low-information by design: just a category +
+  // a short human-readable message. The creator UI surfaces a subtle,
+  // self-expiring chip (see ``BackendStatusChip``) that auto-clears a
+  // few seconds after the last one. ``record=False`` server-side — a
+  // stale "degraded" frame must not replay on reconnect and latch the
+  // chip on.
+  | {
+      type: "backend_status";
+      status: "degraded";
+      message: string;
+    }
+  // Broadcast to EVERY participant when the session hits its configured
+  // turn cap (``max_turns``). The exercise can't advance further; the
+  // creator must End the session to generate the after-action report.
+  // The creator UI makes the End action prominent; players see the
+  // same banner as informational. ``record=True`` server-side so a
+  // late-joining / reconnecting tab still learns the cap was reached.
+  | {
+      type: "turn_limit_reached";
+      max_turns: number;
     };
 
 export type ClientEvent =
@@ -546,6 +570,16 @@ export class WsClient {
               safe.request_id = parsed.request_id;
               safe.retry_hint_seconds = parsed.retry_hint_seconds;
             }
+            break;
+          case "backend_status":
+            // Creator-only health nudge. ``message`` is operator-facing
+            // copy by design (no secrets / no participant content), so
+            // it's safe to surface in the console for debuggability.
+            safe.status = parsed.status;
+            safe.message = parsed.message;
+            break;
+          case "turn_limit_reached":
+            safe.max_turns = parsed.max_turns;
             break;
           case "guardrail_blocked":
             safe.verdict = parsed.verdict;

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -15,6 +15,8 @@ import { AarReportView } from "../components/AarReport";
 import { Composer } from "../components/Composer";
 import { CriticalEventBanner } from "../components/CriticalEventBanner";
 import { UpstreamLlmErrorBanner } from "../components/UpstreamLlmErrorBanner";
+import { BackendStatusChip } from "../components/BackendStatusChip";
+import { TurnLimitBanner } from "../components/TurnLimitBanner";
 import { DecisionLogPanel } from "../components/DecisionLogPanel";
 import { ExportsPanel } from "../components/ExportsPanel";
 import { GodModePanel } from "../components/GodModePanel";
@@ -406,7 +408,29 @@ export function Facilitator() {
   }, []);
 
   const [setupReply, setSetupReply] = useState("");
+  // Creator-only ``setup/reply`` budget signal. Flipped true the moment a
+  // ``setupReply`` response reports the setup-turn budget is spent — the
+  // AI won't ask further questions, so the creator must finalize / skip.
+  // Surfaced as a prompt inside <SetupView>. Cleared when the plan is
+  // finalized (we leave the SETUP phase) — there's no recovery path that
+  // un-exhausts the budget, so it only ever latches on.
+  const [setupBudgetExhausted, setSetupBudgetExhausted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Creator-only "backend degraded / heavy load" signal (``backend_status``
+  // WS event). ``message`` is the latest operator-facing copy; ``nonce``
+  // is bumped on every frame so <BackendStatusChip> re-arms its
+  // self-clear timer even when the message repeats. Low-information by
+  // design — no counts, just the message. Players never receive the
+  // event so this state stays empty on the player path.
+  const [backendStatus, setBackendStatus] = useState<{
+    message: string | null;
+    nonce: number;
+  }>({ message: null, nonce: 0 });
+  // Broadcast ``turn_limit_reached`` cap. Non-null once the session hits
+  // its configured ``max_turns`` — drives the prominent End-session
+  // banner. ``record=True`` server-side so a reconnecting creator tab
+  // still learns the cap was reached.
+  const [turnLimitMax, setTurnLimitMax] = useState<number | null>(null);
   // Issue #191 — most recent ``{type: "error", scope: "upstream_llm"}``
   // event. Creator-only; players never receive these. Cleared by the
   // banner's Dismiss button or replaced by a fresher upstream event.
@@ -1100,6 +1124,27 @@ export function Facilitator() {
       case "cost_updated":
         setCost(evt.cost);
         break;
+      case "backend_status":
+        // Creator-only degraded-health nudge. Bump the nonce so the
+        // subtle, self-expiring chip re-arms even on a repeat message.
+        // Non-blocking and auto-clearing — see <BackendStatusChip>.
+        console.info("[facilitator] backend_status", {
+          status: evt.status,
+          message: evt.message,
+        });
+        setBackendStatus((prev) => ({
+          message: evt.message,
+          nonce: prev.nonce + 1,
+        }));
+        break;
+      case "turn_limit_reached":
+        // Broadcast cap hit. Latch the max so the End-session banner
+        // shows until the creator ends the exercise.
+        console.info("[facilitator] turn_limit_reached", {
+          max_turns: evt.max_turns,
+        });
+        setTurnLimitMax(evt.max_turns);
+        break;
       case "decision_logged":
         setDecisionLog((prev) => {
           // De-dupe defensively in case the snapshot fetch and the WS
@@ -1299,7 +1344,14 @@ export function Facilitator() {
     // small "AI is typing" dots inside <SetupChat>; the prominent
     // DieLoader banner stays parked until plan-drafting time.
     try {
-      await api.setupReply(state.sessionId, state.token, content.trim());
+      const reply = await api.setupReply(state.sessionId, state.token, content.trim());
+      // Latch the setup-budget-exhausted prompt the moment the engine
+      // reports the setup-turn budget is spent (the AI won't ask
+      // further questions; the creator must finalize / skip).
+      if (reply.setup_budget_exhausted) {
+        console.info("[facilitator] setup_budget_exhausted");
+        setSetupBudgetExhausted(true);
+      }
       await refreshSnapshot();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1362,6 +1414,10 @@ export function Facilitator() {
     console.info("[facilitator] looks_ready_clicked nudging plan");
     try {
       const reply = await api.setupReply(state.sessionId, state.token, NUDGE_PROPOSE);
+      if (reply.setup_budget_exhausted) {
+        console.info("[facilitator] setup_budget_exhausted (looks-ready path)");
+        setSetupBudgetExhausted(true);
+      }
       const snap = await api.getSession(state.sessionId, state.token);
       setSnapshot(snap);
       if (snap.plan) {
@@ -1941,6 +1997,7 @@ export function Facilitator() {
           busy={busy}
           busyMessage={busyMessage}
           draftingPlan={draftingPlan || aiDraftingPlan}
+          budgetExhausted={setupBudgetExhausted}
         />
       );
     } else if (wizardReadyForReview && snapshot.plan) {
@@ -1999,6 +2056,24 @@ export function Facilitator() {
             onAcknowledge={() => setCriticalBanner(null)}
           />
         ) : null}
+        {/* Backend-degraded chip also mounts during setup/ready — the
+            ``backend_status`` event can fire while the AI is drafting
+            the plan (setup-tier LLM calls). Same fixed, non-blocking,
+            self-expiring chip as the in-session render. */}
+        <div
+          style={{
+            position: "fixed",
+            right: 12,
+            bottom: 12,
+            zIndex: 30,
+            pointerEvents: "none",
+          }}
+        >
+          <BackendStatusChip
+            message={backendStatus.message}
+            nonce={backendStatus.nonce}
+          />
+        </div>
         <SetupWizard
           phase={phase}
           setupParts={setupParts}
@@ -2053,6 +2128,35 @@ export function Facilitator() {
           onDismiss={() => setUpstreamLlmError(null)}
         />
       ) : null}
+      {/* Turn-cap banner — broadcast to everyone; for the creator the
+          prominent affordance is END SESSION (the creator is who can
+          end). Sits below the infra/critical banners so an active
+          inject still wins the top slot. */}
+      {turnLimitMax !== null ? (
+        <TurnLimitBanner
+          maxTurns={turnLimitMax}
+          isCreator
+          onEnd={handleEnd}
+        />
+      ) : null}
+      {/* Subtle, self-expiring "backend degraded" chip — creator-only,
+          non-blocking (pointer-events:none), auto-clears ~8 s after the
+          last frame. Fixed to the bottom-right so it never reflows the
+          layout or sits over a control. Renders nothing when idle. */}
+      <div
+        style={{
+          position: "fixed",
+          right: 12,
+          bottom: 12,
+          zIndex: 30,
+          pointerEvents: "none",
+        }}
+      >
+        <BackendStatusChip
+          message={backendStatus.message}
+          nonce={backendStatus.nonce}
+        />
+      </div>
       {/* Issue #62 (round 2): consolidated top bar — debug telemetry +
           phase CTA + meta actions on a single row. See ``TopBar`` for
           layout rationale. */}
@@ -2880,6 +2984,7 @@ export function SetupView({
   busy,
   busyMessage,
   draftingPlan,
+  budgetExhausted = false,
 }: {
   snapshot: SessionSnapshot;
   setupReply: string;
@@ -2891,6 +2996,12 @@ export function SetupView({
   onPickOption: (option: string) => void;
   busy: boolean;
   busyMessage: string | null;
+  /** True once the ``setup/reply`` budget is spent — the AI won't ask
+   *  further questions. Renders a clear "finalize or skip" prompt and
+   *  keeps the Finalize / Skip affordances reachable. Defaults false so
+   *  the standalone unit-test renders (which don't pass it) stay
+   *  unaffected. */
+  budgetExhausted?: boolean;
   /** True while the AI is drafting the scenario plan — driven by
    *  EITHER (a) the operator clicking LOOKS READY → PROPOSE THE PLAN
    *  (Facilitator's local ``draftingPlan`` state) OR (b) the
@@ -3086,6 +3197,32 @@ export function SetupView({
           </>
         )}
       </p>
+
+      {/* Setup-budget-exhausted prompt (creator-only flag from the
+          ``setup/reply`` response). The AI won't ask further questions
+          once the budget is spent, so steer the creator to the two ways
+          out: finalize the plan — either approve an existing draft, or
+          click LOOKS READY to draft one — or skip setup. Both
+          affordances live in the reply form / plan panel below and stay
+          reachable; this banner just names the wall. ``role="status"``
+          (not alert) — it's a state nudge, not an error. */}
+      {budgetExhausted ? (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="setup-budget-exhausted"
+          className="flex flex-col gap-1 rounded-r-2 border border-warn bg-warn-bg p-3"
+        >
+          <p className="mono text-[11px] font-bold uppercase tracking-[0.16em] text-warn">
+            ● SETUP LIMIT REACHED
+          </p>
+          <p className="text-xs text-ink-100 leading-relaxed">
+            {hasPlan
+              ? "You've reached the setup limit — finalize the plan (approve it on the panel) or skip setup to continue."
+              : "You've reached the setup limit — finalize the plan with “Looks ready” below, or skip setup to continue."}
+          </p>
+        </div>
+      ) : null}
 
       {hasPlan ? (
         // 2-row × 2-col grid (collapses to a single column at sub-xl).

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -16,6 +16,7 @@ import { Composer } from "../components/Composer";
 import { CriticalEventBanner } from "../components/CriticalEventBanner";
 import { UpstreamLlmErrorBanner } from "../components/UpstreamLlmErrorBanner";
 import { BackendStatusChip } from "../components/BackendStatusChip";
+import { TurnLimitApproachingChip } from "../components/TurnLimitApproachingChip";
 import { TurnLimitBanner } from "../components/TurnLimitBanner";
 import { DecisionLogPanel } from "../components/DecisionLogPanel";
 import { ExportsPanel } from "../components/ExportsPanel";
@@ -431,6 +432,20 @@ export function Facilitator() {
   // banner. ``record=True`` server-side so a reconnecting creator tab
   // still learns the cap was reached.
   const [turnLimitMax, setTurnLimitMax] = useState<number | null>(null);
+  // The session's configured ``MAX_TURNS_PER_SESSION``, learned from the
+  // creator-only ``cost_updated`` frame (which carries ``max_turns``) and
+  // backstopped by the ``turn_limit_approaching`` nudge. Surfaced on the
+  // TURN chips ("TURN 7 / 40") so the operator can self-pace before the
+  // hard cap parks the exercise. Null until the first frame lands.
+  const [maxTurns, setMaxTurns] = useState<number | null>(null);
+  // One-time ``turn_limit_approaching`` soft-warning notice. ``nonce`` is
+  // bumped on each frame so the self-expiring info chip re-arms (the
+  // engine only fires this once per session, but the nonce keeps the
+  // chip pattern identical to <BackendStatusChip>). Null until fired.
+  const [turnLimitNotice, setTurnLimitNotice] = useState<{
+    turnsRemaining: number;
+    nonce: number;
+  }>({ turnsRemaining: 0, nonce: 0 });
   // Issue #191 — most recent ``{type: "error", scope: "upstream_llm"}``
   // event. Creator-only; players never receive these. Cleared by the
   // banner's Dismiss button or replaced by a fresher upstream event.
@@ -1123,6 +1138,8 @@ export function Facilitator() {
         break;
       case "cost_updated":
         setCost(evt.cost);
+        // Latch the configured cap so the TURN chips can render "N / MAX".
+        setMaxTurns(evt.max_turns);
         break;
       case "backend_status":
         // Creator-only degraded-health nudge. Bump the nonce so the
@@ -1144,6 +1161,22 @@ export function Facilitator() {
           max_turns: evt.max_turns,
         });
         setTurnLimitMax(evt.max_turns);
+        setMaxTurns(evt.max_turns);
+        break;
+      case "turn_limit_approaching":
+        // One-time soft warning (cost/abuse C2). Surface a brief,
+        // non-blocking "N turns left" notice so the creator can wrap up
+        // before the hard cap parks the exercise; also seed ``maxTurns``
+        // for the TURN chips in case no cost frame has landed yet.
+        console.info("[facilitator] turn_limit_approaching", {
+          turns_remaining: evt.turns_remaining,
+          max_turns: evt.max_turns,
+        });
+        setMaxTurns(evt.max_turns);
+        setTurnLimitNotice((prev) => ({
+          turnsRemaining: evt.turns_remaining,
+          nonce: prev.nonce + 1,
+        }));
         break;
       case "decision_logged":
         setDecisionLog((prev) => {
@@ -2059,12 +2092,13 @@ export function Facilitator() {
         {/* Backend-degraded chip also mounts during setup/ready — the
             ``backend_status`` event can fire while the AI is drafting
             the plan (setup-tier LLM calls). Same fixed, non-blocking,
-            self-expiring chip as the in-session render. */}
+            self-expiring chip as the in-session render (``bottom: 56``
+            to match — clears any bottom chrome). */}
         <div
           style={{
             position: "fixed",
             right: 12,
-            bottom: 12,
+            bottom: 56,
             zIndex: 30,
             pointerEvents: "none",
           }}
@@ -2139,15 +2173,17 @@ export function Facilitator() {
           onEnd={handleEnd}
         />
       ) : null}
-      {/* Subtle, self-expiring "backend degraded" chip — creator-only,
+      {/* Subtle, self-expiring "system degraded" chip — creator-only,
           non-blocking (pointer-events:none), auto-clears ~8 s after the
-          last frame. Fixed to the bottom-right so it never reflows the
-          layout or sits over a control. Renders nothing when idle. */}
+          last frame. Fixed to the bottom-right and lifted clear of the
+          48 px sticky <BottomActionBar> (``bottom: 56``) so it never
+          reflows the layout or sits over the action-bar counters.
+          Renders nothing when idle. */}
       <div
         style={{
           position: "fixed",
           right: 12,
-          bottom: 12,
+          bottom: 56,
           zIndex: 30,
           pointerEvents: "none",
         }}
@@ -2157,6 +2193,12 @@ export function Facilitator() {
           nonce={backendStatus.nonce}
         />
       </div>
+      {/* One-time soft warning when the session nears its turn cap —
+          owns its own fixed, non-blocking, self-expiring chrome. */}
+      <TurnLimitApproachingChip
+        turnsRemaining={turnLimitNotice.turnsRemaining}
+        nonce={turnLimitNotice.nonce}
+      />
       {/* Issue #62 (round 2): consolidated top bar — debug telemetry +
           phase CTA + meta actions on a single row. See ``TopBar`` for
           layout rationale. */}
@@ -2176,6 +2218,7 @@ export function Facilitator() {
         aarStatus={snapshot.aar_status ?? null}
         busy={busy}
         turnIndex={snapshot.current_turn?.index ?? null}
+        maxTurns={maxTurns}
         rationaleCount={decisionLog.length}
         connectionCount={connectionCount}
         lastEventAt={lastEventAt}
@@ -2677,6 +2720,7 @@ export function Facilitator() {
         aarStatus={snapshot.aar_status ?? null}
         busy={busy}
         turnIndex={snapshot.current_turn?.index ?? null}
+        maxTurns={maxTurns}
         rationaleCount={decisionLog.length}
         connectionCount={connectionCount}
         lastEventAt={lastEventAt}
@@ -2779,6 +2823,10 @@ export function TopBar(props: {
   // before the first WS frame / snapshot fetch lands.
   /** ``snapshot.current_turn?.index`` — null when no turn is active. */
   turnIndex: number | null;
+  /** Configured ``MAX_TURNS_PER_SESSION`` (from the ``cost_updated``
+   *  frame). When set, the TURN chip shows "N / MAX" so the operator can
+   *  self-pace. Null until the first cost frame lands. */
+  maxTurns: number | null;
   /** ``decisionLog.length`` — count of AI rationale entries logged. */
   rationaleCount: number;
   /** Server-pushed total open WS tabs on this session, or null if unknown. */
@@ -2869,7 +2917,11 @@ export function TopBar(props: {
         {props.turnIndex != null ? (
           <span className="mono inline-flex items-center gap-1 rounded-r-1 border border-ink-500 bg-ink-700 px-2 py-0.5 text-[11px] font-semibold uppercase">
             <span className="text-ink-300 opacity-70">TURN</span>
-            <span className="tabular-nums text-ink-100">{props.turnIndex}</span>
+            <span className="tabular-nums text-ink-100">
+              {props.maxTurns != null
+                ? `${props.turnIndex} / ${props.maxTurns}`
+                : props.turnIndex}
+            </span>
           </span>
         ) : null}
         <span className="mono inline-flex items-center gap-1 rounded-r-1 border border-ink-500 bg-ink-700 px-2 py-0.5 text-[11px] font-semibold uppercase">

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "re
 import { api, SessionSnapshot } from "../api/client";
 import { Composer } from "../components/Composer";
 import { CriticalEventBanner } from "../components/CriticalEventBanner";
+import { TurnLimitBanner } from "../components/TurnLimitBanner";
 import { HighlightActionPopover } from "../components/HighlightActionPopover";
 import { RightSidebar } from "../components/RightSidebar";
 import { RoleRoster } from "../components/RoleRoster";
@@ -72,6 +73,13 @@ export function Play({ sessionId, token }: Props) {
     headline: string;
     body: string;
   } | null>(null);
+  // Broadcast ``turn_limit_reached`` cap. Non-null once the session hits
+  // its configured ``max_turns``. Players see an informational banner;
+  // the creator (when their own tab is in the player view) gets the
+  // prominent End affordance via ``TurnLimitBanner``'s ``isCreator``
+  // branch. ``record=True`` server-side so a reconnecting tab still
+  // learns the cap was hit.
+  const [turnLimitMax, setTurnLimitMax] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Incrementing counter the Composer watches so it can restore the
   // last-attempted text on a submit-rejected error rather than letting
@@ -371,6 +379,13 @@ export function Play({ sessionId, token }: Props) {
         break;
       case "critical_event":
         setCriticalBanner({ severity: evt.severity, headline: evt.headline, body: evt.body });
+        break;
+      case "turn_limit_reached":
+        // Broadcast cap hit — surface the informational banner for
+        // players (the creator's own tab gets the prominent End
+        // affordance). Latch the max so it persists until ENDED.
+        console.info("[play] turn_limit_reached", { max_turns: evt.max_turns });
+        setTurnLimitMax(evt.max_turns);
         break;
       case "ai_pause_state_changed":
         // Wave 3 (issue #69): the creator flipped the AI-pause flag.
@@ -1449,6 +1464,18 @@ export function Play({ sessionId, token }: Props) {
         <CriticalEventBanner
           {...criticalBanner}
           onAcknowledge={() => setCriticalBanner(null)}
+        />
+      ) : null}
+      {/* Turn-cap banner — broadcast to everyone. Players see it as
+          informational; the creator (if viewing the player surface)
+          gets the prominent END SESSION affordance. Suppressed once the
+          session is ENDED (the dedicated "Exercise complete" banner
+          below takes over). */}
+      {turnLimitMax !== null && snapshot.state !== "ENDED" ? (
+        <TurnLimitBanner
+          maxTurns={turnLimitMax}
+          isCreator={isSelfCreator}
+          onEnd={handleEnd}
         />
       ) : null}
       {/*

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -3,6 +3,7 @@ import { api, SessionSnapshot } from "../api/client";
 import { Composer } from "../components/Composer";
 import { CriticalEventBanner } from "../components/CriticalEventBanner";
 import { TurnLimitBanner } from "../components/TurnLimitBanner";
+import { TurnLimitApproachingChip } from "../components/TurnLimitApproachingChip";
 import { HighlightActionPopover } from "../components/HighlightActionPopover";
 import { RightSidebar } from "../components/RightSidebar";
 import { RoleRoster } from "../components/RoleRoster";
@@ -80,6 +81,14 @@ export function Play({ sessionId, token }: Props) {
   // branch. ``record=True`` server-side so a reconnecting tab still
   // learns the cap was hit.
   const [turnLimitMax, setTurnLimitMax] = useState<number | null>(null);
+  // One-time ``turn_limit_approaching`` soft-warning notice (cost/abuse
+  // C2). Players get the same "N turns left — wrap up" nudge as the
+  // creator so they're not surprised when the cap parks the exercise.
+  // ``nonce`` re-arms the self-expiring chip; null until fired.
+  const [turnLimitNotice, setTurnLimitNotice] = useState<{
+    turnsRemaining: number;
+    nonce: number;
+  }>({ turnsRemaining: 0, nonce: 0 });
   const [error, setError] = useState<string | null>(null);
   // Incrementing counter the Composer watches so it can restore the
   // last-attempted text on a submit-rejected error rather than letting
@@ -386,6 +395,18 @@ export function Play({ sessionId, token }: Props) {
         // affordance). Latch the max so it persists until ENDED.
         console.info("[play] turn_limit_reached", { max_turns: evt.max_turns });
         setTurnLimitMax(evt.max_turns);
+        break;
+      case "turn_limit_approaching":
+        // One-time soft warning — surface the brief, non-blocking
+        // "N turns left" notice so players know to wrap up.
+        console.info("[play] turn_limit_approaching", {
+          turns_remaining: evt.turns_remaining,
+          max_turns: evt.max_turns,
+        });
+        setTurnLimitNotice((prev) => ({
+          turnsRemaining: evt.turns_remaining,
+          nonce: prev.nonce + 1,
+        }));
         break;
       case "ai_pause_state_changed":
         // Wave 3 (issue #69): the creator flipped the AI-pause flag.
@@ -1478,6 +1499,12 @@ export function Play({ sessionId, token }: Props) {
           onEnd={handleEnd}
         />
       ) : null}
+      {/* One-time soft warning when the session nears its turn cap —
+          owns its own fixed, non-blocking, self-expiring chrome. */}
+      <TurnLimitApproachingChip
+        turnsRemaining={turnLimitNotice.turnsRemaining}
+        nonce={turnLimitNotice.nonce}
+      />
       {/*
         Wave 3 (issue #69): session-wide pause banner. Visible to all
         participants for the duration of the pause so a player who


### PR DESCRIPTION
## Cost/abuse hardening — PR 1 of the pre-launch security audit

First slice of the spend-governor work from the security audit. Goal: stop an anonymous / low-privilege user from running up the operator's LLM bill, and fail gracefully under load. The app has no users in the wild yet, so there are no back-compat shims.

✅ **Ready for review.** Six sub-agent reviews complete (1 BLOCKER + 2 HIGH found and fixed); backend `mypy --strict` + `ruff` + non-live suite (1067 passed) green; frontend lint + `tsc` + 624 tests green; **all CI green including `live-tests`**.

### Engine governors

**H2 — global LLM concurrency cap.** Two-lane semaphore in the `ChatClient` base (heavy: play/setup/aar; a separate guardrail lane so cheap input-screening never queues behind a long Opus AAR), sized by `LLM_MAX_CONCURRENCY`. Queue-and-wait bounded by `LLM_ACQUIRE_TIMEOUT_S`; an acquire-timeout surfaces a retryable `UpstreamLLMError(overloaded)`. Without a global cap, concurrent sessions fan out unbounded calls on the single key and can trip the provider's **account-level** rate limit. A queued call keeps the `ai_thinking` indicator lit; on saturation we log `llm_concurrency_saturated` and push a throttled, **creator-only** `backend_status` "heavy load" notice (new `ConnectionManager.broadcast_to_creator`). Effective max in-flight ≈ 2×N (heavy + guardrail lanes).

**C2 — enforce `MAX_TURNS_PER_SESSION`.** Was display-only; one session could drive unbounded play-tier calls. Now the play loop parks at the cap (no new turn, no play call), emits `turn_limit_reached` + a SYSTEM line, and prompts the creator to end → AAR. No auto-end. The `@facilitator` interject side-channel is gated too (review fix below). A one-time `turn_limit_approaching` soft-warning fires at `AI_TURN_SOFT_WARN_PCT`, and the turn chip now shows "N / MAX".

**M3 — per-session setup-call budget (`MAX_SETUP_CALLS_PER_SESSION`).** `run_setup_turn` stops calling the model once spent; `/setup/reply` returns `setup_budget_exhausted` so the wizard prompts finalize/skip.

### New env knobs (defaults)
| Var | Default | Purpose |
|---|---|---|
| `LLM_MAX_CONCURRENCY` | 4 | max simultaneous heavy LLM calls (0 = unbounded) |
| `LLM_ACQUIRE_TIMEOUT_S` | 30 | max queue wait before surfacing `overloaded` |
| `MAX_SETUP_CALLS_PER_SESSION` | 12 | per-session setup-tier call budget |
| `MAX_TURNS_PER_SESSION` | 40 | now actually enforced (parks + prompts to end) |
| `AI_TURN_SOFT_WARN_PCT` | 80 | now wired → one-time pre-limit nudge |

All documented in `docs/configuration.md`.

### Review pass (6 agents) — resolved
- 🔴 **BLOCKER (Security)** — the `@facilitator` interject (`run_interject`) made a play-tier call with no turn-limit guard → a player could drive unbounded spend past the cap. **Fixed**: a `turn_limit_reached` gate returns before any LLM call; test added.
- 🟠 **HIGH (creator-persona)** — the turn limit arrived with no warning, and the `ai_turn_soft_warn_pct` knob was dead code. **Fixed**: wired the soft-warning + "N/MAX" turn chip.
- 🟠 **HIGH (Product)** — the new knobs were undocumented. **Fixed**: `docs/configuration.md`.
- ✅ QA / UI-UX / Prompt-Expert — no blockers (correctness, layout, and prompt-safety verified).
- Deferred (non-blocking, noted): `_last_degraded_notify` pruning; acquire-timeout `upstream_llm_error` audit-kind parity; setup-limit count display.

### Out of scope (later audit PRs)
C1 (unauthenticated session-creation gate), the general interject rate cap (audit H4), and the rate-limit / multi-code-invite work — deferred by design, not dropped.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcV5vcbww5We1C6RxuTq7Y