### PR TITLE
docs: align README + docs with multi-provider engine and current limits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ authoritative rules live there, not here.
 
 A multi-user, browser-based chat room that runs a cybersecurity tabletop
 exercise. The creator opens a session, defines roles (CISO / IR Lead /
-Legal / Comms / etc.), and shares a per-role join link. The AI drives a
-turn-based loop — narrates beats, throws injects, yields to specific
-roles via tool calls — and produces a markdown after-action report at
-session end. Typical exercise: 30–60 minutes.
+Legal / Comms / etc.), and shares a per-role join link. The AI runs the
+turn-based loop: it narrates beats, throws injects, and hands the turn to
+specific roles via tool calls. At session end it writes a markdown
+after-action report. A typical exercise runs 30–60 minutes.
 
 The session walks a phase machine:
 
@@ -58,7 +58,7 @@ load-bearing references; CONTRIBUTING.md is just the index.
 |---|---|
 | [`docs/architecture.md`](docs/architecture.md) | Touching the request/turn flow. Live diagrams, retry-feedback loop, phase-policy contract, current tool palette, operator runtime controls. |
 | [`docs/configuration.md`](docs/configuration.md) | Adding any env var or operator-tunable knob. Quick-start cheat sheet + hardening checklist. |
-| [`docs/llm_providers.md`](docs/llm_providers.md) | Wiring Bedrock / Vertex / OpenRouter / Ollama via `LLM_API_BASE`. |
+| [`docs/llm_providers.md`](docs/llm_providers.md) | Wiring Bedrock / Vertex / OpenRouter / Ollama via `LLM_MODEL_<TIER>`. |
 | [`docs/prompts.md`](docs/prompts.md) | Editing system prompts, guardrails, tool-use protocol, AAR rubric. JSON tool-use only — no XML function-call shapes. |
 | [`docs/prompt-writing-rules.md`](docs/prompt-writing-rules.md) | **Style guide for prompt copy.** Shape-not-phrase, deflection patterns, trust-boundary first. Distilled from the 2026-05-04 / 2026-05-05 live-test sweep. |
 | [`docs/tool-design.md`](docs/tool-design.md) | **Adding, renaming, or rewording any play-tier tool.** Five trap patterns documented. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ authoritative rules live there, not here.
 
 A multi-user, browser-based chat room that runs a cybersecurity tabletop
 exercise. The creator opens a session, defines roles (CISO / IR Lead /
-Legal / Comms / etc.), and shares a per-role join link. Claude drives a
+Legal / Comms / etc.), and shares a per-role join link. The AI drives a
 turn-based loop — narrates beats, throws injects, yields to specific
 roles via tool calls — and produces a markdown after-action report at
 session end. Typical exercise: 30–60 minutes.
@@ -31,7 +31,7 @@ are enforced in code.
 ## Repo layout
 
 ```
-backend/        FastAPI + Anthropic SDK; all turn / state / LLM logic
+backend/        FastAPI + LiteLLM (routes to ~100 providers); all turn / state / LLM logic
   app/api/      REST endpoints
   app/ws/       WebSocket + connection manager (chat-style fan-out)
   app/sessions/ Phase machine, turn driver, validator, slots, repository

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ itself while the room is still warm.
 > for multi-process WS fan-out). Authoritative architecture:
 > [`docs/PLAN.md`](docs/PLAN.md).
 
+## Why
+
+Small security teams can't run a tabletop on themselves. Someone has to
+be the white cell — write the scenario, throw the injects, adjudicate the
+curveballs — and on a two-person team that someone is the same person who
+most needs the practice. You can't be surprised by an inject you wrote,
+so the lead ends up running the exercise instead of being tested by it.
+
+A facilitated tabletop from an outside firm fixes that, and a good one is
+worth the money — but it's costly and it happens maybe once a year.
+That's not enough reps to build reflexes.
+
+Crittable hands the white-cell seat to the AI. It holds the scenario,
+throws the injects, and reacts to whatever the room does — so the person
+who used to run the exercise can come in blind, work the problem with the
+team, and learn from it instead of running it. It doesn't replace a
+professional facilitated tabletop; it makes the cheap, frequent reps
+possible in between.
+
 ## What it does
 
 - **Set the brief.** Scenario / team / environment / constraints in four

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 **`ROLL · RESPOND · REVIEW`**
 
 A multi-user, browser-based tabletop platform for incident response.
-Open a session, brief the AI, share per-role join links, and Claude
+Open a session, brief the AI, share per-role join links, and the AI
 runs the room while your team responds. The after-action report drafts
 itself while the room is still warm.
 
@@ -43,9 +43,9 @@ itself while the room is still warm.
 ## What it does
 
 - **Set the brief.** Scenario / team / environment / constraints in four
-  short sections. Claude proposes a plan. You approve or skip.
+  short sections. The AI proposes a plan. You approve or skip.
 - **Per-role join links.** HMAC-signed tokens. Kick-and-reissue on demand.
-- **Turn-based exercise.** Claude narrates beats, throws injects, yields
+- **Turn-based exercise.** The AI narrates beats, throws injects, yields
   to specific roles via tool calls. Typical session: 30–60 min.
 - **Critical-event banners.** Per-role typing indicators. AI auto-interject
   on direct questions.
@@ -56,8 +56,10 @@ itself while the room is still warm.
 - **Operator-tunable everything.** Per-tier model / max_tokens / temperature
   / top_p / timeout, strict-retry count, setup-turn cap, submission cap,
   poll cadences. See [`docs/configuration.md`](docs/configuration.md).
-- **Provider swap.** `LLM_API_BASE` → Bedrock / Vertex / OpenRouter
-  / local Ollama via litellm. See [`docs/llm_providers.md`](docs/llm_providers.md).
+- **Provider swap.** Point `LLM_MODEL_<TIER>` at any of ~100 providers
+  (Bedrock / Vertex / OpenRouter / local Ollama / …) via LiteLLM;
+  `LLM_API_BASE` retargets a custom endpoint. See
+  [`docs/llm_providers.md`](docs/llm_providers.md).
 
 ## Quickstart
 
@@ -134,7 +136,8 @@ the forward button (NEXT, or ROLL SESSION on the final step) is disabled
 until you trim, so you'll never get bounced by the server after the
 fact. Role labels and display names are capped at 64 characters each
 (the wizard's role inputs stop you at the limit), and a session can have
-at most 32 invited roles.
+at most 24 roles by default — the creator plus up to 23 others (raise
+`MAX_ROLES_PER_SESSION` to lift it).
 
 > Tip: name systems by product (Splunk, Defender, Okta, IRIS, PagerDuty),
 > not generic categories. The more concrete the environment, the more it
@@ -193,7 +196,7 @@ them):
   cap. Be vivid but tight — cut filler, not detail; if you're running
   long, shorten prose before dropping facts.
 - Each role label (e.g. "IR Lead", "Comms") is at most 64 characters,
-  and so is each person's display name. Propose at most 32 roles.
+  and so is each person's display name. Propose at most 24 roles total.
 - Target duration must be between 15 and 180 minutes.
 
 Now draft the brief in EXACTLY these four sections, each under a clear
@@ -251,6 +254,7 @@ is the long form.
 | `SESSION_SECRET` | randomly generated, with a startup warning | HMAC key for join tokens. Not setting this means tokens are invalidated on every restart. Use 32+ random bytes. |
 | `CORS_ORIGINS` | `*` | Comma-separated allowlist. Lock to your actual origin(s). |
 | `RATE_LIMIT_ENABLED` | `false` | Flip to `true` and tune `RATE_LIMIT_REQ_PER_MIN` (default 60). |
+| `INVITE_CODE` | _unset_ | Optional anti-strangers gate on session creation — creators must supply a matching code. Player join links are unaffected (they carry their own HMAC tokens). Pair with `RATE_LIMIT_ENABLED` on a public URL. |
 
 ### Useful day-to-day
 
@@ -294,9 +298,9 @@ boundaries are enforced in code:
 1. Every turn driver entry point asserts the session state matches the
    tier's `allowed_states`.
 2. The LLM client filters the `tools` list against the tier's
-   `allowed_tool_names` before forwarding to Anthropic.
+   `allowed_tool_names` before forwarding to the provider (via LiteLLM).
 3. The dispatcher rejects forbidden tool calls at runtime and returns a
-   proper Anthropic `tool_result` so the model can self-correct rather
+   proper `tool_result` so the model can self-correct rather
    than retry blind.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Hiring an outside firm to facilitate solves that. A good facilitated
 tabletop is worth the money, but it's expensive, and most teams manage it
 maybe once a year. That isn't often enough to get good at it.
 
-Crittable runs the exercise so we don't have to. It holds the scenario
-and throws the injects, reacting to what the team does. That frees
+Crittable runs the exercise so the whole team can take part. It holds the
+scenario and throws the injects, reacting to what the team does. That frees
 whoever usually facilitates to play instead of run the room. We come in
 blind like everyone else, work the problem together, and actually learn
 something. It won't replace a real facilitated tabletop, but it lets us

--- a/README.md
+++ b/README.md
@@ -42,22 +42,21 @@ itself while the room is still warm.
 
 ## Why
 
-Small security teams can't run a tabletop on themselves. Someone has to
-be the white cell — write the scenario, throw the injects, adjudicate the
-curveballs — and on a two-person team that someone is the same person who
-most needs the practice. You can't be surprised by an inject you wrote,
-so the lead ends up running the exercise instead of being tested by it.
+My security team is two people. That makes it hard to run a tabletop on
+ourselves: someone has to build the scenario and play the adversary, and
+on a team this small that someone is me. I write the injects, so nothing
+in the exercise surprises me, and I end up running the test instead of
+taking it.
 
-A facilitated tabletop from an outside firm fixes that, and a good one is
-worth the money — but it's costly and it happens maybe once a year.
-That's not enough reps to build reflexes.
+Hiring an outside firm to facilitate solves that. A good facilitated
+tabletop is worth the money, but it's expensive, and we do it maybe once
+a year. That isn't often enough to get good at it.
 
-Crittable hands the white-cell seat to the AI. It holds the scenario,
-throws the injects, and reacts to whatever the room does — so the person
-who used to run the exercise can come in blind, work the problem with the
-team, and learn from it instead of running it. It doesn't replace a
-professional facilitated tabletop; it makes the cheap, frequent reps
-possible in between.
+Crittable runs the exercise so I don't have to. It holds the scenario and
+throws the injects, reacting to what the team does. That lets me play
+instead of facilitate. I come in blind like everyone else, work the
+problem with the team, and actually learn something. It won't replace a
+real facilitated tabletop, but it lets us practice in the months between.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -42,21 +42,22 @@ itself while the room is still warm.
 
 ## Why
 
-My security team is two people. That makes it hard to run a tabletop on
-ourselves: someone has to build the scenario and play the adversary, and
-on a team this small that someone is me. I write the injects, so nothing
-in the exercise surprises me, and I end up running the test instead of
-taking it.
+Small security teams can't run a tabletop on themselves. Someone has to
+build the scenario and play the adversary, and that's usually one of the
+people who'd get the most out of taking part. If we wrote the injects,
+nothing in the exercise surprises us, and we end up running the test
+instead of taking it.
 
 Hiring an outside firm to facilitate solves that. A good facilitated
-tabletop is worth the money, but it's expensive, and we do it maybe once
-a year. That isn't often enough to get good at it.
+tabletop is worth the money, but it's expensive, and most teams manage it
+maybe once a year. That isn't often enough to get good at it.
 
-Crittable runs the exercise so I don't have to. It holds the scenario and
-throws the injects, reacting to what the team does. That lets me play
-instead of facilitate. I come in blind like everyone else, work the
-problem with the team, and actually learn something. It won't replace a
-real facilitated tabletop, but it lets us practice in the months between.
+Crittable runs the exercise so we don't have to. It holds the scenario
+and throws the injects, reacting to what the team does. That frees
+whoever usually facilitates to play instead of run the room. We come in
+blind like everyone else, work the problem together, and actually learn
+something. It won't replace a real facilitated tabletop, but it lets us
+practice in the months between.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,9 @@ itself while the room is still warm.
 ## Why
 
 Small security teams can't run a tabletop on themselves. Someone has to
-build the scenario and play the adversary, and that's usually one of the
-people who'd get the most out of taking part. If we wrote the injects,
-nothing in the exercise surprises us, and we end up running the test
-instead of taking it.
+build the scenario and play the adversary, and that person already knows
+every inject. So whoever would get the most out of the exercise ends up
+running the test instead of taking it.
 
 Hiring an outside firm to facilitate solves that. A good facilitated
 tabletop is worth the money, but it's expensive, and most teams manage it
@@ -54,10 +53,10 @@ maybe once a year. That isn't often enough to get good at it.
 
 Crittable runs the exercise so the whole team can take part. It holds the
 scenario and throws the injects, reacting to what the team does. That frees
-whoever usually facilitates to play instead of run the room. We come in
-blind like everyone else, work the problem together, and actually learn
-something. It won't replace a real facilitated tabletop, but it lets us
-practice in the months between.
+whoever usually facilitates to play instead of run the room. Everyone
+comes in blind, works the problem together, and actually learns something.
+It won't replace a real facilitated tabletop, but it lets a team practice
+in the months between.
 
 ## What it does
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ export at session end.
 │  sessions/   models · repository(InMemory) · turn_engine     │
 │              · phase_policy · turn_driver · manager          │
 │              (per-session asyncio.Lock)                      │
-│  llm/    ChatClient ABC + Anthropic/LiteLLM backends         │
+│  llm/    ChatClient ABC + LiteLLM backend (~100 providers)   │
 │          · dispatch · guardrail · export                     │
 │  extensions/   ToolRegistry · ResourceRegistry ·             │
 │                PromptRegistry · loaders/env                  │
@@ -41,9 +41,9 @@ export at session end.
 └────────────────────────────┬─────────────────────────────────┘
                              │
                              ▼
-                    Anthropic API (HTTPS)
-                    (or any Anthropic-compatible
-                     endpoint via LLM_API_BASE)
+                    LLM provider API (HTTPS)
+                    (Anthropic / OpenAI / Bedrock /
+                     Vertex / … routed via LiteLLM)
 ```
 
 ## Session state machine

--- a/docs/llm_providers.md
+++ b/docs/llm_providers.md
@@ -265,10 +265,9 @@ If you add a new astream call site, add a row here.
 
 ## Why this matters
 
-Operators have varying constraints — air-gapped networks, regional
-data-residency rules, vendor-diversity mandates, model-family
-preferences, existing contractual relationships. Routing every call
-through LiteLLM covers:
+Operators run under different constraints: air-gapped networks,
+data-residency rules, or an approved-vendor list that doesn't include
+Anthropic. Routing every call through LiteLLM covers:
 
 - **The 95% case**: stick with the default, point at Anthropic.
 - **The "we have an Anthropic-shaped proxy" case**: `LLM_API_BASE`.

--- a/docs/tool-design.md
+++ b/docs/tool-design.md
@@ -153,7 +153,6 @@ Before adding or rewording a tool, verify each:
 | `share_data` | DRIVE | AI text bubble with bold label + markdown body | Synthetic data dump (logs, IOCs, telemetry) **only when explicitly asked**. |
 | `pose_choice` | DRIVE | AI text bubble with question + lettered options | Multi-choice tactical decision prompt for one role. |
 | `set_active_roles` | YIELD | (no chat — engine state change) | Yield the turn. Mandatory pair with one of the player-facing tools above. |
-| `end_session` | TERMINATE | (no chat — kicks AAR) | Terminate the exercise. |
 | `inject_critical_event` | ESCALATE | Red banner (everyone) | Headline-grade escalation. MUST be followed in same turn by broadcast + set_active_roles. |
 | `request_artifact` | BOOKKEEPING | (no chat — engine state) | Ask a role for a structured deliverable. Pair with broadcast for the framing. |
 | `track_role_followup` | BOOKKEEPING | (no chat) | Open a per-role follow-up todo. |
@@ -172,6 +171,12 @@ Before adding or rewording a tool, verify each:
   (`*[T+5min — Defender auto-isolated FIN-04]*`).
 - `mark_timeline_point` — sidebar pin. Model picked it as a "do
   something quick and stop" attractor.
+- `end_session` — model-facing turn terminator. Removed in the
+  2026-05-02 cleanup (after this redesign, issue #104); ending an
+  exercise is now operator-only via the creator's `request_end_session`
+  control, so the model can't self-terminate a session mid-turn. The
+  dispatcher / turn-driver still carry the `end_session_reason` plumbing
+  for that operator path.
 
 The dispatcher handlers for these tools remain as defensive dead code
 so an extension or legacy mock script that emits them still routes
@@ -249,12 +254,11 @@ head ref via the Actions UI.
 ### Per-run dollar cap
 
 [`backend/tests/live/cost_cap.py`](../backend/tests/live/cost_cap.py)
-intercepts every `AsyncAnthropic.messages.create` AND
-`messages.stream` call during the live session, multiplies
-`usage.input_tokens` / `output_tokens` / cache tokens by the
-per-million rate from
-[`app/llm/cost.py`](../backend/app/llm/cost.py), and aborts the run
-when the cumulative spend crosses the cap. Default cap: **$2.00**
+records usage on every live LLM call — a `litellm.callbacks` handler
+covers the production (LiteLLM-routed) path, with a fallback wrapper
+around the direct-Anthropic judge client — and prices each call via
+`app.llm._shared.compute_cost_usd` (which reads `litellm.cost_per_token`),
+aborting the run when the cumulative spend crosses the cap. Default cap: **$2.00**
 (standing suite is ~$1.40, ~$0.60 / 40% headroom for new tests,
 latency variance, and one retried flake). A tighter default would
 false-trip on routine variance and push contributors toward


### PR DESCRIPTION
## What & why

The README and contributor docs predated several shipped changes. This pass verifies every factual claim against the current code (config, routes, tools, state machine) and recent commits/PRs/issues, then fixes what drifted. **Docs-only — no application code touched.**

The headline ask was provider neutrality: the engine routes every call through LiteLLM now (the Anthropic-direct backend, `LLMClient`, and `MockAnthropic` were removed in #195/#221), so user-facing copy shouldn't say the product "is Claude."

## Changes

**README.md**
- "Claude runs the room / proposes a plan / narrates beats" → "the AI …" (provider-neutral). Anthropic-as-example and "Claude" as one of *your* drafting LLMs are left intact.
- **Role cap 32 → 24.** The README claimed "32 invited roles," but the enforced default is `MAX_ROLES_PER_SESSION=24` (the manager rejects past 24; over-limit invitees become a logged partial-failure). Fixed both mentions and noted the env override.
- "Provider swap" reframed around `LLM_MODEL_<TIER>` (the actual mechanism) instead of `LLM_API_BASE` alone.
- Added the **`INVITE_CODE`** hardening var (#234) to the env shortlist.
- Phase-policy enforcement points: "forwarding to Anthropic" / "Anthropic `tool_result`" → provider-neutral.

**CONTRIBUTING.md** — "Claude drives a turn-based loop" → "the AI …"; backend is "FastAPI + LiteLLM (~100 providers)", not "Anthropic SDK".

**docs/architecture.md** — component box shows a single LiteLLM backend (not "Anthropic/LiteLLM backends"); the downstream API node is any provider via LiteLLM.

**docs/tool-design.md** — `end_session` removed from the current play-tier tool table (it was removed from `PLAY_TOOLS` in the 2026-05-02 cleanup, #104) and documented under "Removed"; the per-run dollar-cap section no longer points at the deleted `app/llm/cost.py` / `AsyncAnthropic`-as-main-path and instead describes the `litellm.callbacks` handler + `app.llm._shared.compute_cost_usd`.

## Verified accurate — deliberately left unchanged

Checked against code and **not** stale: per-tier model defaults (Sonnet 4.6 / Sonnet 4.6 / Opus 4.7 / Haiku 4.5), the 16k scenario-prompt cap, 64-char role labels, 15–180 min duration, the `CREATED → … → ENDED` phase machine, all three escape hatches (force-advance / abort-turn / proxy-respond), and the HUD **"placeholders today"** note — the right-rail gauges are still static (`data-placeholder="1"`); #239's computed telemetry grounds the *AI facilitator* (exercise clock in the prompt), not those gauges.

A broad sweep of the rest of `docs/` (configuration.md, llm_providers.md, prompts.md, extensions.md, turn-lifecycle.md, prompt-writing-rules.md, testing-llm.md, PLAN.md) found no further drift — config defaults and removed-symbol references there are already current.

## Testing

None required — LLM-blind markdown only. The scenario-replay and six-agent review rules apply to application-code changes, not docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTkcsibGUvijmCiApAfoX

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZTkcsibGUvijmCiApAfoX)_