### PR TITLE
security(pr2): HTTP-edge hardening — front-door rate limit, capacity, headers, XFF, str(exc) sweep

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,13 @@
-# Extends the prebuilt Python 3.12 devcontainer image to drop a stale Yarn apt
+# Extends the prebuilt Python 3.13 devcontainer image to drop a stale Yarn apt
 # source. The upstream image ships /etc/apt/sources.list.d/yarn.list pointing at
 # dl.yarnpkg.com, but Yarn rotated their signing key (62D54FD4003F6525) and the
 # image hasn't been rebuilt with the new one. Any feature that runs apt-get
 # update (e.g. docker-in-docker) then fails with NO_PUBKEY. Removing the file
 # is safe — nothing in this repo uses Yarn, and the Node devcontainer feature
 # can install it on demand.
-FROM mcr.microsoft.com/devcontainers/python:3.14-bookworm
+# Pin to 3.13 to match the runtime image (security audit M9): 3.14 pulled a
+# newer litellm (1.83.0) carrying open CVEs into dev containers; the runtime is
+# on 3.13 so dev should match it rather than drift onto a different resolve.
+FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm
 
 RUN rm -f /etc/apt/sources.list.d/yarn.list

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -1,0 +1,106 @@
+"""Curated client-error mapping (security audit M11 / CWE-209).
+
+CodeQL ``py/stack-trace-exposure`` flags any flow where an exception
+object's string reaches a client response. The repo returned
+``str(exc)`` as the ``HTTPException`` detail at ~57 REST sites and in
+~12 WebSocket ``error`` frames. Even when the exception text is
+currently benign, that flow is the taint sink CodeQL reports — and it's
+a real footgun the moment a swallowed lower-level exception (a
+``KeyError`` repr, a pydantic validation dump, a stdlib message naming
+an internal path) bubbles into one of these handlers.
+
+The fix breaks the exception→response taint flow with one boundary
+helper:
+
+* **Log** the full ``str(exc)`` via structlog (operator keeps the
+  detail for debugging — structlog goes to stdout/JSONL, never to the
+  client).
+* **Return** a curated, *constant* message chosen by the exception
+  *type*, never derived from the exception string.
+
+Known domain exceptions map to a short, safe, human message. Anything
+unrecognised collapses to a generic ``"operation failed"`` — the
+client learns the request failed and the HTTP status; the specifics
+live only in the log.
+
+Use :func:`http_error` at every REST ``raise HTTPException`` that would
+otherwise carry ``str(exc)``; use :func:`ws_error_message` to build the
+``message`` field of a WebSocket ``error`` frame.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from ..auth.authn import InvalidTokenError
+from ..auth.authz import AuthorizationError
+from ..sessions.repository import SessionCapacityError, SessionNotFoundError
+from ..sessions.turn_engine import IllegalTransitionError
+
+# Curated, constant messages keyed on exception type. Ordered most- to
+# least-specific; the lookup walks the MRO so a subclass falls back to
+# its nearest registered base. None of these strings is derived from the
+# exception instance — that's the whole point.
+_CURATED: dict[type[BaseException], str] = {
+    AuthorizationError: "you are not allowed to perform this action",
+    InvalidTokenError: "invalid or expired token",
+    SessionNotFoundError: "session not found",
+    SessionCapacityError: "the server is at capacity; try again shortly",
+    IllegalTransitionError: "the session is not in a state that allows this action",
+}
+
+_GENERIC = "operation failed"
+
+
+def curate(exc: BaseException) -> str:
+    """Return the curated client message for ``exc`` (never its string)."""
+
+    for klass in type(exc).__mro__:
+        msg = _CURATED.get(klass)
+        if msg is not None:
+            return msg
+    return _GENERIC
+
+
+def http_error(
+    exc: BaseException,
+    *,
+    status_code: int,
+    log: Any,
+    log_event: str,
+    message: str | None = None,
+    **log_ctx: object,
+) -> HTTPException:
+    """Log ``exc`` in full, return an ``HTTPException`` with a curated detail.
+
+    The caller ``raise``s the return value (so ``raise http_error(...)
+    from exc`` preserves the traceback chain in the logs). The detail
+    handed to the client is the type-curated constant — the raw
+    ``str(exc)`` only ever reaches the structlog line.
+
+    ``message`` lets a call site supply a more specific *constant* detail
+    when one curated-per-type string can't capture the context (e.g. an
+    ``IllegalTransitionError`` raised for a creator-only gate vs. a
+    wrong-state transition). It is still a literal chosen by our code,
+    never derived from ``exc`` — so the CWE-209 taint flow stays broken.
+    """
+
+    log.warning(log_event, error=str(exc), **log_ctx)
+    return HTTPException(status_code, message if message is not None else curate(exc))
+
+
+def ws_error_message(exc: BaseException, *, message: str | None = None) -> str:
+    """Curated ``message`` for a WebSocket ``error`` frame.
+
+    The caller is responsible for logging the raw detail (the WS
+    handlers already emit a structlog line at each failure boundary);
+    this only sanitises the client-visible string. ``message`` is an
+    optional call-site *constant* override (see :func:`http_error`).
+    """
+
+    return message if message is not None else curate(exc)
+
+
+__all__ = ["curate", "http_error", "ws_error_message"]

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -6,7 +6,7 @@ import json
 import re
 from typing import Any, Literal
 
-from fastapi import APIRouter, FastAPI, HTTPException, Query, Request, status
+from fastapi import APIRouter, FastAPI, HTTPException, Request, status
 from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -19,6 +19,7 @@ from ..auth.authz import (
 )
 from ..extensions.registry import FrozenRegistry
 from ..logging_setup import get_logger
+from ..rate_limit import SessionCreateRateLimiter
 from ..sessions.manager import SessionManager, sanitize_role_text
 from ..sessions.models import (
     ParticipantKind,
@@ -27,9 +28,10 @@ from ..sessions.models import (
     SessionState,
 )
 from ..sessions.progress import compute_progress_pct
-from ..sessions.repository import SessionNotFoundError
+from ..sessions.repository import SessionCapacityError, SessionNotFoundError
 from ..sessions.turn_driver import TurnDriver
 from ..sessions.turn_engine import IllegalTransitionError
+from .errors import curate, http_error
 
 
 def _ascii_filename_slug(title: str | None, *, max_len: int = 40) -> str:
@@ -49,6 +51,53 @@ def _ascii_filename_slug(title: str | None, *, max_len: int = 40) -> str:
     # Strip again after the length truncation so a slice that lands
     # mid-separator doesn't leave a trailing "-" in the filename.
     return slug[:max_len].strip("-") or "exercise"
+
+
+# Enumerated ``failed_invitees[].reason`` codes (security audit M11).
+# The bulk-invitee registration in ``create_session`` returns these
+# stable tokens to the client instead of a raw ``str(exc)``; the
+# frontend maps them to friendly copy. ``duplicate`` is emitted inline
+# at the de-dup check; the rest are derived from the ``add_role``
+# failure here.
+_INVITEE_REASON_DUPLICATE = "duplicate"
+_INVITEE_REASON_INVALID_LABEL = "invalid_label"
+_INVITEE_REASON_LIMIT_REACHED = "limit_reached"
+_INVITEE_REASON_ERROR = "error"
+
+
+def _invitee_failure_code(exc: BaseException) -> str:
+    """Map an ``add_role`` failure to an enumerated wire code.
+
+    The full ``str(exc)`` is logged by the caller; this function only
+    classifies it into one of the four stable tokens the frontend
+    understands. We key off substrings of the manager's own
+    ``IllegalTransitionError`` messages — those are our strings, not
+    user- or model-controlled, so the match is stable.
+    """
+
+    text = str(exc).lower()
+    if "max roles reached" in text or "ended session" in text:
+        return _INVITEE_REASON_LIMIT_REACHED
+    if "blank" in text or "label" in text:
+        return _INVITEE_REASON_INVALID_LABEL
+    return _INVITEE_REASON_ERROR
+
+
+def _proxy_target_reject_message(exc: BaseException) -> str:
+    """Curated client detail for a proxy-respond target rejection.
+
+    ``proxy_submit_as`` raises a plain ``IllegalTransitionError`` for two
+    distinct cases (target not seated vs. target is a spectator). We can't
+    distinguish them by exception *type*, so we classify on the manager's
+    own stable message substrings — those are our strings, not user- or
+    model-controlled (same pattern as ``_invitee_failure_code``). The
+    value returned is a constant chosen by our code, never ``str(exc)``,
+    so the M11 / CWE-209 taint flow stays broken.
+    """
+
+    if "not a player role" in str(exc).lower():
+        return "target role is not a player role; cannot proxy-submit"
+    return "target role is not seated in this session"
 
 
 class InviteeRoleSpec(BaseModel):
@@ -352,7 +401,16 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             return authn.verify(token)
         except InvalidTokenError as exc:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, str(exc)) from exc
+            # M11: curated constant ("invalid or expired token") instead
+            # of the raw verifier message — the detail (which HMAC check
+            # failed, expiry vs signature) is an info-leak to an attacker
+            # probing tokens and is logged server-side instead.
+            raise http_error(
+                exc,
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                log=get_logger("api"),
+                log_event="token_verify_failed",
+            ) from exc
 
     async def _bind_token(req: Request, session_id: str) -> JoinTokenPayload:
         """Verify token signature, session binding, AND that the role still
@@ -379,46 +437,41 @@ def register_api_routes(app: FastAPI) -> None:
 
     # ---------------------------------------------------- routes
     @router.get("/invite/status")
-    async def invite_status(
-        request: Request,
-        # Length-cap the query so an attacker can't grind ``?code=<5MB>``
-        # against ``hmac.compare_digest`` and chew CPU when the
-        # rate-limit middleware is off. Mirrors the
-        # ``CreateSessionBody.invite_code`` cap. Path scrubber in
-        # ``logging_setup._scrub_path_bytes`` redacts the value before
-        # it reaches the access log.
-        code: str | None = Query(default=None, max_length=128),
-    ) -> dict[str, Any]:
-        """Tell the frontend whether the gate is on, and (optionally)
-        whether a supplied code passes.
+    async def invite_status(request: Request) -> dict[str, Any]:
+        """Tell the frontend *whether* the invite gate is on — nothing more.
 
-        ``GET /api/invite/status`` (no ``?code=``) returns
-        ``{"required": bool, "valid": null}`` so the wizard knows
-        whether to render the gate at all.
-
-        ``GET /api/invite/status?code=XYZ`` additionally returns
-        ``{"valid": bool}`` so the gate can confirm the code without
-        going through the full create-session path. Failures are
-        logged at WARNING so brute-force attempts are visible in
-        ``/healthz``-style log scans; the code itself is never logged.
+        Returns ``{"required": bool}`` only. Security audit M7 removed
+        the optional ``?code=`` verification branch: returning
+        ``{"valid": bool}`` for an arbitrary candidate turned this
+        endpoint into an online brute-force oracle for ``INVITE_CODE``
+        (cheap GET, no side effects, instant yes/no). The code is now
+        validated **only** inline on ``POST /api/sessions`` — which
+        already 403s on a bad code and is throttled by the C1
+        create-rate limiter — so an attacker can't grind candidates
+        against a free verification endpoint. The frontend uses the
+        ``required`` flag purely to decide whether to render the gate
+        UI; the actual code check happens on submit.
         """
 
         settings = request.app.state.settings
-        log = get_logger("api")
-        if not settings.invite_code_required():
-            return {"required": False, "valid": None}
-        if code is None:
-            return {"required": True, "valid": None}
-        valid = settings.verify_invite_code(code)
-        if valid:
-            log.info("invite_validate_ok")
-        else:
-            log.warning("invite_validate_rejected")
-        return {"required": True, "valid": valid}
+        return {"required": settings.invite_code_required()}
 
     @router.post("/sessions")
     async def create_session(body: CreateSessionBody, request: Request) -> dict[str, Any]:
         settings = request.app.state.settings
+        # C1: dedicated per-IP creation throttle. Runs BEFORE the invite
+        # check and BEFORE any LLM-driving work — session creation is the
+        # expensive path (each one fires a setup-tier call), so we throttle
+        # it regardless of RATE_LIMIT_ENABLED. The limiter keys on the
+        # hardened client-IP resolver (H7) so a spoofed X-Forwarded-For
+        # can't mint a fresh bucket per request.
+        limiter: SessionCreateRateLimiter = request.app.state.session_create_limiter
+        if not await limiter.check(request.scope):
+            raise HTTPException(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                "session creation rate limit exceeded; slow down",
+                headers={"Retry-After": "60"},
+            )
         if settings.invite_code_required() and not settings.verify_invite_code(
             body.invite_code
         ):
@@ -437,8 +490,26 @@ def register_api_routes(app: FastAPI) -> None:
                 creator_display_name=body.creator_display_name,
                 settings=body.settings,
             )
+        except SessionCapacityError as exc:
+            # M2: capacity is a "server full" condition, not a bad
+            # request. 503 + Retry-After reads correctly to the client
+            # (and to the frontend's at-capacity card) and tells crawlers
+            # / monitors to back off rather than treating it as a 4xx
+            # client error. The raw detail is logged; the client gets a
+            # curated, operator-friendly message.
+            get_logger("api").warning("create_session_at_capacity", error=str(exc))
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Crittable is at capacity; try again shortly.",
+                headers={"Retry-After": "30"},
+            ) from exc
         except (RuntimeError, ValueError) as exc:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+            raise http_error(
+                exc,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                log=get_logger("api"),
+                log_event="create_session_failed",
+            ) from exc
 
         # Register pre-declared invitee roles BEFORE the setup turn
         # fires so the AI sees the full roster on its first turn (the
@@ -484,7 +555,7 @@ def register_api_routes(app: FastAPI) -> None:
                 # Duplicate is benign — flag it so the UI can collapse
                 # the row but don't fail the request.
                 failed_invitees.append(
-                    {"label": label_clean, "reason": "duplicate"}
+                    {"label": label_clean, "reason": _INVITEE_REASON_DUPLICATE}
                 )
                 continue
             seen_labels.add(label_lower)
@@ -502,16 +573,25 @@ def register_api_routes(app: FastAPI) -> None:
                 # Don't fail session creation on a single bad role —
                 # capture the per-row reason for the response and log
                 # so the operator has a breadcrumb either way. Label
-                # is already sanitised above; the exception text is
-                # generated by our own code, so it's safe to log raw.
+                # is already sanitised above.
+                #
+                # M11 (CWE-209): the response ``reason`` is an enumerated
+                # CODE, never the raw ``str(exc)`` — the full detail is
+                # logged for the operator but the wire carries only a
+                # stable token the frontend maps to friendly copy.
+                # ``IllegalTransitionError`` here means the roster is full
+                # (``add_role`` rejects past ``MAX_ROLES_PER_SESSION``);
+                # ``ValueError`` is a label the manager rejected.
+                reason_code = _invitee_failure_code(exc)
                 log.warning(
                     "invitee_role_add_failed",
                     session_id=session.id,
                     label=label_clean,
+                    reason_code=reason_code,
                     error=str(exc),
                 )
                 failed_invitees.append(
-                    {"label": label_clean, "reason": str(exc)}
+                    {"label": label_clean, "reason": reason_code}
                 )
         if invitee_role_ids:
             log.info(
@@ -583,9 +663,9 @@ def register_api_routes(app: FastAPI) -> None:
                 acting_token_version=int(token.get("v", 0)),
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
         return {
@@ -798,9 +878,9 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             await manager.start_session(session_id=session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
 
         # Kick the briefing turn off in the background.
         driver = TurnDriver(manager=manager)
@@ -827,7 +907,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
 
         # Stale tab / already-finalized setup (raced finalize / skip /
         # start): return the consistent ``/setup/reply`` shape instead of
@@ -899,9 +979,9 @@ def register_api_routes(app: FastAPI) -> None:
                 plan=_default_dev_plan(session.scenario_prompt),
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/setup/finalize")
@@ -934,9 +1014,9 @@ def register_api_routes(app: FastAPI) -> None:
                 )
             await manager.finalize_setup(session_id=session_id, plan=scenario_plan)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/admin/proxy-respond")
@@ -1039,9 +1119,11 @@ def register_api_routes(app: FastAPI) -> None:
                 mentions=cleaned_mentions,
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, _proxy_target_reject_message(exc)
+            ) from exc
 
         session = await manager.get_session(session_id)
         # Decoupled-ready model: ``proxy_submit_as`` never advances the
@@ -1119,9 +1201,9 @@ def register_api_routes(app: FastAPI) -> None:
                 content=content,
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
 
         # If the proxy filled the last pending seat, drive the next AI turn
         # exactly the way submit_response does.
@@ -1151,7 +1233,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1191,9 +1273,9 @@ def register_api_routes(app: FastAPI) -> None:
                 reason="operator aborted via god mode",
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/force-advance")
@@ -1204,9 +1286,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             await manager.force_advance(session_id=session_id, by_role_id=token["role_id"])
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "the AI is still processing — wait a few seconds before forcing advance",
+            ) from exc
 
         # Drive the AI turn now that the player gate is open. When force-
         # advance recovers from an errored turn the manager opens a fresh
@@ -1236,9 +1321,11 @@ def register_api_routes(app: FastAPI) -> None:
                 reason=(body.reason or "ended"),
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "only the creator can end the session"
+            ) from exc
         return {"ok": True}
 
     # ---------------------------------------------------- AI pause toggle (#69)
@@ -1256,7 +1343,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         await manager.set_ai_paused(
             session_id=session_id, paused=True, by_role_id=token["role_id"]
         )
@@ -1273,7 +1360,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         await manager.set_ai_paused(
             session_id=session_id, paused=False, by_role_id=token["role_id"]
         )
@@ -1308,7 +1395,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1322,13 +1409,31 @@ def register_api_routes(app: FastAPI) -> None:
                 is_creator=is_creator,
             )
         except IllegalTransitionError as exc:
+            # M11: the prefix routing reads our own message strings to
+            # choose the status code, but the CLIENT detail is a curated
+            # constant per branch — never the raw ``str(exc)`` (which can
+            # carry ids / internal phrasing). Raw text is logged.
             text = str(exc)
+            get_logger("api").warning(
+                "workstream_override_rejected",
+                session_id=session_id,
+                message_id=message_id,
+                error=text,
+            )
             if text.startswith("message not found"):
-                raise HTTPException(status.HTTP_404_NOT_FOUND, text) from exc
+                raise HTTPException(
+                    status.HTTP_404_NOT_FOUND, "message not found"
+                ) from exc
             if text.startswith("only the message"):
-                raise HTTPException(status.HTTP_403_FORBIDDEN, text) from exc
+                raise HTTPException(
+                    status.HTTP_403_FORBIDDEN,
+                    "only the creator or the message author can re-tag it",
+                ) from exc
             # workstream-not-declared / other validation
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, text) from exc
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "invalid workstream for this message",
+            ) from exc
         return {"ok": True}
 
     # ---------------------------------------- per-message AI-mute (issue #162)
@@ -1363,7 +1468,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1377,12 +1482,27 @@ def register_api_routes(app: FastAPI) -> None:
                 is_creator=is_creator,
             )
         except IllegalTransitionError as exc:
+            # M11: curated client detail per branch; raw text logged.
             text = str(exc)
+            get_logger("api").warning(
+                "hidden_from_ai_rejected",
+                session_id=session_id,
+                message_id=message_id,
+                error=text,
+            )
             if text.startswith("message not found"):
-                raise HTTPException(status.HTTP_404_NOT_FOUND, text) from exc
+                raise HTTPException(
+                    status.HTTP_404_NOT_FOUND, "message not found"
+                ) from exc
             if text.startswith("only the message"):
-                raise HTTPException(status.HTTP_403_FORBIDDEN, text) from exc
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, text) from exc
+                raise HTTPException(
+                    status.HTTP_403_FORBIDDEN,
+                    "only the creator or the message author can change this",
+                ) from exc
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "cannot change AI visibility for this message",
+            ) from exc
         return {"ok": True, "hidden_from_ai": body.hidden_from_ai}
 
     # ---------------------------------------------------- shared notepad (#98)
@@ -1424,7 +1544,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
 
         notepad = manager.notepad()
         async with await manager.with_lock(session_id):
@@ -1507,7 +1627,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
 
         # Validate against the catalog. ``"custom"`` is reserved for
         # creators who paste their own template; everything else has
@@ -1562,7 +1682,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
 
         notepad = manager.notepad()
         async with await manager.with_lock(session_id):
@@ -1576,7 +1696,18 @@ def register_api_routes(app: FastAPI) -> None:
                     status.HTTP_429_TOO_MANY_REQUESTS, "rate limited"
                 ) from exc
             except NotepadOversizedError as exc:
-                raise HTTPException(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, str(exc)) from exc
+                # M11: don't echo the exception string (it could carry a
+                # byte count derived from internals); a constant message
+                # + the status is enough for the client.
+                get_logger("api").warning(
+                    "notepad_snapshot_oversized",
+                    session_id=session_id,
+                    error=str(exc),
+                )
+                raise HTTPException(
+                    status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    "notepad snapshot too large",
+                ) from exc
             except NotepadRoleNotAllowedError as exc:
                 raise HTTPException(status.HTTP_403_FORBIDDEN, "role not in roster") from exc
         return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -1602,7 +1733,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         # Touch the session so a missing id 404s consistently with the
         # other notepad endpoints.
         await manager.get_session(session_id)
@@ -1632,7 +1763,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
 
         async with await manager.with_lock(session_id):
             session = await manager.get_session(session_id)
@@ -1670,9 +1801,9 @@ def register_api_routes(app: FastAPI) -> None:
                 value=body.value,
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/roles/{role_id}/reissue")
@@ -1697,9 +1828,9 @@ def register_api_routes(app: FastAPI) -> None:
                 by_role_id=token["role_id"],
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+            raise HTTPException(status.HTTP_404_NOT_FOUND, curate(exc)) from exc
         return {"token": new_token, "join_url": f"/play/{session_id}/{new_token}"}
 
     @router.post("/sessions/{session_id}/roles/{role_id}/revoke")
@@ -1723,9 +1854,9 @@ def register_api_routes(app: FastAPI) -> None:
                 by_role_id=token["role_id"],
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         return {"token": new_token, "join_url": f"/play/{session_id}/{new_token}"}
 
     @router.post("/sessions/{session_id}/roles/me/display_name")
@@ -1778,7 +1909,7 @@ def register_api_routes(app: FastAPI) -> None:
                 role_id=token["role_id"],
                 error=str(exc),
             )
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
             api_logger.warning(
                 "set_self_display_name_rejected",
@@ -1786,7 +1917,7 @@ def register_api_routes(app: FastAPI) -> None:
                 role_id=token["role_id"],
                 error=str(exc),
             )
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         except SessionNotFoundError as exc:
             api_logger.warning(
                 "set_self_display_name_session_missing",
@@ -1812,9 +1943,9 @@ def register_api_routes(app: FastAPI) -> None:
                 session_id=session_id, role_id=role_id, by_role_id=token["role_id"]
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
         return {"ok": True}
 
     @router.get("/sessions/{session_id}/export.md", response_class=PlainTextResponse)
@@ -1851,7 +1982,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1931,7 +2062,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2087,7 +2218,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2123,7 +2254,7 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2159,7 +2290,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         session = await manager.get_session(session_id)
         in_flight = manager.llm().in_flight_for(session_id)
         import time as _t
@@ -2272,7 +2403,7 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
         session = await manager.get_session(session_id)
         registry = _registry(request)
         audit = manager.audit().dump(session_id)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -31,7 +31,7 @@ from ..sessions.progress import compute_progress_pct
 from ..sessions.repository import SessionCapacityError, SessionNotFoundError
 from ..sessions.turn_driver import TurnDriver
 from ..sessions.turn_engine import IllegalTransitionError
-from .errors import curate, http_error
+from .errors import http_error
 
 
 def _ascii_filename_slug(title: str | None, *, max_len: int = 40) -> str:
@@ -86,18 +86,62 @@ def _invitee_failure_code(exc: BaseException) -> str:
 def _proxy_target_reject_message(exc: BaseException) -> str:
     """Curated client detail for a proxy-respond target rejection.
 
-    ``proxy_submit_as`` raises a plain ``IllegalTransitionError`` for two
-    distinct cases (target not seated vs. target is a spectator). We can't
-    distinguish them by exception *type*, so we classify on the manager's
-    own stable message substrings — those are our strings, not user- or
-    model-controlled (same pattern as ``_invitee_failure_code``). The
-    value returned is a constant chosen by our code, never ``str(exc)``,
+    ``proxy_submit_as`` raises a plain ``IllegalTransitionError`` for four
+    distinct causes — target not a player role, target not seated, no
+    current turn, and "not accepting player input" — and we can't tell
+    them apart by exception *type*. We classify on the manager's own
+    stable message substrings (our strings, never user- or
+    model-controlled; same pattern as ``_invitee_failure_code``). The
+    returned value is a constant chosen by our code, never ``str(exc)``,
     so the M11 / CWE-209 taint flow stays broken.
+
+    Audit M-1: the pre-fix version collapsed the two wrong-state causes
+    into "not seated", mis-telling the operator the *target role* was the
+    problem when the session simply wasn't accepting input. Each cause
+    now maps to its own message; the raw ``str(exc)`` is logged at the
+    call site.
     """
 
-    if "not a player role" in str(exc).lower():
+    text = str(exc).lower()
+    if "not a player role" in text:
         return "target role is not a player role; cannot proxy-submit"
-    return "target role is not seated in this session"
+    if "not seated" in text:
+        return "target role is not seated in this session"
+    if "no current turn" in text or "not accepting player input" in text:
+        return "the session is not accepting input right now"
+    return "cannot proxy-submit for that role right now"
+
+
+def _reject(
+    exc: BaseException,
+    *,
+    status_code: int,
+    event: str,
+    session_id: str | None = None,
+    message: str | None = None,
+    **ctx: object,
+) -> HTTPException:
+    """Log ``exc`` in full and return a curated ``HTTPException`` (audit H-1).
+
+    Thin routes-layer wrapper over :func:`app.api.errors.http_error`: pins
+    the ``api`` logger and threads ``session_id`` (plus any extra context)
+    into the WARNING line so every domain error mapped onto a 4xx leaves a
+    server-side breadcrumb carrying the real ``str(exc)``. Without it the
+    curated client detail alone makes a 403/409 undiagnosable past the
+    generic access-log entry — the exact swallowed-context gap CLAUDE.md's
+    logging rules call out as must-fix.
+    """
+
+    if session_id is not None:
+        ctx["session_id"] = session_id
+    return http_error(
+        exc,
+        status_code=status_code,
+        log=get_logger("api"),
+        log_event=event,
+        message=message,
+        **ctx,
+    )
 
 
 class InviteeRoleSpec(BaseModel):
@@ -663,9 +707,19 @@ def register_api_routes(app: FastAPI) -> None:
                 acting_token_version=int(token.get("v", 0)),
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
         return {
@@ -878,9 +932,19 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             await manager.start_session(session_id=session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
 
         # Kick the briefing turn off in the background.
         driver = TurnDriver(manager=manager)
@@ -907,7 +971,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
 
         # Stale tab / already-finalized setup (raced finalize / skip /
         # start): return the consistent ``/setup/reply`` shape instead of
@@ -979,9 +1048,19 @@ def register_api_routes(app: FastAPI) -> None:
                 plan=_default_dev_plan(session.scenario_prompt),
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/setup/finalize")
@@ -1014,9 +1093,19 @@ def register_api_routes(app: FastAPI) -> None:
                 )
             await manager.finalize_setup(session_id=session_id, plan=scenario_plan)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/admin/proxy-respond")
@@ -1119,10 +1208,19 @@ def register_api_routes(app: FastAPI) -> None:
                 mentions=cleaned_mentions,
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="proxy_respond_forbidden",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT, _proxy_target_reject_message(exc)
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="proxy_respond_rejected",
+                session_id=session_id,
+                message=_proxy_target_reject_message(exc),
             ) from exc
 
         session = await manager.get_session(session_id)
@@ -1201,9 +1299,19 @@ def register_api_routes(app: FastAPI) -> None:
                 content=content,
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
 
         # If the proxy filled the last pending seat, drive the next AI turn
         # exactly the way submit_response does.
@@ -1233,7 +1341,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1273,9 +1386,19 @@ def register_api_routes(app: FastAPI) -> None:
                 reason="operator aborted via god mode",
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/force-advance")
@@ -1286,7 +1409,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             await manager.force_advance(session_id=session_id, by_role_id=token["role_id"])
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
@@ -1321,7 +1449,12 @@ def register_api_routes(app: FastAPI) -> None:
                 reason=(body.reason or "ended"),
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
             raise HTTPException(
                 status.HTTP_409_CONFLICT, "only the creator can end the session"
@@ -1343,7 +1476,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         await manager.set_ai_paused(
             session_id=session_id, paused=True, by_role_id=token["role_id"]
         )
@@ -1360,7 +1498,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         await manager.set_ai_paused(
             session_id=session_id, paused=False, by_role_id=token["role_id"]
         )
@@ -1395,7 +1538,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1468,7 +1616,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -1544,7 +1697,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
 
         notepad = manager.notepad()
         async with await manager.with_lock(session_id):
@@ -1627,7 +1785,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
 
         # Validate against the catalog. ``"custom"`` is reserved for
         # creators who paste their own template; everything else has
@@ -1682,7 +1845,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
 
         notepad = manager.notepad()
         async with await manager.with_lock(session_id):
@@ -1733,7 +1901,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         # Touch the session so a missing id 404s consistently with the
         # other notepad endpoints.
         await manager.get_session(session_id)
@@ -1763,7 +1936,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_participant(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
 
         async with await manager.with_lock(session_id):
             session = await manager.get_session(session_id)
@@ -1801,9 +1979,19 @@ def register_api_routes(app: FastAPI) -> None:
                 value=body.value,
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         return {"ok": True}
 
     @router.post("/sessions/{session_id}/roles/{role_id}/reissue")
@@ -1828,9 +2016,23 @@ def register_api_routes(app: FastAPI) -> None:
                 by_role_id=token["role_id"],
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="reissue_role_forbidden",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, curate(exc)) from exc
+            # Reissue (revoke_previous=False) can only fail with "role
+            # not found" — a 404, not the generic curated "wrong state"
+            # string the bare ``curate`` produced (audit M-2).
+            raise _reject(
+                exc,
+                status_code=status.HTTP_404_NOT_FOUND,
+                event="reissue_role_not_found",
+                session_id=session_id,
+                message="role not found",
+            ) from exc
         return {"token": new_token, "join_url": f"/play/{session_id}/{new_token}"}
 
     @router.post("/sessions/{session_id}/roles/{role_id}/revoke")
@@ -1854,9 +2056,33 @@ def register_api_routes(app: FastAPI) -> None:
                 by_role_id=token["role_id"],
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="revoke_role_forbidden",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            # Revoke (revoke_previous=True) fails for two distinct
+            # reasons: the role doesn't exist (404), or it's the
+            # creator's own token, which can't be revoked mid-session
+            # (409). The bare curated string mislabelled both (audit
+            # M-2); branch on the manager's stable message.
+            if "role not found" in str(exc).lower():
+                raise _reject(
+                    exc,
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    event="revoke_role_not_found",
+                    session_id=session_id,
+                    message="role not found",
+                ) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="revoke_role_conflict",
+                session_id=session_id,
+                message="cannot revoke the creator's token mid-session",
+            ) from exc
         return {"token": new_token, "join_url": f"/play/{session_id}/{new_token}"}
 
     @router.post("/sessions/{session_id}/roles/me/display_name")
@@ -1909,7 +2135,12 @@ def register_api_routes(app: FastAPI) -> None:
                 role_id=token["role_id"],
                 error=str(exc),
             )
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
             api_logger.warning(
                 "set_self_display_name_rejected",
@@ -1917,7 +2148,12 @@ def register_api_routes(app: FastAPI) -> None:
                 role_id=token["role_id"],
                 error=str(exc),
             )
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             api_logger.warning(
                 "set_self_display_name_session_missing",
@@ -1943,9 +2179,19 @@ def register_api_routes(app: FastAPI) -> None:
                 session_id=session_id, role_id=role_id, by_role_id=token["role_id"]
             )
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except IllegalTransitionError as exc:
-            raise HTTPException(status.HTTP_409_CONFLICT, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_409_CONFLICT,
+                event="illegal_transition",
+                session_id=session_id,
+            ) from exc
         return {"ok": True}
 
     @router.get("/sessions/{session_id}/export.md", response_class=PlainTextResponse)
@@ -1982,7 +2228,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2062,7 +2313,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_participant(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2218,7 +2474,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2254,7 +2515,12 @@ def register_api_routes(app: FastAPI) -> None:
             require_creator(token)
             session = await manager.get_session(session_id)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         except SessionNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "session not found") from exc
 
@@ -2290,7 +2556,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         session = await manager.get_session(session_id)
         in_flight = manager.llm().in_flight_for(session_id)
         import time as _t
@@ -2403,7 +2674,12 @@ def register_api_routes(app: FastAPI) -> None:
         try:
             require_creator(token)
         except AuthorizationError as exc:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, curate(exc)) from exc
+            raise _reject(
+                exc,
+                status_code=status.HTTP_403_FORBIDDEN,
+                event="authz_denied",
+                session_id=session_id,
+            ) from exc
         session = await manager.get_session(session_id)
         registry = _registry(request)
         audit = manager.audit().dump(session_id)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -335,6 +335,53 @@ class Settings(BaseSettings):
     cors_origins: str = Field(default="*", alias="CORS_ORIGINS")
     rate_limit_enabled: bool = Field(default=False, alias="RATE_LIMIT_ENABLED")
     rate_limit_req_per_min: int = Field(default=60, alias="RATE_LIMIT_REQ_PER_MIN", ge=1)
+    # Dedicated per-IP throttle on ``POST /api/sessions`` (security audit
+    # C1). Session creation is the single most expensive request the app
+    # serves — each one fires a setup-tier LLM call — so it gets its own
+    # token bucket independent of ``RATE_LIMIT_REQ_PER_MIN`` and runs
+    # *regardless* of ``RATE_LIMIT_ENABLED``: the general request limiter
+    # is opt-in for the cheap routes, but the create path is always
+    # throttled because the abuse-cost asymmetry is too steep to leave
+    # ungated by default. Tune the cap up for a busy multi-facilitator
+    # deploy; set ``0`` to disable entirely (only safe behind an
+    # ``INVITE_CODE`` gate or an upstream WAF). Keyed on the same
+    # hardened client-IP resolution the request limiter uses, so a
+    # spoofed ``X-Forwarded-For`` can't shard the bucket.
+    session_create_rate_per_min: int = Field(
+        default=5, alias="SESSION_CREATE_RATE_PER_MIN", ge=0
+    )
+    # Trust the ``X-Forwarded-For`` header for client-IP resolution
+    # (security audit H7). OFF by default: when off, the rate limiters
+    # key on the socket peer (``scope["client"]``) and ignore XFF
+    # entirely, so a direct client can't spoof its way into a fresh
+    # bucket. Turn ON only when the app sits behind a reverse proxy you
+    # control that **overwrites** (not appends) XFF — and list that
+    # proxy's egress IP(s) in ``TRUSTED_PROXIES``. With both set, the
+    # resolver walks XFF right-to-left, skipping trusted hops, and takes
+    # the first untrusted entry as the real client. An XFF arriving from
+    # an untrusted immediate peer is ignored even when this flag is on.
+    trust_forwarded_for: bool = Field(
+        default=False, alias="TRUST_FORWARDED_FOR"
+    )
+    # Comma-separated IPs / CIDRs of the reverse proxies whose
+    # ``X-Forwarded-For`` is trusted (security audit H7). Empty (the
+    # default) means "trust no proxy" — consulted only when
+    # ``TRUST_FORWARDED_FOR=true``. Membership is tested with the
+    # stdlib ``ipaddress`` module so both single addresses
+    # (``10.0.0.7``) and ranges (``10.0.0.0/8``, ``2001:db8::/32``)
+    # work. The immediate socket peer must be in this set before any
+    # XFF entry is honoured.
+    trusted_proxies: str = Field(default="", alias="TRUSTED_PROXIES")
+    # Optional override for the response ``Content-Security-Policy``
+    # header (security audit M5). Empty (the default) ships the
+    # hardened built-in policy in ``app.security_headers``. Set this
+    # only if a deployment genuinely needs a looser policy (e.g. an
+    # operator embedding an external analytics beacon) — the default
+    # is self-hosted-only on purpose so air-gapped / strict-CSP
+    # security-team deploys work out of the box.
+    content_security_policy: str = Field(
+        default="", alias="CONTENT_SECURITY_POLICY"
+    )
     # Soft "anti-strangers" gate on ``POST /api/sessions``. When set to
     # a non-empty value, the creator must supply a matching ``invite_code``
     # on session creation; the player-side join links still work without
@@ -521,6 +568,17 @@ class Settings(BaseSettings):
         if raw == "*":
             return "*"
         return [item.strip() for item in raw.split(",") if item.strip()]
+
+    def trusted_proxy_list(self) -> list[str]:
+        """Parse ``TRUSTED_PROXIES`` into a list of raw IP / CIDR strings.
+
+        Empty / whitespace-only entries are dropped. The strings are
+        validated into ``ip_network`` objects lazily in
+        ``rate_limit.resolve_client_ip`` (a malformed entry there logs a
+        warning and is skipped rather than crashing request handling).
+        """
+
+        return [item.strip() for item in self.trusted_proxies.split(",") if item.strip()]
 
     def resolve_session_secret(self) -> str:
         """Return the configured secret, or generate (and warn about) a transient one."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -241,21 +241,28 @@ def create_app(
             ),
         )
     # Boot-time confirmation that the soft anti-strangers gate is on,
-    # plus a loud warning if the operator forgot to pair it with the
-    # rate-limit middleware. Without the warn an operator can think
-    # "INVITE_CODE is set, I'm safe" and miss that an attacker can
-    # grind ``GET /api/invite/status?code=…`` at thousands of probes
-    # per second to brute the value.
+    # plus a loud warning if the operator has *also* disabled every
+    # throttle on the only path that checks the code. The invite code is
+    # validated inline on ``POST /api/sessions`` (the brute-force surface;
+    # the old ``GET /api/invite/status?code=…`` oracle was removed in M7).
+    # That path is normally throttled by the always-on per-IP create
+    # limiter (``SESSION_CREATE_RATE_PER_MIN``, default 5) independent of
+    # ``RATE_LIMIT_ENABLED`` — so the code is only grindable when BOTH
+    # throttles are off. Warn precisely for that combination; an operator
+    # on defaults (create limiter = 5/min) is already protected and
+    # shouldn't see a misleading "no throttling" warning.
     if cfg.invite_code_required():
         _bootstrap_log.info("invite_code_gate_enabled")
-        if not cfg.rate_limit_enabled:
+        if not cfg.rate_limit_enabled and cfg.session_create_rate_per_min <= 0:
             _bootstrap_log.warning(
-                "invite_code_set_without_rate_limit",
+                "invite_code_set_without_throttle",
                 note=(
-                    "INVITE_CODE is set but RATE_LIMIT_ENABLED=false; "
-                    "an attacker can brute the code via "
-                    "POST /api/sessions without throttling. "
-                    "Enable RATE_LIMIT_ENABLED=true for any public deploy."
+                    "INVITE_CODE is set but both RATE_LIMIT_ENABLED=false "
+                    "and SESSION_CREATE_RATE_PER_MIN=0; the code is checked "
+                    "inline on POST /api/sessions with no per-IP throttle, "
+                    "so an attacker can grind candidates. Set "
+                    "SESSION_CREATE_RATE_PER_MIN (a per-IP create cap) "
+                    "and/or RATE_LIMIT_ENABLED=true for any public deploy."
                 ),
             )
 
@@ -282,12 +289,32 @@ def create_app(
             "Refusing to boot an exposed deploy where anonymous callers "
             "can loop session creation and burn setup-tier LLM tokens."
         )
-    _bootstrap_log.info(
-        "session_create_front_door_ok",
-        is_real_deploy=_is_real_deploy,
-        invite_code_gate=cfg.invite_code_required(),
-        session_create_rate_per_min=cfg.session_create_rate_per_min,
-    )
+    if _has_front_door:
+        _bootstrap_log.info(
+            "session_create_front_door_ok",
+            is_real_deploy=_is_real_deploy,
+            invite_code_gate=cfg.invite_code_required(),
+            session_create_rate_per_min=cfg.session_create_rate_per_min,
+        )
+    else:
+        # Reachable only for a local/toy deploy (CORS_ORIGINS='*') — the
+        # real-deploy + no-door combo already raised above. We still boot
+        # so laptop dev stays frictionless, but POST /api/sessions is
+        # unthrottled here: if this exact config is exposed on a reachable
+        # port, an anonymous caller can loop session creation and burn
+        # setup-tier LLM tokens. Warn loudly so the operator finds it in
+        # the boot log instead of via a surprise Anthropic bill (audit
+        # L-1).
+        _bootstrap_log.warning(
+            "session_create_unthrottled_local",
+            note=(
+                "CORS_ORIGINS='*' with no INVITE_CODE and "
+                "SESSION_CREATE_RATE_PER_MIN=0 — session creation is "
+                "unthrottled. Fine on a laptop; if this port is reachable "
+                "by anyone else, set SESSION_CREATE_RATE_PER_MIN (a per-IP "
+                "cap) and/or INVITE_CODE to gate it."
+            ),
+        )
 
     app = FastAPI(
         title="Crittable",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,7 +29,8 @@ from .llm.dispatch import ToolDispatcher
 from .llm.guardrail import InputGuardrail
 from .llm.protocol import ChatClient
 from .logging_setup import RequestContextMiddleware, configure_logging, get_logger
-from .rate_limit import RateLimitMiddleware
+from .rate_limit import RateLimitMiddleware, SessionCreateRateLimiter
+from .security_headers import SecurityHeadersMiddleware
 from .sessions.gc import SessionGC
 from .sessions.manager import SessionManager
 from .sessions.repository import InMemoryRepository
@@ -115,6 +116,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.registry = registry
     app.state.llm = llm
     app.state.session_gc = session_gc
+    # Dedicated per-IP throttle on POST /api/sessions (security audit
+    # C1). Constructed here so its bucket state lives for the app's
+    # lifetime; the create_session handler reads it off app.state.
+    app.state.session_create_limiter = SessionCreateRateLimiter(settings)
 
     from .config import ModelTier
 
@@ -249,11 +254,40 @@ def create_app(
                 note=(
                     "INVITE_CODE is set but RATE_LIMIT_ENABLED=false; "
                     "an attacker can brute the code via "
-                    "GET /api/invite/status?code=… or "
                     "POST /api/sessions without throttling. "
                     "Enable RATE_LIMIT_ENABLED=true for any public deploy."
                 ),
             )
+
+    # Fail-closed front-door gate (security audit C1). On a real deploy
+    # (CORS_ORIGINS narrowed away from "*") the session-create path must
+    # have *some* protection — either the INVITE_CODE gate or the
+    # dedicated per-IP creation throttle (SESSION_CREATE_RATE_PER_MIN).
+    # With neither, an anonymous caller can loop POST /api/sessions and
+    # each request fires a setup-tier LLM call. Mirrors the
+    # require_llm_api_key() import-time gate: raising here makes uvicorn
+    # exit non-zero with a clear message instead of silently booting an
+    # exposed deploy. Local / toy deploys (CORS_ORIGINS="*") are
+    # untouched so dev stays frictionless.
+    _is_real_deploy = cfg.cors_origin_list() != "*"
+    _has_front_door = (
+        cfg.invite_code_required() or cfg.session_create_rate_per_min > 0
+    )
+    if _is_real_deploy and not _has_front_door:
+        raise RuntimeError(
+            "No front-door protection on POST /api/sessions for a "
+            "non-local deploy (CORS_ORIGINS is not '*'). Set INVITE_CODE "
+            "to gate session creation, and/or set "
+            "SESSION_CREATE_RATE_PER_MIN to a non-zero per-IP cap. "
+            "Refusing to boot an exposed deploy where anonymous callers "
+            "can loop session creation and burn setup-tier LLM tokens."
+        )
+    _bootstrap_log.info(
+        "session_create_front_door_ok",
+        is_real_deploy=_is_real_deploy,
+        invite_code_gate=cfg.invite_code_required(),
+        session_create_rate_per_min=cfg.session_create_rate_per_min,
+    )
 
     app = FastAPI(
         title="Crittable",
@@ -278,6 +312,14 @@ def create_app(
     # the middleware itself short-circuits when disabled so adding it to the
     # stack is cheap.
     app.add_middleware(RateLimitMiddleware, settings=cfg)
+
+    # Security-headers middleware (security audit M5). Added last so it
+    # is the OUTERMOST wrapper — every response gets the hardening
+    # headers, including rate-limit 429s, CORS responses, the SPA
+    # fallback, and static assets. Priority header is
+    # ``Referrer-Policy: no-referrer`` (the join token rides in the URL
+    # path, so a Referer leak would expose it).
+    app.add_middleware(SecurityHeadersMiddleware, settings=cfg)
 
     @app.get("/healthz")
     async def healthz() -> JSONResponse:

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -11,12 +11,12 @@ horizontal scale-out keeps a coherent view. The interface here doesn't change.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import time
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
-from typing import Any
+from functools import lru_cache
 
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .config import Settings
 from .logging_setup import get_logger
@@ -24,6 +24,105 @@ from .logging_setup import get_logger
 _logger = get_logger("rate_limit")
 
 _SECONDS_PER_MINUTE = 60.0
+
+
+@lru_cache(maxsize=32)
+def _parse_trusted_networks(
+    raw: tuple[str, ...],
+) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    """Validate raw ``TRUSTED_PROXIES`` strings into ``ip_network`` objects.
+
+    A bad entry is logged once (the cache makes this idempotent across
+    requests) and dropped — a typo in one CIDR must not crash every
+    request. ``strict=False`` lets an operator write ``10.0.0.7/8``
+    (host bits set) without a ``ValueError``.
+    """
+
+    nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for entry in raw:
+        try:
+            nets.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            _logger.warning("trusted_proxy_parse_failed", entry=entry)
+    return tuple(nets)
+
+
+def _ip_in_networks(
+    ip: str,
+    networks: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...],
+) -> bool:
+    """True iff ``ip`` parses and is a member of any trusted network."""
+
+    if not networks:
+        return False
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return any(addr in net for net in networks)
+
+
+def _peer_ip(scope: Scope) -> str:
+    """The immediate socket peer IP from the ASGI scope, or ``"unknown"``."""
+
+    client = scope.get("client")
+    if client and isinstance(client, (list, tuple)) and client:
+        return str(client[0])
+    return "unknown"
+
+
+def resolve_client_ip(scope: Scope, settings: Settings) -> str:
+    """Resolve the real client IP, hardened against ``X-Forwarded-For`` spoofing.
+
+    Security audit H7. The legacy implementation trusted the *first*
+    ``X-Forwarded-For`` value unconditionally, which any direct client
+    can forge to evade per-IP throttling (or to frame another address).
+
+    Policy:
+
+    * Default to the socket peer (``scope["client"][0]``).
+    * Only consult ``X-Forwarded-For`` when ``TRUST_FORWARDED_FOR`` is
+      true AND the immediate peer is itself in ``TRUSTED_PROXIES``
+      (i.e. the request actually came through a proxy we control).
+    * When honoured, walk the XFF list **right-to-left** and return the
+      first entry that is *not* in the trusted set — that's the hop the
+      outermost trusted proxy observed, i.e. the real client. A client
+      can prepend junk to the left of the header, but it cannot control
+      what the trusted proxy appends on the right, so the right-most
+      untrusted entry is the trustworthy one.
+    * If every XFF entry is trusted (or the header is empty/garbage),
+      fall back to the peer.
+
+    This resolver is shared by the request limiter and the C1
+    session-create limiter so both key on an identical, spoof-resistant
+    value.
+    """
+
+    peer = _peer_ip(scope)
+    if not settings.trust_forwarded_for:
+        return peer
+
+    networks = _parse_trusted_networks(tuple(settings.trusted_proxy_list()))
+    # The immediate peer must be a trusted proxy before we believe ANY
+    # forwarded header — otherwise a direct attacker just sets the header
+    # themselves.
+    if not _ip_in_networks(peer, networks):
+        return peer
+
+    headers: dict[bytes, bytes] = dict(scope.get("headers") or [])
+    fwd: bytes | None = headers.get(b"x-forwarded-for")
+    if not fwd:
+        return peer
+    try:
+        chain = [p.strip() for p in fwd.decode("ascii").split(",") if p.strip()]
+    except (UnicodeDecodeError, AttributeError):
+        return peer
+    # Right-to-left: the first hop the trusted proxy chain didn't add.
+    for candidate in reversed(chain):
+        if not _ip_in_networks(candidate, networks):
+            return candidate
+    # Every entry was a trusted proxy — no real client hop to extract.
+    return peer
 
 
 class _Bucket:
@@ -48,6 +147,7 @@ class RateLimitMiddleware:
         settings: Settings,
     ) -> None:
         self.app = app
+        self._settings = settings
         self._enabled = settings.rate_limit_enabled
         self._capacity = float(settings.rate_limit_req_per_min)
         # tokens-per-second
@@ -60,9 +160,9 @@ class RateLimitMiddleware:
 
     async def __call__(
         self,
-        scope: dict[str, Any],
-        receive: Callable[..., Awaitable[Any]],
-        send: Callable[..., Awaitable[Any]],
+        scope: Scope,
+        receive: Receive,
+        send: Send,
     ) -> None:
         if not self._enabled or scope["type"] not in ("http", "websocket"):
             await self.app(scope, receive, send)
@@ -75,7 +175,7 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        ip = _client_ip(scope)
+        ip = resolve_client_ip(scope, self._settings)
         allowed = await self._consume(ip)
         if not allowed:
             _logger.warning("rate_limited", ip=ip, path=path)
@@ -101,21 +201,63 @@ class RateLimitMiddleware:
             return False
 
 
-def _client_ip(scope: dict[str, Any]) -> str:
-    headers = dict(scope.get("headers") or [])
-    fwd = headers.get(b"x-forwarded-for")
-    if fwd:
-        try:
-            return str(fwd.decode("ascii").split(",")[0].strip())
-        except (UnicodeDecodeError, AttributeError):
-            pass
-    client = scope.get("client")
-    if client and isinstance(client, (list, tuple)) and client:
-        return str(client[0])
-    return "unknown"
+class SessionCreateRateLimiter:
+    """Dedicated per-IP token bucket for ``POST /api/sessions`` (audit C1).
+
+    Session creation fires a setup-tier LLM call, so it's the costliest
+    request the app serves. This limiter is independent of the general
+    ``RateLimitMiddleware`` and runs even when ``RATE_LIMIT_ENABLED`` is
+    false — the cost asymmetry means the create path is always throttled
+    (tunable / disable-able via ``SESSION_CREATE_RATE_PER_MIN``).
+
+    Constructed once in the lifespan and stored on ``app.state`` so the
+    route handler can call :meth:`check` per request. Keyed on the
+    hardened :func:`resolve_client_ip` so a spoofed ``X-Forwarded-For``
+    can't shard the bucket into unlimited fresh allowances.
+
+    Single-process MVP, same as ``RateLimitMiddleware`` — a multi-worker
+    deploy needs the Phase-3 Redis backend for a coherent view.
+    """
+
+    __slots__ = ("_buckets", "_capacity", "_enabled", "_lock", "_refill", "_settings")
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        cap = settings.session_create_rate_per_min
+        self._enabled = cap > 0
+        self._capacity = float(cap)
+        self._refill = self._capacity / _SECONDS_PER_MINUTE
+        self._buckets: dict[str, _Bucket] = defaultdict(self._fresh)
+        self._lock = asyncio.Lock()
+
+    def _fresh(self) -> _Bucket:
+        return _Bucket(self._capacity)
+
+    async def check(self, scope: Scope) -> bool:
+        """Consume one token for the request's client IP.
+
+        Returns ``True`` when the request is allowed (or the limiter is
+        disabled), ``False`` when the per-IP bucket is empty. The caller
+        is responsible for translating ``False`` into an HTTP 429.
+        """
+
+        if not self._enabled:
+            return True
+        ip = resolve_client_ip(scope, self._settings)
+        async with self._lock:
+            bucket = self._buckets[ip]
+            now = time.monotonic()
+            elapsed = now - bucket.last_refill
+            bucket.tokens = min(self._capacity, bucket.tokens + elapsed * self._refill)
+            bucket.last_refill = now
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True
+            _logger.warning("session_create_rate_limited", ip=ip)
+            return False
 
 
-async def _send_429(send: Callable[..., Awaitable[Any]]) -> None:
+async def _send_429(send: Send) -> None:
     body = b'{"detail":"rate limit exceeded"}'
     await send(
         {

--- a/backend/app/security_headers.py
+++ b/backend/app/security_headers.py
@@ -1,0 +1,89 @@
+"""Security-headers middleware (security audit M5).
+
+Sets a small, fixed set of hardening headers on every HTTP response:
+
+* ``Referrer-Policy: no-referrer`` — **the priority**. Player join links
+  carry their per-role HMAC token in the URL path (``/play/<token>``);
+  without this header a click-through to any external link would leak
+  the token in the ``Referer`` request header. ``no-referrer`` stops
+  the browser sending a Referer at all.
+* ``X-Content-Type-Options: nosniff`` — block MIME-sniffing.
+* ``X-Frame-Options: DENY`` — legacy clickjacking guard (paired with
+  ``frame-ancestors 'none'`` in the CSP for modern browsers).
+* ``Content-Security-Policy`` — self-hosted-only by default. Fonts and
+  assets are bundled (CLAUDE.md: no Google Fonts CDN, no external
+  runtime assets), so ``default-src 'self'`` is sufficient.
+  ``connect-src 'self'`` covers the same-origin WebSocket.
+
+The CSP is overridable via the ``CONTENT_SECURITY_POLICY`` env var for
+the rare deploy that needs a looser policy; the default is the hardened
+constant below.
+
+Implemented as plain ASGI (no per-request object allocation beyond the
+header rewrite) so it sits cheaply at the top of the middleware stack
+and applies uniformly to API responses, the SPA fallback, and the
+static asset mounts. ``/healthz`` / ``/readyz`` get the headers too —
+they're harmless on a JSON health probe and keeping the path
+unconditional avoids a "which routes are covered?" gap.
+"""
+
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from .config import Settings
+
+# Self-hosted-only default. Kept as a module constant so tests can assert
+# the exact string and a future tightening lands in one place.
+DEFAULT_CSP = (
+    "default-src 'self'; "
+    "img-src 'self' data:; "
+    "style-src 'self' 'unsafe-inline'; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'none'"
+)
+
+
+class SecurityHeadersMiddleware:
+    """Inject fixed hardening headers on every HTTP response."""
+
+    __slots__ = ("_csp", "app")
+
+    def __init__(self, app: ASGIApp, *, settings: Settings) -> None:
+        self.app = app
+        override = settings.content_security_policy.strip()
+        self._csp = override or DEFAULT_CSP
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers: list[tuple[bytes, bytes]] = message.setdefault("headers", [])
+                # Append our headers; never clobber an existing value a
+                # handler set deliberately (none currently do, but keep
+                # the contract explicit). Header names are matched
+                # case-insensitively per RFC, so we lowercase both sides.
+                present = {name.lower() for name, _ in headers}
+                for raw_name, raw_value in (
+                    (b"referrer-policy", b"no-referrer"),
+                    (b"x-content-type-options", b"nosniff"),
+                    (b"x-frame-options", b"DENY"),
+                    (b"content-security-policy", self._csp.encode("latin-1")),
+                ):
+                    if raw_name not in present:
+                        headers.append((raw_name, raw_value))
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
+
+
+__all__ = ["DEFAULT_CSP", "SecurityHeadersMiddleware"]

--- a/backend/app/sessions/repository.py
+++ b/backend/app/sessions/repository.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Iterable
 from typing import Protocol
 
-from .models import Session
+from .models import Session, SessionState
 
 
 class SessionNotFoundError(KeyError):
@@ -44,7 +44,18 @@ class InMemoryRepository:
         async with self._lock:
             if session.id in self._sessions:
                 raise ValueError(f"session already exists: {session.id}")
-            if len(self._sessions) >= self._max:
+            # Count only LIVE (non-ENDED) sessions toward the cap
+            # (security audit M2). ENDED sessions linger as tombstones
+            # until the GC reaps them per ``EXPORT_RETENTION_MIN``, but
+            # they no longer hold an LLM-driving slot — so ending a
+            # session frees capacity for a new one immediately instead
+            # of the operator having to wait out the retention window.
+            live = sum(
+                1
+                for existing in self._sessions.values()
+                if existing.state != SessionState.ENDED
+            )
+            if live >= self._max:
                 raise SessionCapacityError(
                     f"session capacity reached ({self._max}); end one before creating another"
                 )

--- a/backend/app/ws/routes.py
+++ b/backend/app/ws/routes.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, status
 
+from ..api.errors import ws_error_message
 from ..auth.authn import HMACAuthenticator, InvalidTokenError, ParticipantKindLiteral
 from ..auth.authz import AuthorizationError, require_creator, require_participant
 from ..config import Settings
@@ -608,11 +609,19 @@ async def _client_pump(
                 try:
                     require_participant(token_payload)
                 except AuthorizationError as exc:
+                    # M11: curated client message; raw detail logged.
+                    _logger.warning(
+                        "ws_mutating_event_unauthorized",
+                        session_id=session_id,
+                        role_id=role_id,
+                        event_type=event_type,
+                        error=str(exc),
+                    )
                     await websocket.send_json(
                         {
                             "type": "error",
                             "scope": event_type,
-                            "message": str(exc),
+                            "message": ws_error_message(exc),
                         }
                     )
                     continue
@@ -690,8 +699,19 @@ async def _client_pump(
                     )
                     continue
                 except IllegalTransitionError as exc:
+                    # M11: curated client message; raw detail logged.
+                    _logger.warning(
+                        "ws_submit_response_rejected",
+                        session_id=session_id,
+                        role_id=role_id,
+                        error=str(exc),
+                    )
                     await websocket.send_json(
-                        {"type": "error", "scope": "submit_response", "message": str(exc)}
+                        {
+                            "type": "error",
+                            "scope": "submit_response",
+                            "message": ws_error_message(exc),
+                        }
                     )
                     continue
                 if outcome.truncated:
@@ -782,7 +802,7 @@ async def _client_pump(
                         {
                             "type": "error",
                             "scope": "force_advance",
-                            "message": str(exc),
+                            "message": ws_error_message(exc),
                         }
                     )
                     continue
@@ -796,13 +816,20 @@ async def _client_pump(
                         await TurnDriver(manager=manager).run_play_turn(
                             session=session, turn=turn
                         )
-                except AuthorizationError as exc:
-                    await websocket.send_json(
-                        {"type": "error", "scope": "force_advance", "message": str(exc)}
+                except (AuthorizationError, IllegalTransitionError) as exc:
+                    # M11: curated client message; raw detail logged.
+                    _logger.warning(
+                        "ws_force_advance_rejected",
+                        session_id=session_id,
+                        role_id=role_id,
+                        error=str(exc),
                     )
-                except IllegalTransitionError as exc:
                     await websocket.send_json(
-                        {"type": "error", "scope": "force_advance", "message": str(exc)}
+                        {
+                            "type": "error",
+                            "scope": "force_advance",
+                            "message": ws_error_message(exc),
+                        }
                     )
             elif event_type == "set_ready":
                 # Decoupled-ready model: the composer no longer carries
@@ -907,7 +934,13 @@ async def _client_pump(
                         reason=str(exc),
                     )
                     await websocket.send_json(
-                        {"type": "error", "scope": "end_session", "message": str(exc)}
+                        {
+                            "type": "error",
+                            "scope": "end_session",
+                            "message": ws_error_message(
+                                exc, message="only the creator can end the session"
+                            ),
+                        }
                     )
             elif event_type in ("typing_start", "typing_stop"):
                 # Relay to other connections only (not the sender). Lightweight

--- a/backend/tests/test_app_boot_gate.py
+++ b/backend/tests/test_app_boot_gate.py
@@ -1,0 +1,70 @@
+"""C1(b) — fail-closed front-door boot gate in ``create_app``.
+
+On a real deploy (``CORS_ORIGINS`` narrowed away from ``*``) the
+session-create path must have *some* protection — either ``INVITE_CODE``
+or a non-zero ``SESSION_CREATE_RATE_PER_MIN``. With neither, an
+anonymous caller can loop ``POST /api/sessions`` and burn setup-tier LLM
+tokens. The gate raises at import time (mirroring
+``require_llm_api_key``) so uvicorn exits non-zero instead of silently
+booting an exposed deploy.
+
+Local / toy deploys (``CORS_ORIGINS="*"``) are untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import reset_settings_cache
+from app.main import create_app
+
+
+@pytest.fixture(autouse=True)
+def _base_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_API_KEY", "x")
+    monkeypatch.setenv("SESSION_SECRET", "x" * 32)
+
+
+def test_boot_fails_on_real_deploy_with_no_front_door(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CORS_ORIGINS", "https://crit.example.com")
+    monkeypatch.delenv("INVITE_CODE", raising=False)
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "0")
+    reset_settings_cache()
+    with pytest.raises(RuntimeError, match="front-door"):
+        create_app()
+
+
+def test_boot_ok_real_deploy_with_create_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CORS_ORIGINS", "https://crit.example.com")
+    monkeypatch.delenv("INVITE_CODE", raising=False)
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "5")
+    reset_settings_cache()
+    # Should not raise.
+    create_app()
+
+
+def test_boot_ok_real_deploy_with_invite_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CORS_ORIGINS", "https://crit.example.com")
+    monkeypatch.setenv("INVITE_CODE", "tabletop-2026")
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "0")
+    reset_settings_cache()
+    create_app()
+
+
+def test_boot_ok_local_deploy_even_with_no_front_door(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CORS_ORIGINS='*' is a local/toy deploy — the gate stays out of
+    the way so dev is frictionless."""
+
+    monkeypatch.setenv("CORS_ORIGINS", "*")
+    monkeypatch.delenv("INVITE_CODE", raising=False)
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "0")
+    reset_settings_cache()
+    create_app()

--- a/backend/tests/test_e2e_session.py
+++ b/backend/tests/test_e2e_session.py
@@ -25,6 +25,50 @@ _TOOLS_JSON = """[{
 }]"""
 
 
+def _bounded_receive_json(ws: Any, *, timeout: float = 2.0) -> dict[str, Any] | None:
+    """Receive a single WS frame, bounded by ``timeout``.
+
+    Starlette's ``WebSocketTestSession.receive_json`` blocks forever on
+    its underlying queue — there is no ``timeout`` kwarg. A regression
+    that drops an expected frame would therefore HANG CI on the receive
+    loop rather than failing the asserting test. We bound it by running
+    the receive in a daemon thread and ``join(timeout=...)``-ing; a
+    still-alive thread (no frame arrived) returns ``None`` so the caller
+    fails fast. Socket / decode errors are logged before swallowing
+    (CLAUDE.md logging rules apply to test infra too). Mirrors
+    ``test_set_ready._drain``; kept local so each WS test file stays
+    self-contained.
+    """
+
+    import threading
+
+    holder: dict[str, Any] = {}
+
+    def _recv() -> None:
+        try:
+            holder["evt"] = ws.receive_json()
+        except Exception as exc:
+            holder["err"] = exc
+
+    t = threading.Thread(target=_recv, daemon=True)
+    t.start()
+    t.join(timeout=timeout)
+    if t.is_alive():
+        # Daemon thread dies with the test process.
+        print(
+            f"[test_e2e_session] _bounded_receive_json: timed out after "
+            f"{timeout}s waiting for a frame"
+        )
+        return None
+    if "err" in holder:
+        print(
+            f"[test_e2e_session] _bounded_receive_json: socket error before "
+            f"a frame arrived: {holder['err']!r}"
+        )
+        return None
+    return holder.get("evt")
+
+
 @pytest.fixture(autouse=True)
 def _e2e_env(monkeypatch) -> None:
     monkeypatch.setenv("LLM_MODEL_PLAY", "mock-play")
@@ -570,10 +614,16 @@ def test_ws_request_end_session_rejected_for_non_creator(
     ) as ws:
         ws.send_json({"type": "request_end_session", "reason": "spite"})
         saw_rejection = False
+        # Bounded receive: this loop matches on the rejection *wording*
+        # ("creator"), so an M11-style message reflatten that drops the
+        # word would otherwise hang here forever on a bare
+        # ``receive_json()`` (the ``range(64)`` only advances when a
+        # frame actually arrives). ``_bounded_receive_json`` returns
+        # ``None`` once no frame lands within the timeout, so a future
+        # regression fails this assertion fast instead of stalling CI.
         for _ in range(64):
-            try:
-                evt = ws.receive_json()
-            except Exception:
+            evt = _bounded_receive_json(ws)
+            if evt is None:
                 break
             if (
                 evt.get("type") == "error"

--- a/backend/tests/test_http_edge_hardening.py
+++ b/backend/tests/test_http_edge_hardening.py
@@ -18,6 +18,7 @@ The C1 boot gate (also part of this PR) is exercised in
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -206,6 +207,30 @@ def test_security_headers_on_error_response(
     with TestClient(app) as client:
         r = client.get("/api/sessions/nope")
         assert r.status_code == 401
+        _assert_security_headers(r.headers)
+
+
+def test_security_headers_on_spa_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """M5: the SPA catch-all (``GET /play/<sid>/<token>`` → index.html)
+    must carry the hardening headers too. That route serves the player
+    join page whose URL embeds the per-role HMAC token, so the
+    no-referrer header is load-bearing *exactly* here — a click-out from
+    the join page must not leak the token in the Referer. The middleware
+    is the outermost layer, so it should wrap the FileResponse; pin it
+    via the ``static_dir_override`` test seam."""
+
+    (tmp_path / "index.html").write_text(
+        "<!doctype html><title>crit-spa</title>", encoding="utf-8"
+    )
+    reset_settings_cache()
+    app = create_app(static_dir_override=tmp_path)
+    with TestClient(app) as client:
+        r = client.get("/play/abc/some-token")
+        assert r.status_code == 200, r.text
+        # Served the SPA shell (fell through to index.html), not a 404.
+        assert "crit-spa" in r.text
         _assert_security_headers(r.headers)
 
 

--- a/backend/tests/test_http_edge_hardening.py
+++ b/backend/tests/test_http_edge_hardening.py
@@ -1,0 +1,260 @@
+"""Security audit PR 2 — HTTP-edge / front-door hardening.
+
+Covers:
+
+* C1 — dedicated per-IP throttle on ``POST /api/sessions`` (429 +
+  Retry-After past the cap, independent of ``RATE_LIMIT_ENABLED``).
+* M2 — session capacity maps to 503 + Retry-After, and ending a
+  session frees a slot immediately.
+* M5 — security-headers middleware present on normal responses and on
+  ``/healthz``.
+* M11 — curated client errors: representative error responses carry a
+  curated message, not the raw exception string, and the raw detail
+  still reaches the structlog line.
+
+The C1 boot gate (also part of this PR) is exercised in
+``test_app_boot_gate.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import reset_settings_cache
+from app.main import create_app
+from app.security_headers import DEFAULT_CSP
+from tests.conftest import default_settings_body
+from tests.mock_chat_client import install_mock_chat_client
+
+
+def _create_body() -> dict[str, Any]:
+    return {
+        "scenario_prompt": "Ransomware tabletop",
+        "creator_label": "CISO",
+        "creator_display_name": "Alex",
+        "skip_setup": True,
+        **default_settings_body(),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INPUT_GUARDRAIL_ENABLED", "false")
+    reset_settings_cache()
+
+
+# ---------------------------------------------------------------- C1: create limit
+
+
+def test_create_session_rate_limited_after_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past ``SESSION_CREATE_RATE_PER_MIN`` from one IP, creation 429s
+    with a Retry-After header — even though RATE_LIMIT_ENABLED is off
+    (creation is always throttled)."""
+
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "2")
+    monkeypatch.delenv("RATE_LIMIT_ENABLED", raising=False)
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        codes = [client.post("/api/sessions", json=_create_body()).status_code for _ in range(3)]
+        assert codes[:2] == [200, 200], codes
+        assert codes[2] == 429, codes
+        # The 429 carries Retry-After so the client backs off.
+        last = client.post("/api/sessions", json=_create_body())
+        assert last.status_code == 429
+        assert last.headers.get("Retry-After") == "60"
+        assert "rate limit" in last.json()["detail"].lower()
+
+
+def test_create_session_limit_disabled_when_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``SESSION_CREATE_RATE_PER_MIN=0`` disables the dedicated limiter
+    (the boot gate still demands a front door on real deploys, but a
+    local CORS=* deploy can opt out)."""
+
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "0")
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        codes = [client.post("/api/sessions", json=_create_body()).status_code for _ in range(6)]
+        assert codes == [200] * 6, codes
+
+
+def test_create_limit_does_not_block_other_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The create limiter is scoped to POST /api/sessions only — a
+    drained create bucket must not 429 unrelated reads."""
+
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "1")
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        assert client.post("/api/sessions", json=_create_body()).status_code == 200
+        # Second create is throttled...
+        assert client.post("/api/sessions", json=_create_body()).status_code == 429
+        # ...but the health probe and invite-status are unaffected.
+        assert client.get("/healthz").status_code == 200
+        assert client.get("/api/invite/status").status_code == 200
+
+
+# ---------------------------------------------------------------- M2: capacity 503
+
+
+def _end_session(client: TestClient, sid: str, token: str) -> int:
+    return client.post(
+        f"/api/sessions/{sid}/end?token={token}",
+        json={"reason": "done"},
+    ).status_code
+
+
+def test_capacity_returns_503_with_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M2: a full repository maps to 503 + Retry-After (server full),
+    not 400 (bad request). The frontend renders its at-capacity card
+    off the 503."""
+
+    monkeypatch.setenv("MAX_SESSIONS", "1")
+    # Don't let the create-rate limiter mask the capacity path.
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "0")
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        first = client.post("/api/sessions", json=_create_body())
+        assert first.status_code == 200, first.text
+        # Second create — repo is full (1 LIVE session).
+        second = client.post("/api/sessions", json=_create_body())
+        assert second.status_code == 503, second.text
+        assert second.headers.get("Retry-After") == "30"
+        assert "capacity" in second.json()["detail"].lower()
+
+
+def test_ending_a_session_frees_a_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M2: ENDED sessions no longer count toward MAX_SESSIONS — ending
+    one immediately frees capacity for a new create (the tombstone
+    lingers for GC but doesn't hold a slot)."""
+
+    monkeypatch.setenv("MAX_SESSIONS", "1")
+    monkeypatch.setenv("SESSION_CREATE_RATE_PER_MIN", "0")
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        first = client.post("/api/sessions", json=_create_body()).json()
+        sid, token = first["session_id"], first["creator_token"]
+        # Full → 503.
+        assert client.post("/api/sessions", json=_create_body()).status_code == 503
+        # End the first session.
+        assert _end_session(client, sid, token) == 200
+        # Slot is free again.
+        retry = client.post("/api/sessions", json=_create_body())
+        assert retry.status_code == 200, retry.text
+
+
+# ---------------------------------------------------------------- M5: security headers
+
+
+def _assert_security_headers(headers: Any) -> None:
+    assert headers["referrer-policy"] == "no-referrer"
+    assert headers["x-content-type-options"] == "nosniff"
+    assert headers["x-frame-options"] == "DENY"
+    assert headers["content-security-policy"] == DEFAULT_CSP
+
+
+def test_security_headers_on_normal_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        r = client.get("/api/invite/status")
+        assert r.status_code == 200
+        _assert_security_headers(r.headers)
+
+
+def test_security_headers_on_healthz(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.get("/healthz")
+        assert r.status_code == 200
+        _assert_security_headers(r.headers)
+
+
+def test_security_headers_on_error_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headers ride EVERY response, including 4xx — a token-less
+    snapshot fetch 401s but must still carry no-referrer etc."""
+
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.get("/api/sessions/nope")
+        assert r.status_code == 401
+        _assert_security_headers(r.headers)
+
+
+def test_csp_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONTENT_SECURITY_POLICY", "default-src 'none'")
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.get("/healthz")
+        assert r.headers["content-security-policy"] == "default-src 'none'"
+
+
+# ---------------------------------------------------------------- M11: curated errors
+
+
+def test_unauthorized_snapshot_returns_curated_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bad token yields the curated 'invalid or expired token'
+    message, not the raw verifier internals."""
+
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        created = client.post("/api/sessions", json=_create_body()).json()
+        sid = created["session_id"]
+        r = client.get(f"/api/sessions/{sid}?token=garbage.token.value")
+        assert r.status_code == 401
+        assert r.json()["detail"] == "invalid or expired token"
+
+
+def test_curated_detail_logs_raw_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The curated client message hides the detail, but the raw
+    ``str(exc)`` must still hit the structlog line so operators can
+    debug from the log."""
+
+    reset_settings_cache()
+    app = create_app()
+    with TestClient(app) as client:
+        install_mock_chat_client(client)
+        created = client.post("/api/sessions", json=_create_body()).json()
+        sid = created["session_id"]
+        capsys.readouterr()  # drain create noise
+        r = client.get(f"/api/sessions/{sid}?token=garbage.token.value")
+        assert r.status_code == 401
+        out = capsys.readouterr().out
+        # The boundary log fires with the raw verifier detail.
+        assert "token_verify_failed" in out, out

--- a/backend/tests/test_invite_code.py
+++ b/backend/tests/test_invite_code.py
@@ -108,43 +108,40 @@ def test_invite_status_reports_not_required_when_env_unset(
     try:
         r = client.get("/api/invite/status")
         assert r.status_code == 200
-        assert r.json() == {"required": False, "valid": None}
+        # M7: ``valid`` was removed — the endpoint reports ONLY whether
+        # the gate is on, never verifies a candidate (that would be a
+        # brute-force oracle).
+        assert r.json() == {"required": False}
     finally:
         client.close()
 
 
-def test_invite_status_required_no_code_returns_required_only(
+def test_invite_status_required_returns_required_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _client(monkeypatch, code="tabletop-2026")
     try:
         r = client.get("/api/invite/status")
         assert r.status_code == 200
-        assert r.json() == {"required": True, "valid": None}
+        assert r.json() == {"required": True}
     finally:
         client.close()
 
 
-def test_invite_status_required_with_correct_code_returns_valid_true(
+def test_invite_status_never_reports_valid_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """M7 regression net: the oracle is gone. Even with a ``?code=``
+    query (which the handler now ignores), the response must never carry
+    a ``valid`` field — no online verification of a candidate."""
+
     client = _client(monkeypatch, code="tabletop-2026")
     try:
-        r = client.get("/api/invite/status", params={"code": "tabletop-2026"})
-        assert r.status_code == 200
-        assert r.json() == {"required": True, "valid": True}
-    finally:
-        client.close()
-
-
-def test_invite_status_required_with_wrong_code_returns_valid_false(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    client = _client(monkeypatch, code="tabletop-2026")
-    try:
-        r = client.get("/api/invite/status", params={"code": "wrong"})
-        assert r.status_code == 200
-        assert r.json() == {"required": True, "valid": False}
+        for code in ("tabletop-2026", "wrong"):
+            r = client.get("/api/invite/status", params={"code": code})
+            assert r.status_code == 200
+            assert r.json() == {"required": True}
+            assert "valid" not in r.json()
     finally:
         client.close()
 
@@ -220,45 +217,12 @@ def test_create_session_gated_empty_string_code_rejected(
         client.close()
 
 
-def test_create_session_status_endpoint_caps_query_length(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Defense against a no-rate-limit deployment getting
-    ``?code=<5MB>`` probes — the validator chains
-    ``hmac.compare_digest`` on the candidate and that's O(n)."""
-
-    client = _client(monkeypatch, code="tabletop-2026")
-    try:
-        oversized = "a" * 129
-        r = client.get("/api/invite/status", params={"code": oversized})
-        assert r.status_code == 422, r.text
-    finally:
-        client.close()
-
-
 # ---------------------------------------------------------------- logging contracts
 #
 # CLAUDE.md elevates "missing log line at a meaningful boundary" to a
 # must-fix even at LOW. These tests lock the WARNING level so a future
 # refactor can't silently demote them to INFO and disappear the only
 # brute-force breadcrumb on the audit trail.
-
-
-def test_invite_validate_rejected_emits_warning(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    client = _client(monkeypatch, code="tabletop-2026")
-    try:
-        r = client.get("/api/invite/status", params={"code": "wrong"})
-        assert r.status_code == 200
-        out = capsys.readouterr().out
-        assert "invite_validate_rejected" in out, out
-        # The code itself MUST NOT appear anywhere in the log line —
-        # not in the structlog event, not in the access-log path.
-        assert "wrong" not in out, out
-    finally:
-        client.close()
 
 
 def test_create_session_invite_rejected_emits_warning(

--- a/backend/tests/test_invitee_roles_setup.py
+++ b/backend/tests/test_invitee_roles_setup.py
@@ -293,3 +293,76 @@ def test_invitee_role_label_strips_control_chars(client: TestClient) -> None:
     assert resp.status_code == 200, resp.text
     # Every control byte stripped; surrounding whitespace .strip()'d.
     assert captured["labels"] == ["CISO", "Threat IntelFAKE: statechanged"]
+
+
+def test_invitee_failure_code_classifies_manager_messages() -> None:
+    """``_invitee_failure_code`` is a brittle-by-design substring
+    classifier over the manager's own ``IllegalTransitionError`` strings
+    (M11: the wire carries a stable enumerated token, never ``str(exc)``).
+    Pin every branch so a reworded manager message that would silently
+    reclassify to the ``error`` catch-all fails here instead of shipping
+    a wrong code to the wizard. The partial-failure e2e above only
+    exercises the ``limit_reached`` branch.
+    """
+
+    from app.api.routes import _invitee_failure_code
+    from app.sessions.turn_engine import IllegalTransitionError
+
+    # Roster-full → limit_reached. Both the cap message and the
+    # ENDED-session refusal map here.
+    assert (
+        _invitee_failure_code(IllegalTransitionError("max roles reached: 32"))
+        == "limit_reached"
+    )
+    assert (
+        _invitee_failure_code(
+            IllegalTransitionError("cannot add roles to an ENDED session")
+        )
+        == "limit_reached"
+    )
+    # Bad label → invalid_label ("blank" or "label" substring).
+    assert (
+        _invitee_failure_code(IllegalTransitionError("label must not be blank"))
+        == "invalid_label"
+    )
+    # Anything unrecognised collapses to the catch-all.
+    assert _invitee_failure_code(ValueError("disk on fire")) == "error"
+
+
+def test_invitee_duplicate_label_surfaces_duplicate_reason(
+    client: TestClient,
+) -> None:
+    """An invitee whose label collides (case-insensitively) with an
+    already-seated label is benign — the row is dropped, the create still
+    200s, and the drop is echoed in ``failed_invitees`` with the stable
+    ``duplicate`` code so the wizard can collapse it. Pins the inline
+    de-dup branch (the only producer of ``duplicate``), which the
+    roster-ordering test exercised but never asserted on the wire.
+    """
+
+    async def fake_run_setup_turn(self, *, session: Session) -> Session:  # type: ignore[no-untyped-def]
+        return session
+
+    with patch(
+        "app.sessions.turn_driver.TurnDriver.run_setup_turn",
+        new=fake_run_setup_turn,
+    ):
+        resp = client.post(
+            "/api/sessions",
+            json={
+                "scenario_prompt": "seed",
+                "creator_label": "CISO",
+                "creator_display_name": "Alex",
+                "invitee_roles": [
+                    {"label": "Incident Commander"},
+                    # Case-insensitive collision with the creator's seat.
+                    {"label": "ciso"},
+                ],
+                **default_settings_body(),
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    failed = resp.json()["failed_invitees"]
+    assert len(failed) == 1
+    assert failed[0]["reason"] == "duplicate"
+    assert failed[0]["label"].lower() == "ciso"

--- a/backend/tests/test_invitee_roles_setup.py
+++ b/backend/tests/test_invitee_roles_setup.py
@@ -213,8 +213,11 @@ def test_invitee_roles_partial_failure_surfaces_in_response(
     # Patch ``manager.add_role`` to raise ``IllegalTransitionError``
     # for one specific label so we can verify the create call still
     # 200s, the OK invitees land in the response context, and the
-    # failed one is echoed in ``failed_invitees`` with the
-    # exception text.
+    # failed one is echoed in ``failed_invitees`` with a structured,
+    # enumerated reason code (M11 / CWE-209 — the wire carries a stable
+    # token, never the raw ``str(exc)``). We raise the manager's own
+    # roster-full message so ``_invitee_failure_code`` classifies it as
+    # ``limit_reached`` — the realistic "cap hit" path this test names.
     from app.sessions.manager import SessionManager
     from app.sessions.turn_engine import IllegalTransitionError
 
@@ -222,7 +225,7 @@ def test_invitee_roles_partial_failure_surfaces_in_response(
 
     async def patched_add_role(self, *, session_id, label, **kw):  # type: ignore[no-untyped-def]
         if label == "Doomed Role":
-            raise IllegalTransitionError("simulated cap hit")
+            raise IllegalTransitionError("max roles reached for this session")
         return await real_add_role(self, session_id=session_id, label=label, **kw)
 
     monkeypatch.setattr(SessionManager, "add_role", patched_add_role)
@@ -253,7 +256,9 @@ def test_invitee_roles_partial_failure_surfaces_in_response(
     failed = body["failed_invitees"]
     assert len(failed) == 1
     assert failed[0]["label"] == "Doomed Role"
-    assert "simulated cap hit" in failed[0]["reason"]
+    # M11 alert-#5: the reason is now a stable enumerated code, not the
+    # raw exception text. A roster-full failure maps to "limit_reached".
+    assert failed[0]["reason"] == "limit_reached"
 
 
 def test_invitee_role_label_strips_control_chars(client: TestClient) -> None:

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -21,7 +21,7 @@ from typing import Any
 import pytest
 
 from app.config import Settings
-from app.rate_limit import RateLimitMiddleware, _client_ip
+from app.rate_limit import RateLimitMiddleware, resolve_client_ip
 
 # ---------------------------------------------------------------- helpers
 
@@ -222,47 +222,116 @@ async def test_ws_burst_closes_with_4429() -> None:
     assert closes[0]["code"] == 4429
 
 
-# ---------------------------------------------------------------- _client_ip parsing
+# ----------------------------------------------- resolve_client_ip (H7 hardening)
 
 
-def test_client_ip_prefers_xff_first_value() -> None:
+def _ip_settings(*, trust: bool = False, proxies: str = "") -> Settings:
+    return Settings(
+        LLM_API_KEY="x",
+        SESSION_SECRET="x" * 32,
+        TRUST_FORWARDED_FOR=trust,
+        TRUSTED_PROXIES=proxies,
+    )
+
+
+def test_resolve_client_ip_ignores_xff_by_default() -> None:
+    """H7: with TRUST_FORWARDED_FOR off (default), a spoofed XFF is
+    ignored entirely — we key on the socket peer. This is the core
+    anti-spoof property."""
+
     scope = {
         "client": ["10.10.10.10", 9000],
-        "headers": [(b"x-forwarded-for", b"203.0.113.7, 10.0.0.1")],
+        "headers": [(b"x-forwarded-for", b"203.0.113.7, 1.2.3.4")],
     }
-    assert _client_ip(scope) == "203.0.113.7"
+    assert resolve_client_ip(scope, _ip_settings()) == "10.10.10.10"
 
 
-def test_client_ip_falls_back_to_scope_client_when_no_xff() -> None:
-    scope = {"client": ["192.168.0.1", 9000], "headers": []}
-    assert _client_ip(scope) == "192.168.0.1"
-
-
-def test_client_ip_returns_unknown_when_no_client() -> None:
-    scope = {"client": None, "headers": []}
-    assert _client_ip(scope) == "unknown"
-
-
-def test_client_ip_handles_malformed_xff_bytes() -> None:
-    """Production has seen the proxy attach garbage bytes here; we
-    must fall through to the scope's ``client`` rather than 500-ing."""
+def test_resolve_client_ip_ignores_xff_when_peer_not_trusted() -> None:
+    """Trusting XFF is enabled, but the immediate peer is NOT a trusted
+    proxy → the header is a direct-client forgery and must be ignored."""
 
     scope = {
-        "client": ["10.0.0.5", 9000],
-        # Invalid UTF-8 — split() fires on the bytes after .decode("ascii"),
-        # which raises UnicodeDecodeError. Caller falls through.
+        "client": ["8.8.8.8", 9000],  # not in TRUSTED_PROXIES
+        "headers": [(b"x-forwarded-for", b"203.0.113.7")],
+    }
+    settings = _ip_settings(trust=True, proxies="10.0.0.0/8")
+    assert resolve_client_ip(scope, settings) == "8.8.8.8"
+
+
+def test_resolve_client_ip_honors_xff_from_trusted_proxy_rightmost() -> None:
+    """When the peer is a trusted proxy, walk XFF right-to-left and take
+    the first untrusted hop — the real client the outermost trusted
+    proxy observed. A client-prepended junk entry on the left is
+    ignored."""
+
+    scope = {
+        "client": ["10.0.0.7", 9000],  # trusted proxy
+        # Client forged "1.1.1.1" on the far left; "10.0.0.9" is an
+        # internal trusted hop; "203.0.113.7" is the real client edge.
+        "headers": [
+            (b"x-forwarded-for", b"1.1.1.1, 203.0.113.7, 10.0.0.9"),
+        ],
+    }
+    settings = _ip_settings(trust=True, proxies="10.0.0.0/8")
+    assert resolve_client_ip(scope, settings) == "203.0.113.7"
+
+
+def test_resolve_client_ip_single_hop_from_trusted_proxy() -> None:
+    scope = {
+        "client": ["10.0.0.7", 9000],
+        "headers": [(b"x-forwarded-for", b"203.0.113.7")],
+    }
+    settings = _ip_settings(trust=True, proxies="10.0.0.7")
+    assert resolve_client_ip(scope, settings) == "203.0.113.7"
+
+
+def test_resolve_client_ip_all_trusted_falls_back_to_peer() -> None:
+    """If every XFF entry is itself a trusted proxy, there's no real
+    client hop to extract — fall back to the peer."""
+
+    scope = {
+        "client": ["10.0.0.7", 9000],
+        "headers": [(b"x-forwarded-for", b"10.0.0.8, 10.0.0.9")],
+    }
+    settings = _ip_settings(trust=True, proxies="10.0.0.0/8")
+    assert resolve_client_ip(scope, settings) == "10.0.0.7"
+
+
+def test_resolve_client_ip_returns_unknown_when_no_client() -> None:
+    scope = {"client": None, "headers": []}
+    assert resolve_client_ip(scope, _ip_settings()) == "unknown"
+
+
+def test_resolve_client_ip_handles_malformed_xff_bytes() -> None:
+    """Garbage bytes in XFF must fall through to the peer, not 500."""
+
+    scope = {
+        "client": ["10.0.0.7", 9000],
         "headers": [(b"x-forwarded-for", b"\xff\xfe garbage")],
     }
-    assert _client_ip(scope) == "10.0.0.5"
+    settings = _ip_settings(trust=True, proxies="10.0.0.0/8")
+    assert resolve_client_ip(scope, settings) == "10.0.0.7"
 
 
-def test_client_ip_handles_empty_xff() -> None:
+def test_resolve_client_ip_empty_xff_from_trusted_peer() -> None:
     scope = {
-        "client": ["10.0.0.5", 9000],
+        "client": ["10.0.0.7", 9000],
         "headers": [(b"x-forwarded-for", b"")],
     }
-    # Empty xff is falsy — falls through to scope.client.
-    assert _client_ip(scope) == "10.0.0.5"
+    settings = _ip_settings(trust=True, proxies="10.0.0.0/8")
+    assert resolve_client_ip(scope, settings) == "10.0.0.7"
+
+
+def test_resolve_client_ip_skips_malformed_trusted_proxy_cidr() -> None:
+    """A typo in TRUSTED_PROXIES must not crash resolution — the bad
+    entry is dropped and the good one still matches."""
+
+    scope = {
+        "client": ["10.0.0.7", 9000],
+        "headers": [(b"x-forwarded-for", b"203.0.113.7")],
+    }
+    settings = _ip_settings(trust=True, proxies="not-an-ip, 10.0.0.0/8")
+    assert resolve_client_ip(scope, settings) == "203.0.113.7"
 
 
 # ---------------------------------------------------------------- concurrency

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -21,7 +21,11 @@ from typing import Any
 import pytest
 
 from app.config import Settings
-from app.rate_limit import RateLimitMiddleware, resolve_client_ip
+from app.rate_limit import (
+    RateLimitMiddleware,
+    SessionCreateRateLimiter,
+    resolve_client_ip,
+)
 
 # ---------------------------------------------------------------- helpers
 
@@ -204,6 +208,37 @@ async def test_bucket_refills_over_time(monkeypatch: pytest.MonkeyPatch) -> None
         await mw(_http_scope(), receive=lambda: None, send=send2)  # type: ignore[arg-type]
     statuses2 = [ev["status"] for ev in send2.events if ev.get("type") == "http.response.start"]
     assert statuses2 == [200, 200, 200]
+
+
+@pytest.mark.asyncio
+async def test_session_create_limiter_refills_over_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dedicated create limiter (audit C1) shares the token-bucket
+    refill math with the middleware: faking monotonic time fully refills
+    its per-IP bucket after a minute idle. The HTTP-layer 429 + Retry-After
+    path is covered in ``test_http_edge_hardening``; this pins the refill
+    directly so a regression in the create limiter's own consume/refill
+    loop (it's a separate class from the middleware) fails here."""
+
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: fake_now["t"])
+
+    limiter = SessionCreateRateLimiter(
+        Settings(
+            LLM_API_KEY="x",
+            SESSION_SECRET="x" * 32,
+            SESSION_CREATE_RATE_PER_MIN=3,
+        )
+    )
+    scope = _http_scope()
+    # Drain the full 3-token bucket; the 4th request is refused.
+    assert [await limiter.check(scope) for _ in range(3)] == [True, True, True]
+    assert await limiter.check(scope) is False
+    # Idle 60s → full refill → allowed again, then refused again.
+    fake_now["t"] += 60.0
+    assert [await limiter.check(scope) for _ in range(3)] == [True, True, True]
+    assert await limiter.check(scope) is False
 
 
 # ---------------------------------------------------------------- 4429 path (WS)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,10 +160,42 @@ Defaults preserve historical behavior so unset = no change.
 | Var | Default | Effect |
 |---|---|---|
 | `SESSION_SECRET` | randomly generated at startup (warn) | HMAC key for join tokens. **Set explicitly for any non-toy deploy.** |
-| `CORS_ORIGINS` | `*` | Comma-separated allowlist. **Set explicitly before going public.** |
-| `RATE_LIMIT_ENABLED` | `false` | Toggle the rate-limit middleware |
-| `RATE_LIMIT_REQ_PER_MIN` | `60` | Per-IP request cap when enabled |
-| `INVITE_CODE` | unset (no gate) | Soft anti-strangers gate on `POST /api/sessions`. When set to a non-empty value, the creator must supply a matching code on the wizard's invite gate before a session can be created; the wizard caches a validated code in `localStorage` so refreshes don't re-prompt. Player join links don't need it — they already carry per-role HMAC tokens. This is NOT a security boundary; it's a stopgap so a public-URL deploy doesn't burn LLM tokens on every drive-by. **Pair with `RATE_LIMIT_ENABLED=true`** so a brute-forcer can't grind through the code via the cheap `GET /api/invite/status?code=…` probe or the heavier `POST /api/sessions` path. Comparison is constant-time and surrounding whitespace is stripped so a copy-paste with a trailing newline still matches. The value is redacted from access logs and the browser-console request wrapper. App emits `invite_code_gate_enabled` at boot (or `invite_code_set_without_rate_limit` WARNING if the rate-limit middleware isn't on). |
+| `CORS_ORIGINS` | `*` | Comma-separated allowlist. **Set explicitly before going public.** Narrowing it away from `*` marks the deploy as "real" and arms the C1 front-door boot gate (see below). |
+| `RATE_LIMIT_ENABLED` | `false` | Toggle the general per-IP rate-limit middleware (covers all routes except `/healthz` / `/readyz`). |
+| `RATE_LIMIT_REQ_PER_MIN` | `60` | Per-IP request cap for the general middleware when enabled. |
+| `SESSION_CREATE_RATE_PER_MIN` | `5` | **Dedicated** per-IP token bucket on `POST /api/sessions` (security audit C1), independent of `RATE_LIMIT_REQ_PER_MIN` and applied **regardless of `RATE_LIMIT_ENABLED`**. Session creation is the costliest request (each one fires a setup-tier LLM call), so it's always throttled. Past the cap the route returns **429 + `Retry-After: 60`**. Set `0` to disable — only safe behind an `INVITE_CODE` gate or an upstream WAF (and the C1 boot gate will refuse to start a non-local deploy that has neither). Keyed on the hardened client-IP resolver (see `TRUST_FORWARDED_FOR`). |
+| `TRUST_FORWARDED_FOR` | `false` | Whether to trust the `X-Forwarded-For` header for client-IP resolution in the rate limiters (security audit H7). **Off by default**: the limiters key on the socket peer, so a direct client can't spoof XFF to mint a fresh per-IP bucket. Turn on **only** behind a reverse proxy you control that **overwrites** (not appends) XFF, and list that proxy in `TRUSTED_PROXIES`. When on, the resolver walks XFF right-to-left, skips trusted hops, and takes the first untrusted entry as the real client; an XFF arriving from an untrusted immediate peer is ignored. |
+| `TRUSTED_PROXIES` | unset (empty) | Comma-separated IPs / CIDRs of the reverse proxies whose `X-Forwarded-For` is trusted (security audit H7). Consulted only when `TRUST_FORWARDED_FOR=true`. Both single addresses (`10.0.0.7`) and ranges (`10.0.0.0/8`, `2001:db8::/32`) work (stdlib `ipaddress`). A malformed entry is logged (`trusted_proxy_parse_failed`) and skipped. The immediate socket peer must match this set before any XFF entry is honoured. |
+| `CONTENT_SECURITY_POLICY` | unset (hardened default) | Override for the response `Content-Security-Policy` header (security audit M5). Empty ships the self-hosted-only default: `default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'`. Set this only if a deploy genuinely needs a looser policy — the default is intentionally external-asset-free so air-gapped / strict-CSP security-team deploys work out of the box. |
+| `INVITE_CODE` | unset (no gate) | Soft anti-strangers gate on `POST /api/sessions`. When set to a non-empty value, the creator must supply a matching code on the wizard's invite gate before a session can be created; the wizard caches a validated code in `localStorage` so refreshes don't re-prompt. Player join links don't need it — they already carry per-role HMAC tokens. This is NOT a security boundary; it's a stopgap so a public-URL deploy doesn't burn LLM tokens on every drive-by. The code is validated **inline on `POST /api/sessions`** (403 on mismatch); there is **no `?code=` verification on `GET /api/invite/status`** — that endpoint returns only `{"required": bool}` so it can't be used as a brute-force oracle (security audit M7). Comparison is constant-time and surrounding whitespace is stripped so a copy-paste with a trailing newline still matches. The value is redacted from access logs and the browser-console request wrapper. App emits `invite_code_gate_enabled` at boot. |
+
+> **Security headers (M5).** Every HTTP response (API, SPA fallback,
+> static assets, error responses, `/healthz`) carries
+> `Referrer-Policy: no-referrer` (the priority — the per-role join token
+> rides in the URL path, so this stops Referer leakage),
+> `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and the
+> `Content-Security-Policy` above.
+
+> **Front-door boot gate (C1).** On a real deploy (`CORS_ORIGINS != "*"`),
+> the app **refuses to start** unless `POST /api/sessions` has some
+> protection — either `INVITE_CODE` set, or `SESSION_CREATE_RATE_PER_MIN`
+> non-zero (the default 5 satisfies this). With neither, `create_app`
+> raises at import time (uvicorn exits non-zero) rather than booting an
+> exposed deploy where anonymous callers can loop session creation and
+> burn setup-tier LLM tokens. Local deploys (`CORS_ORIGINS="*"`) are
+> exempt. The pass case logs `session_create_front_door_ok`.
+
+> **Rate-limit proxy requirement & multi-worker note.** The per-IP
+> limiters only resolve a trustworthy client IP behind a proxy that
+> **overwrites** `X-Forwarded-For` (e.g. Cloudflare, a correctly-
+> configured nginx `proxy_set_header X-Forwarded-For $remote_addr`) — a
+> proxy that *appends* lets a client prepend a forged left-most hop.
+> Both limiters keep their token buckets **in-process**, so a
+> multi-worker / horizontally-scaled deploy gets one bucket *per worker*
+> (effective cap = configured cap × workers). The Phase-3 Redis backend
+> replaces the in-memory buckets with a shared store for a coherent
+> cross-worker view; until then, prefer a single worker if the per-IP
+> cap must be exact.
 
 ## Extensions
 
@@ -177,8 +209,17 @@ Defaults preserve historical behavior so unset = no change.
 ## Before going public — hardening checklist
 
 1. Set `SESSION_SECRET` to a long random value (minimum 32 bytes).
-2. Set `CORS_ORIGINS` to your actual origin(s).
-3. Set `RATE_LIMIT_ENABLED=true` and tune `RATE_LIMIT_REQ_PER_MIN`.
-4. Restrict the GHCR image's port exposure to the reverse proxy only.
-5. Front the container with a TLS-terminating proxy (Caddy / Cloudflare / etc.).
-6. Confirm `LLM_API_KEY` is supplied via the runtime secret store, not baked in.
+2. Set `CORS_ORIGINS` to your actual origin(s). (This also arms the C1
+   front-door boot gate — the app won't start without a create-path
+   protection once CORS is narrowed.)
+3. Set `RATE_LIMIT_ENABLED=true` and tune `RATE_LIMIT_REQ_PER_MIN`. The
+   dedicated `SESSION_CREATE_RATE_PER_MIN` create-path throttle is on by
+   default (cap 5); tune or pair with `INVITE_CODE`.
+4. If behind a proxy that overwrites `X-Forwarded-For`, set
+   `TRUST_FORWARDED_FOR=true` and `TRUSTED_PROXIES` to the proxy's
+   egress IP(s)/CIDR(s) so per-IP limits key on the real client. Leave
+   both unset if clients hit the app directly.
+5. Restrict the GHCR image's port exposure to the reverse proxy only.
+6. Front the container with a TLS-terminating proxy (Caddy / Cloudflare / etc.)
+   that **overwrites** (not appends) `X-Forwarded-For`.
+7. Confirm `LLM_API_KEY` is supplied via the runtime secret store, not baked in.

--- a/frontend/src/__tests__/Facilitator.atCapacity.test.tsx
+++ b/frontend/src/__tests__/Facilitator.atCapacity.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Tests for the "at capacity" (HTTP 503) handling on session creation.
+ *
+ * When ``POST /api/sessions`` comes back 503 (the server has hit its
+ * live-session cap), <Facilitator/> must render a distinct, on-brand
+ * "at capacity" card instead of the generic red error line, mention the
+ * ``Retry-After`` wait when the header is present, and let the operator
+ * RETRY back into the wizard (draft intact). A non-503 failure must keep
+ * the existing generic-error path.
+ *
+ * The WS module is stubbed because the test stays on the intro phase and
+ * never opens a session, but the connect effect constructs ``WsClient``
+ * regardless.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/ws", () => {
+  return {
+    WsClient: class {
+      connect() {
+        /* no-op */
+      }
+      close() {
+        /* no-op */
+      }
+      send() {
+        /* no-op */
+      }
+    },
+  };
+});
+
+import { api, ApiError } from "../api/client";
+import { Facilitator } from "../pages/Facilitator";
+import { INVITE_CODE_STORAGE_KEY } from "../lib/inviteCodeStorage";
+
+// The wizard splits creation across 3 steps; ROLL SESSION lives on
+// step 3. Walk there, then submit the form the button belongs to (the
+// same pattern Facilitator.intro.test.tsx uses to fire create).
+async function rollSession() {
+  fireEvent.click(
+    await screen.findByRole("button", { name: /NEXT · ENVIRONMENT/i }),
+  );
+  fireEvent.click(screen.getByRole("button", { name: /NEXT · ROLES/i }));
+  const rollBtn = await screen.findByRole("button", { name: /ROLL SESSION/i });
+  const form = rollBtn.closest("form");
+  if (!form) throw new Error("ROLL SESSION button not inside a form");
+  fireEvent.submit(form);
+}
+
+describe("Facilitator — at-capacity (503) handling", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    // No invite gate — go straight to the wizard.
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({ required: false });
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the at-capacity card (not a generic error) and names the Retry-After wait", async () => {
+    vi.spyOn(api, "createSession").mockRejectedValue(
+      new ApiError("Crittable is at capacity; try again shortly.", 503, 120),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(<Facilitator />);
+    await rollSession();
+
+    expect(
+      await screen.findByText(/Crittable is at capacity/i),
+    ).toBeInTheDocument();
+    // 120 s rounds up to "about 2 minutes".
+    expect(screen.getByText(/about 2 minutes/i)).toBeInTheDocument();
+    // The wizard's scenario textarea is gone — the card replaced it.
+    expect(
+      screen.queryByPlaceholderText(/What happened, when, at what severity/i),
+    ).not.toBeInTheDocument();
+    // Per the logging rules, the surfaced state also warns with context.
+    const warnText = warnSpy.mock.calls.flat().join(" ");
+    expect(warnText).toContain("create_session_at_capacity");
+  });
+
+  it("falls back to a generic wait when no Retry-After header was present", async () => {
+    vi.spyOn(api, "createSession").mockRejectedValue(
+      new ApiError("Crittable is at capacity; try again shortly.", 503, null),
+    );
+    render(<Facilitator />);
+    await rollSession();
+
+    expect(
+      await screen.findByText(/Crittable is at capacity/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/in a few minutes/i)).toBeInTheDocument();
+  });
+
+  it("RETRY dismisses the card and returns to the wizard with the draft intact", async () => {
+    vi.spyOn(api, "createSession").mockRejectedValue(
+      new ApiError("at capacity", 503, 30),
+    );
+    render(<Facilitator />);
+    // Type into the scenario brief so we can prove the draft survives.
+    const scenario = await screen.findByLabelText(/SCENARIO BRIEF/i);
+    fireEvent.change(scenario, { target: { value: "Ransomware drill" } });
+    await rollSession();
+
+    const retry = await screen.findByRole("button", {
+      name: /back to setup · retry/i,
+    });
+    fireEvent.click(retry);
+
+    // Back on the wizard. ROLL SESSION is on step 3, where the submit
+    // left us, and the scenario value is preserved (navigate back to
+    // step 1 to read it).
+    expect(
+      await screen.findByRole("button", { name: /ROLL SESSION/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Crittable is at capacity/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the generic-error path for a non-503 failure (no capacity card)", async () => {
+    vi.spyOn(api, "createSession").mockRejectedValue(
+      new ApiError("Boom: internal server error", 500, null),
+    );
+    render(<Facilitator />);
+    await rollSession();
+
+    // Generic error surfaces inline on the wizard; no capacity card.
+    expect(await screen.findByText(/Boom: internal server error/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Crittable is at capacity/i),
+    ).not.toBeInTheDocument();
+    // Still on the wizard (ROLL SESSION reachable).
+    expect(
+      screen.getByRole("button", { name: /ROLL SESSION/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("re-prompts the invite gate on a 403 (stale-code path still works)", async () => {
+    // Gate on this time; carry a stored code, then 403 on create.
+    window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, "old-code");
+    vi.spyOn(api, "getInviteStatus").mockResolvedValue({ required: true });
+    vi.spyOn(api, "createSession").mockRejectedValue(
+      new ApiError("invite code rejected", 403, null),
+    );
+    render(<Facilitator />);
+    // Stored code skips the gate → wizard. Roll → 403 → gate returns.
+    await rollSession();
+    expect(await screen.findByLabelText(/invite code/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/no longer valid/i),
+    ).toBeInTheDocument();
+    // Not the capacity card.
+    expect(
+      screen.queryByText(/Crittable is at capacity/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Facilitator.intro.test.tsx
+++ b/frontend/src/__tests__/Facilitator.intro.test.tsx
@@ -37,7 +37,6 @@ describe("Facilitator intro — Roles step (issue #61, redesign)", () => {
     });
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
       required: false,
-      valid: null,
     });
   });
 
@@ -266,7 +265,6 @@ describe("Facilitator intro — refresh recovery", () => {
   beforeEach(() => {
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
       required: false,
-      valid: null,
     });
   });
 

--- a/frontend/src/__tests__/Facilitator.inviteGate.test.tsx
+++ b/frontend/src/__tests__/Facilitator.inviteGate.test.tsx
@@ -5,11 +5,10 @@
  *
  * - The wizard does NOT render while the mount-time probe is in flight.
  * - The wizard renders when the server reports the gate is off.
- * - A returning visitor with a stored + still-valid code skips the
- *   gate entirely (no wizard-filling-then-bouncing UX from the
- *   user-agent review HIGH-1).
- * - A returning visitor with a stored + invalid code lands on the
- *   gate (stored value cleared) without filling the wizard first.
+ * - A returning visitor with ANY stored code skips the gate (the code
+ *   is carried forward optimistically; a stale one is rejected at
+ *   create time, not by a mount-time oracle — that oracle was removed
+ *   server-side). The stored value is preserved, not cleared.
  * - A first-time visitor on a gated deploy lands on the gate.
  *
  * The WS module is stubbed because the test stays on the intro phase
@@ -69,7 +68,6 @@ describe("Facilitator — invite-code probe orchestration", () => {
   it("renders the wizard when the server reports no gate", async () => {
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
       required: false,
-      valid: null,
     });
     render(<Facilitator />);
     expect(
@@ -82,7 +80,6 @@ describe("Facilitator — invite-code probe orchestration", () => {
   it("renders the gate (not the wizard) on a first-time visit to a gated deploy", async () => {
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
       required: true,
-      valid: null,
     });
     render(<Facilitator />);
     expect(
@@ -93,11 +90,15 @@ describe("Facilitator — invite-code probe orchestration", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("skips the gate for a returning visitor whose stored code is still valid", async () => {
+  it("skips the gate (and preserves the stored code) for a returning visitor on a gated deploy", async () => {
+    // Post-oracle-removal: the mount probe only reports ``required``,
+    // so ANY stored code is carried forward optimistically and the gate
+    // is skipped. A stale code is no longer caught here — it's rejected
+    // at create time (covered in the create-403 path), where the user
+    // is re-prompted. The stored value is NOT cleared on mount.
     window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, "tabletop-2026");
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
       required: true,
-      valid: true,
     });
     render(<Facilitator />);
     expect(
@@ -109,22 +110,22 @@ describe("Facilitator — invite-code probe orchestration", () => {
     expect(readStoredInviteCode()).toBe("tabletop-2026");
   });
 
-  it("clears storage + shows the gate when a returning visitor's stored code is no longer valid", async () => {
-    // The user-agent review HIGH-1 — a returning visitor with a
-    // rotated-since-last-visit code MUST NOT fill out the wizard
-    // first. The revalidation lives at the Facilitator probe.
-    window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, "old-code");
+  it("clears the stored code and shows the wizard when the gate is off", async () => {
+    // When the server reports no gate, a leftover stored code is
+    // dropped so a later flip back to gated can't accept a now-
+    // untrusted value. (This is the one mount-time path that still
+    // clears storage; the invalid-code clear moved to the create-403
+    // handler.)
+    window.localStorage.setItem(INVITE_CODE_STORAGE_KEY, "leftover");
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
-      required: true,
-      valid: false,
+      required: false,
     });
     render(<Facilitator />);
     expect(
-      await screen.findByLabelText(/invite code/i),
+      await screen.findByPlaceholderText(
+        /What happened, when, at what severity/i,
+      ),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText(/What happened, when, at what severity/i),
-    ).not.toBeInTheDocument();
     await waitFor(() => {
       expect(readStoredInviteCode()).toBeNull();
     });

--- a/frontend/src/__tests__/Facilitator.looksReady.test.tsx
+++ b/frontend/src/__tests__/Facilitator.looksReady.test.tsx
@@ -120,7 +120,6 @@ describe("Facilitator — handleLooksReady doesn't auto-finalize (regression)", 
     // already polls, so an explicit mock is simpler.
     vi.spyOn(api, "getInviteStatus").mockResolvedValue({
       required: false,
-      valid: null,
     });
   });
 

--- a/frontend/src/__tests__/InviteGate.test.tsx
+++ b/frontend/src/__tests__/InviteGate.test.tsx
@@ -1,14 +1,17 @@
 /**
  * Component tests for the soft anti-strangers invite gate.
  *
- * Pins the contract <Facilitator/> depends on: the user can submit a
- * code, the submit path revalidates against ``api.getInviteStatus``,
- * valid codes persist to localStorage + call ``onValidated``, invalid
- * ones surface an inline error without storing anything, and a
- * ``staleNotice`` prop renders the operator-rotated-code recovery
- * banner. The stored-code revalidation on mount is <Facilitator/>'s
- * responsibility (covered in ``Facilitator.intro.test.tsx``), not
- * the gate's — keeping it here would split the source of truth.
+ * Pins the contract <Facilitator/> depends on AFTER the invite-status
+ * oracle removal: the user can submit a code, a non-empty code is
+ * persisted to localStorage and handed up via ``onValidated`` WITHOUT a
+ * pre-validation probe (the match oracle was removed server-side — the
+ * code is validated on the create-session call instead), an empty /
+ * whitespace-only code is blocked inline, and a ``staleNotice`` prop
+ * renders the operator-rotated-code recovery banner.
+ *
+ * The mount-time probe + the create-time 403 re-prompt are
+ * <Facilitator/>'s responsibility (covered in Facilitator.inviteGate /
+ * Facilitator.atCapacity tests), not the gate's.
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,12 +29,10 @@ describe("InviteGate", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls onValidated and persists the code when the server accepts it", async () => {
+  it("persists the code and calls onValidated without probing the server", async () => {
     const onValidated = vi.fn();
-    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
-      required: true,
-      valid: true,
-    });
+    // The gate must NOT hit the status endpoint on submit anymore.
+    const probe = vi.spyOn(api, "getInviteStatus");
     render(<InviteGate onValidated={onValidated} />);
 
     fireEvent.change(screen.getByLabelText(/invite code/i), {
@@ -43,29 +44,25 @@ describe("InviteGate", () => {
       expect(onValidated).toHaveBeenCalledWith("tabletop-2026");
     });
     expect(readStoredInviteCode()).toBe("tabletop-2026");
+    expect(probe).not.toHaveBeenCalled();
   });
 
-  it("surfaces an inline error and does not persist when the server rejects", async () => {
+  it("trims surrounding whitespace before persisting and handing up", async () => {
     const onValidated = vi.fn();
-    vi.spyOn(api, "getInviteStatus").mockResolvedValue({
-      required: true,
-      valid: false,
-    });
     render(<InviteGate onValidated={onValidated} />);
 
     fireEvent.change(screen.getByLabelText(/invite code/i), {
-      target: { value: "wrong" },
+      target: { value: "  tabletop-2026  " },
     });
     fireEvent.click(screen.getByRole("button", { name: /continue/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent(/didn't match/i);
+      expect(onValidated).toHaveBeenCalledWith("tabletop-2026");
     });
-    expect(onValidated).not.toHaveBeenCalled();
-    expect(readStoredInviteCode()).toBeNull();
+    expect(readStoredInviteCode()).toBe("tabletop-2026");
   });
 
-  it("blocks submit on an empty / whitespace-only code without probing the server", async () => {
+  it("blocks submit on an empty / whitespace-only code without storing or handing up", async () => {
     const onValidated = vi.fn();
     const probe = vi.spyOn(api, "getInviteStatus");
     render(<InviteGate onValidated={onValidated} />);
@@ -77,22 +74,6 @@ describe("InviteGate", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent(/enter the invite code/i);
     expect(probe).not.toHaveBeenCalled();
-    expect(onValidated).not.toHaveBeenCalled();
-  });
-
-  it("surfaces a network error instead of silently dropping the submit", async () => {
-    const onValidated = vi.fn();
-    vi.spyOn(api, "getInviteStatus").mockRejectedValue(new Error("boom"));
-    render(<InviteGate onValidated={onValidated} />);
-
-    fireEvent.change(screen.getByLabelText(/invite code/i), {
-      target: { value: "tabletop-2026" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent(/boom/);
-    });
     expect(onValidated).not.toHaveBeenCalled();
     expect(readStoredInviteCode()).toBeNull();
   });

--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -211,6 +211,78 @@ describe("api/client — request wrapper", () => {
     await expect(api.start("s1", "tok")).rejects.toThrow(/500/);
   });
 
+  it("parses a numeric Retry-After header onto ApiError.retryAfter (503 at-capacity)", async () => {
+    _mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ detail: "Crittable is at capacity; try again shortly." }),
+          {
+            status: 503,
+            headers: {
+              "content-type": "application/json",
+              "Retry-After": "30",
+            },
+          },
+        ),
+    );
+    const err = (await api
+      .createSession({
+        scenario_prompt: "x",
+        creator_label: "CISO",
+        creator_display_name: "Alex",
+        settings: {
+          difficulty: "standard",
+          duration_minutes: 60,
+          features: {
+            active_adversary: true,
+            time_pressure: true,
+            executive_escalation: true,
+            media_pressure: false,
+          },
+        },
+      })
+      .catch((e) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(503);
+    expect(err.retryAfter).toBe(30);
+    expect(err.message).toMatch(/at capacity/i);
+  });
+
+  it("leaves ApiError.retryAfter null when the header is absent or non-numeric", async () => {
+    // Absent header → null.
+    _mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "nope" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const absent = (await api.start("s1", "tok").catch((e) => e)) as ApiError;
+    expect(absent.retryAfter).toBeNull();
+
+    // HTTP-date form (spec-legal but our server never sends it) → null,
+    // not a misleading number.
+    _mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "nope" }), {
+        status: 503,
+        headers: {
+          "content-type": "application/json",
+          "Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT",
+        },
+      }),
+    );
+    const dated = (await api.start("s1", "tok").catch((e) => e)) as ApiError;
+    expect(dated.retryAfter).toBeNull();
+  });
+
+  it("getInviteStatus probes the bare endpoint with no ?code= oracle query", async () => {
+    const fetchMock = _mockFetch(async () => _jsonResponse({ required: true }));
+    const status = await api.getInviteStatus();
+    expect(status).toEqual({ required: true });
+    const [path] = fetchMock.mock.calls[0]!;
+    expect(path).toBe("/api/invite/status");
+    expect(String(path)).not.toContain("code=");
+  });
+
   it("warns to console on a 4xx without exposing the raw token", async () => {
     _mockFetch(async () =>
       new Response(JSON.stringify({ detail: "nope" }), {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -279,10 +279,22 @@ function _scrub(path: string): string {
  */
 export class ApiError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  /**
+   * Parsed ``Retry-After`` header value in **seconds**, when the server
+   * sent one (it does on the 503 "at capacity" rejection from
+   * ``POST /api/sessions`` and on the 425 AAR-poll path). ``null`` when
+   * the header is absent or non-numeric. Callers branching on a 503 use
+   * this to tell the operator roughly how long to wait. This is a
+   * client-side error property, not a wire field — it's genuinely
+   * absent on the vast majority of errors, so optional here is correct
+   * (it is NOT a back-compat shim for an older backend).
+   */
+  retryAfter: number | null;
+  constructor(message: string, status: number, retryAfter: number | null = null) {
     super(message);
     this.name = "ApiError";
     this.status = status;
+    this.retryAfter = retryAfter;
   }
 }
 
@@ -349,6 +361,22 @@ function _formatErrorDetail(detail: unknown, status: number): string {
   return `${status}`;
 }
 
+/**
+ * Parse a ``Retry-After`` header into a non-negative integer number of
+ * seconds, or ``null`` when absent / non-numeric. The backend emits the
+ * delta-seconds form (``Retry-After: 30``) on its backpressure paths;
+ * the HTTP-date form is allowed by the spec but our server never sends
+ * it, so we don't parse it (and a stray date safely degrades to
+ * ``null`` rather than a misleading number).
+ */
+function _parseRetryAfter(raw: string | null): number | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const n = Number.parseInt(trimmed, 10);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
   const safePath = _scrub(path);
   console.debug(`[api] ${method} ${safePath}`, body ?? "");
@@ -367,8 +395,13 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     } catch {
       /* ignore */
     }
+    // ``Retry-After`` is a delta-seconds integer on the backpressure
+    // paths (503 at-capacity, 425 AAR-not-ready). Surface it on the
+    // error so a caller can tell the operator how long to wait without
+    // re-reading the response (which the wrapper has already consumed).
+    const retryAfter = _parseRetryAfter(res.headers.get("retry-after"));
     console.warn(`[api] ${method} ${safePath} → ${res.status} (${ms}ms)`, detail);
-    throw new ApiError(detail, res.status);
+    throw new ApiError(detail, res.status, retryAfter);
   }
   const out = (await res.json()) as T;
   console.debug(`[api] ${method} ${safePath} → ${res.status} (${ms}ms)`);
@@ -405,30 +438,30 @@ export const DEFAULT_SESSION_FEATURES: SessionFeatures = {
 };
 
 /** Shape returned by ``GET /api/invite/status``. ``required`` reflects
- *  whether the server has the ``INVITE_CODE`` env var set; ``valid``
- *  is ``null`` when no ``?code=`` was supplied or when no gate runs.
- *  The frontend hits this on the facilitator page mount to decide
- *  whether to show the gate UI, and again on submit to validate the
- *  user's entry without going through the heavier create-session
- *  path. */
+ *  whether the server has the ``INVITE_CODE`` env var set — that's the
+ *  *only* thing this endpoint reveals. The frontend hits it on the
+ *  facilitator page mount to decide whether to SHOW the invite-code
+ *  input.
+ *
+ *  The old ``valid`` field (a live "does this code match?" oracle) was
+ *  removed server-side: echoing match/no-match for an arbitrary
+ *  ``?code=`` turned the endpoint into a brute-force oracle. Code
+ *  validation now happens only on the authenticated, rate-limited
+ *  ``POST /api/sessions`` path, which returns 403 for a bad code. */
 export interface InviteStatus {
   required: boolean;
-  valid: boolean | null;
 }
 
 export const api = {
   /** Probe the soft anti-strangers gate.
    *
-   *  ``code`` is optional: without it, the response just says
-   *  whether the gate is on. With it, ``valid`` reports whether the
-   *  supplied code matches. The backend logs rejected probes at
-   *  WARNING so brute-force attempts surface in normal log scans;
-   *  the code is never logged. */
-  async getInviteStatus(code?: string): Promise<InviteStatus> {
-    const qs = code != null && code.length > 0
-      ? `?code=${encodeURIComponent(code)}`
-      : "";
-    return request("GET", `/api/invite/status${qs}`);
+   *  Returns only ``{ required }`` — whether the server has
+   *  ``INVITE_CODE`` set. There is no longer a code-match oracle here
+   *  (see ``InviteStatus``); the supplied code, if any, is not echoed
+   *  back as valid/invalid. We still call this with no argument from
+   *  the facilitator mount to decide whether to render the gate. */
+  async getInviteStatus(): Promise<InviteStatus> {
+    return request("GET", "/api/invite/status");
   },
 
   async createSession(body: {

--- a/frontend/src/components/InviteGate.tsx
+++ b/frontend/src/components/InviteGate.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, useId, useState } from "react";
 import { writeStoredInviteCode } from "../lib/inviteCodeStorage";
+import { CenteredCard } from "./brand/CenteredCard";
 import { Eyebrow } from "./brand/Eyebrow";
-import { SiteHeader } from "./brand/SiteHeader";
 
 /**
  * Soft anti-strangers gate rendered ahead of the facilitator wizard
@@ -20,8 +20,10 @@ import { SiteHeader } from "./brand/SiteHeader";
  *   3. We persist it via the ``inviteCodeStorage`` module and call
  *      ``onValidated(code)`` — there is no separate validation probe
  *      anymore. <Facilitator> threads that code into ``createSession``;
- *      a wrong code surfaces as a 403 on that authenticated call, at
- *      which point <Facilitator> clears storage and remounts us with a
+ *      a wrong code surfaces as a 403 on that create call (session
+ *      creation is the unauthenticated front door — invite-gated and
+ *      rate-limited, not token-authenticated), at which point
+ *      <Facilitator> clears storage and remounts us with a
  *      ``staleNotice`` so the user can re-enter the current code.
  *
  * The gate is intentionally NOT a security boundary against a
@@ -58,7 +60,8 @@ export function InviteGate({ onValidated, staleNotice }: Props) {
     // We persist the code and hand it up; <Facilitator> threads it into
     // ``POST /api/sessions``, where a wrong code comes back as a 403 and
     // <Facilitator> re-prompts us with a stale-code notice. This keeps
-    // brute-force attempts on the authenticated, rate-limited path.
+    // brute-force attempts on the rate-limited create path (invite-gated
+    // and per-IP throttled — not token-authenticated).
     setError(null);
     writeStoredInviteCode(trimmed);
     console.info("[invite] code entered; validation deferred to create");
@@ -66,163 +69,141 @@ export function InviteGate({ onValidated, staleNotice }: Props) {
   }
 
   return (
-    <main
-      className="grid min-h-screen grid-cols-1"
-      style={{ background: "var(--ink-900)" }}
-    >
-      <SiteHeader />
-      <section
-        className="flex flex-1 items-start justify-center overflow-auto p-5 lg:p-8"
-        style={{ minHeight: 0 }}
-      >
-        <div
-          className="flex flex-col gap-5"
+    <CenteredCard>
+      <header className="flex flex-col gap-2">
+        <Eyebrow>Access · Invite required</Eyebrow>
+        <h1
+          className="sans"
           style={{
-            width: "100%",
-            maxWidth: 480,
-            marginTop: "8vh",
-            padding: 24,
-            background: "var(--ink-800)",
-            border: "1px solid var(--ink-600)",
-            borderRadius: 4,
+            fontSize: 26,
+            fontWeight: 600,
+            color: "var(--ink-050)",
+            margin: 0,
+            letterSpacing: "-0.01em",
           }}
         >
-          <header className="flex flex-col gap-2">
-            <Eyebrow>Access · Invite required</Eyebrow>
-            <h1
-              className="sans"
-              style={{
-                fontSize: 26,
-                fontWeight: 600,
-                color: "var(--ink-050)",
-                margin: 0,
-                letterSpacing: "-0.01em",
-              }}
-            >
-              Enter your invite code to start a session
-            </h1>
-            <p
-              className="sans"
-              style={{
-                fontSize: 13,
-                color: "var(--ink-300)",
-                margin: 0,
-                lineHeight: 1.5,
-              }}
-            >
-              Session creation is gated. Paste your invite code below.
-              Already invited as a player? Use the link you were sent —
-              no code needed. Self-hosting? Check{" "}
-              <code
-                className="mono"
-                style={{
-                  background: "var(--ink-700)",
-                  padding: "1px 6px",
-                  borderRadius: 2,
-                  fontSize: 12,
-                  color: "var(--ink-100)",
-                }}
-              >
-                INVITE_CODE
-              </code>{" "}
-              in your backend env (unset to disable this gate). The
-              backend rate-limits invalid attempts.
-            </p>
-          </header>
-          {staleNotice ? (
-            <div
-              role="status"
-              className="sans"
-              style={{
-                fontSize: 12,
-                color: "var(--warn)",
-                background: "var(--warn-bg)",
-                border: "1px solid var(--warn)",
-                borderRadius: 2,
-                padding: "8px 10px",
-                lineHeight: 1.5,
-              }}
-            >
-              {staleNotice}
-            </div>
-          ) : null}
-          <form
-            onSubmit={handleSubmit}
-            className="flex flex-col gap-3"
-            noValidate
+          Enter your invite code to start a session
+        </h1>
+        <p
+          className="sans"
+          style={{
+            fontSize: 13,
+            color: "var(--ink-300)",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          Session creation is gated. Paste your invite code below.
+          Already invited as a player? Use the link you were sent —
+          no code needed. Self-hosting? Check{" "}
+          <code
+            className="mono"
+            style={{
+              background: "var(--ink-700)",
+              padding: "1px 6px",
+              borderRadius: 2,
+              fontSize: 12,
+              color: "var(--ink-100)",
+            }}
           >
-            <label
-              htmlFor={inputId}
-              className="mono"
-              style={{
-                fontSize: 11,
-                letterSpacing: "0.18em",
-                textTransform: "uppercase",
-                color: "var(--ink-300)",
-                fontWeight: 700,
-              }}
-            >
-              Invite code
-            </label>
-            <input
-              id={inputId}
-              name="invite_code"
-              type="text"
-              autoComplete="one-time-code"
-              autoFocus
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              spellCheck={false}
-              maxLength={128}
-              className="mono invite-input"
-              style={{
-                background: "var(--ink-700)",
-                color: "var(--ink-100)",
-                border: `1px solid ${error ? "var(--crit)" : "var(--ink-500)"}`,
-                borderRadius: 2,
-                padding: "10px 12px",
-                fontSize: 14,
-                letterSpacing: "0.04em",
-                outline: "none",
-              }}
-              aria-invalid={error ? true : undefined}
-              aria-describedby={error ? `${inputId}-error` : undefined}
-            />
-            {error ? (
-              <div
-                id={`${inputId}-error`}
-                role="alert"
-                className="sans"
-                style={{
-                  fontSize: 12,
-                  color: "var(--crit)",
-                }}
-              >
-                {error}
-              </div>
-            ) : null}
-            <button
-              type="submit"
-              className="mono invite-submit"
-              style={{
-                marginTop: 4,
-                padding: "10px 16px",
-                background: "var(--signal)",
-                color: "var(--ink-950)",
-                border: "1px solid var(--signal-deep)",
-                borderRadius: 2,
-                fontSize: 12,
-                fontWeight: 700,
-                letterSpacing: "0.12em",
-                textTransform: "uppercase",
-                cursor: "pointer",
-              }}
-            >
-              Continue
-            </button>
-          </form>
+            INVITE_CODE
+          </code>{" "}
+          in your backend env (unset to disable this gate). The
+          backend rate-limits invalid attempts.
+        </p>
+      </header>
+      {staleNotice ? (
+        <div
+          role="status"
+          className="sans"
+          style={{
+            fontSize: 12,
+            color: "var(--warn)",
+            background: "var(--warn-bg)",
+            border: "1px solid var(--warn)",
+            borderRadius: 2,
+            padding: "8px 10px",
+            lineHeight: 1.5,
+          }}
+        >
+          {staleNotice}
         </div>
-      </section>
-    </main>
+      ) : null}
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-3"
+        noValidate
+      >
+        <label
+          htmlFor={inputId}
+          className="mono"
+          style={{
+            fontSize: 11,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: "var(--ink-300)",
+            fontWeight: 700,
+          }}
+        >
+          Invite code
+        </label>
+        <input
+          id={inputId}
+          name="invite_code"
+          type="text"
+          autoComplete="one-time-code"
+          autoFocus
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          spellCheck={false}
+          maxLength={128}
+          className="mono invite-input"
+          style={{
+            background: "var(--ink-700)",
+            color: "var(--ink-100)",
+            border: `1px solid ${error ? "var(--crit)" : "var(--ink-500)"}`,
+            borderRadius: 2,
+            padding: "10px 12px",
+            fontSize: 14,
+            letterSpacing: "0.04em",
+            outline: "none",
+          }}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? `${inputId}-error` : undefined}
+        />
+        {error ? (
+          <div
+            id={`${inputId}-error`}
+            role="alert"
+            className="sans"
+            style={{
+              fontSize: 12,
+              color: "var(--crit)",
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+        <button
+          type="submit"
+          className="mono invite-submit"
+          style={{
+            marginTop: 4,
+            padding: "10px 16px",
+            background: "var(--signal)",
+            color: "var(--ink-950)",
+            border: "1px solid var(--signal-deep)",
+            borderRadius: 2,
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            cursor: "pointer",
+          }}
+        >
+          Continue
+        </button>
+      </form>
+    </CenteredCard>
   );
 }

--- a/frontend/src/components/InviteGate.tsx
+++ b/frontend/src/components/InviteGate.tsx
@@ -1,5 +1,4 @@
 import { type FormEvent, useId, useState } from "react";
-import { api } from "../api/client";
 import { writeStoredInviteCode } from "../lib/inviteCodeStorage";
 import { Eyebrow } from "./brand/Eyebrow";
 import { SiteHeader } from "./brand/SiteHeader";
@@ -12,19 +11,18 @@ import { SiteHeader } from "./brand/SiteHeader";
  * links don't need it because they already carry per-role HMAC tokens.
  *
  * Lifecycle:
- *   1. <Facilitator> probes ``api.getInviteStatus(storedCode)`` on
- *      mount. The single probe answers both "is the gate on?" and
- *      "is the stored code still valid?" — so a returning visitor
- *      with a rotated-since-last-visit code lands here directly,
- *      not after filling out the whole wizard.
- *   2. If the probe says required + invalid (or no stored code),
- *      <Facilitator> renders this component. The user pastes the
- *      code; we re-check via ``getInviteStatus(code)``.
- *   3. On ``valid: true`` we persist via the ``inviteCodeStorage``
- *      module and call ``onValidated(code)``. <Facilitator> threads
- *      that code into ``createSession`` and clears it from storage
- *      if the create call later 403s (the rotated-code recovery
- *      path; <Facilitator> remounts us with a ``staleNotice``).
+ *   1. <Facilitator> probes ``api.getInviteStatus()`` on mount. The
+ *      probe answers one thing — "is the gate on?". (It used to also
+ *      report whether a stored code matched, but that match oracle was
+ *      removed server-side; the endpoint no longer echoes validity.)
+ *   2. If the probe says required AND no code has been entered yet,
+ *      <Facilitator> renders this component. The user pastes the code.
+ *   3. We persist it via the ``inviteCodeStorage`` module and call
+ *      ``onValidated(code)`` — there is no separate validation probe
+ *      anymore. <Facilitator> threads that code into ``createSession``;
+ *      a wrong code surfaces as a 403 on that authenticated call, at
+ *      which point <Facilitator> clears storage and remounts us with a
+ *      ``staleNotice`` so the user can re-enter the current code.
  *
  * The gate is intentionally NOT a security boundary against a
  * motivated attacker — it's a stopgap so a public URL doesn't burn
@@ -33,7 +31,9 @@ import { SiteHeader } from "./brand/SiteHeader";
  */
 
 interface Props {
-  /** Called once the entered code is server-validated and stored. */
+  /** Called once a non-empty code is entered and stored. The code is
+   *  NOT pre-validated here (the match oracle was removed); validation
+   *  happens on the create-session call <Facilitator> makes next. */
   onValidated: (code: string) => void;
   /** Optional banner shown above the input — used by <Facilitator>
    *  on the stale-code-after-rotation recovery path so the user
@@ -44,43 +44,25 @@ interface Props {
 export function InviteGate({ onValidated, staleNotice }: Props) {
   const inputId = useId();
   const [code, setCode] = useState("");
-  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: FormEvent) {
+  function handleSubmit(e: FormEvent) {
     e.preventDefault();
     const trimmed = code.trim();
     if (trimmed.length === 0) {
       setError("Enter the invite code provided to you.");
+      console.warn("[invite] submit blocked: empty code");
       return;
     }
-    setBusy(true);
+    // No pre-validation probe: the match oracle was removed server-side.
+    // We persist the code and hand it up; <Facilitator> threads it into
+    // ``POST /api/sessions``, where a wrong code comes back as a 403 and
+    // <Facilitator> re-prompts us with a stale-code notice. This keeps
+    // brute-force attempts on the authenticated, rate-limited path.
     setError(null);
-    try {
-      const status = await api.getInviteStatus(trimmed);
-      if (!status.required) {
-        // Gate was removed server-side between mount and submit; let
-        // the user through and don't bother persisting a now-unused
-        // code.
-        onValidated(trimmed);
-        return;
-      }
-      if (status.valid !== true) {
-        setError(
-          "That code didn't match. Watch for stray spaces or look-alike characters (0/O, 1/l).",
-        );
-        return;
-      }
-      writeStoredInviteCode(trimmed);
-      onValidated(trimmed);
-    } catch (err) {
-      const detail =
-        err instanceof Error && err.message ? err.message : "Network error";
-      console.warn("[invite] validation failed", detail);
-      setError(`Couldn't reach the server (${detail}). Try again.`);
-    } finally {
-      setBusy(false);
-    }
+    writeStoredInviteCode(trimmed);
+    console.info("[invite] code entered; validation deferred to create");
+    onValidated(trimmed);
   }
 
   return (
@@ -190,7 +172,6 @@ export function InviteGate({ onValidated, staleNotice }: Props) {
               autoFocus
               value={code}
               onChange={(e) => setCode(e.target.value)}
-              disabled={busy}
               spellCheck={false}
               maxLength={128}
               className="mono invite-input"
@@ -222,23 +203,22 @@ export function InviteGate({ onValidated, staleNotice }: Props) {
             ) : null}
             <button
               type="submit"
-              disabled={busy}
               className="mono invite-submit"
               style={{
                 marginTop: 4,
                 padding: "10px 16px",
-                background: busy ? "var(--ink-700)" : "var(--signal)",
-                color: busy ? "var(--ink-300)" : "var(--ink-950)",
+                background: "var(--signal)",
+                color: "var(--ink-950)",
                 border: "1px solid var(--signal-deep)",
                 borderRadius: 2,
                 fontSize: 12,
                 fontWeight: 700,
                 letterSpacing: "0.12em",
                 textTransform: "uppercase",
-                cursor: busy ? "wait" : "pointer",
+                cursor: "pointer",
               }}
             >
-              {busy ? "Checking…" : "Continue"}
+              Continue
             </button>
           </form>
         </div>

--- a/frontend/src/components/brand/CenteredCard.tsx
+++ b/frontend/src/components/brand/CenteredCard.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties, ReactNode } from "react";
+import { SiteHeader } from "./SiteHeader";
+
+type Tone = "neutral" | "warn";
+
+const TONE_BORDER: Record<Tone, string> = {
+  neutral: "var(--ink-600)",
+  warn: "var(--warn)",
+};
+
+/**
+ * Full-screen, single-card interstitial chrome shared by the invite gate
+ * and the at-capacity notice (and any future one-card screen). Both used
+ * to render the identical ``<main> / <SiteHeader> / <section> / card
+ * <div>`` stack inline with the same brand tokens; the only differences
+ * were the card border colour and the ARIA role. Extracting it keeps the
+ * card geometry (maxWidth / marginTop / padding / radius) and the ink
+ * tokens in one place so a brand tweak lands once instead of drifting
+ * between copy/pasted style blocks (PR #256 review).
+ */
+export function CenteredCard({
+  tone = "neutral",
+  role,
+  children,
+}: {
+  /** Border accent: ``neutral`` (ink) for ordinary cards, ``warn`` for
+   *  attention states like at-capacity. */
+  tone?: Tone;
+  /** Passed through to the card container (e.g. ``"alert"`` for the
+   *  at-capacity notice so screen readers announce it). */
+  role?: string;
+  children: ReactNode;
+}) {
+  const cardStyle: CSSProperties = {
+    width: "100%",
+    maxWidth: 480,
+    marginTop: "8vh",
+    padding: 24,
+    background: "var(--ink-800)",
+    border: `1px solid ${TONE_BORDER[tone]}`,
+    borderRadius: 4,
+  };
+  return (
+    <main
+      className="grid min-h-screen grid-cols-1"
+      style={{ background: "var(--ink-900)" }}
+    >
+      <SiteHeader />
+      <section
+        className="flex flex-1 items-start justify-center overflow-auto p-5 lg:p-8"
+        style={{ minHeight: 0 }}
+      >
+        <div role={role} className="flex flex-col gap-5" style={cardStyle}>
+          {children}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -51,6 +51,7 @@ import {
   writeStoredSessionDraft,
 } from "../lib/sessionDraftStorage";
 import { SiteHeader } from "../components/brand/SiteHeader";
+import { Eyebrow } from "../components/brand/Eyebrow";
 import { SetupLobbyView } from "../components/setup/SetupLobbyView";
 import { SetupReviewView } from "../components/setup/SetupReviewView";
 import { PlanView } from "../components/setup/PlanView";
@@ -337,15 +338,15 @@ export function Facilitator() {
   // Tri-state: ``null`` while the mount-time probe is in flight (we
   // render a tiny loader rather than flashing the wizard then snapping
   // to the gate); ``false`` once the server confirms no gate; ``true``
-  // when the server confirms a gate AND we haven't already validated a
-  // code below. The probe answers both questions in one round-trip —
-  // is the gate on, and (if there's a localStorage code) is it still
-  // valid — so a returning visitor whose code was rotated mid-night
-  // lands on the gate directly instead of after filling out the whole
-  // wizard. Backend re-validates on ``POST /api/sessions`` regardless,
-  // so a stale localStorage value or a missed probe still get caught
-  // there; the front-side gate is the UX layer, not the security
-  // boundary.
+  // when the server confirms a gate AND we don't yet have a candidate
+  // code below. The probe answers ONE question now — is the gate on?
+  // (The old code-match oracle was removed server-side; the endpoint no
+  // longer reports whether a stored code is still valid.) A stored code
+  // is carried forward optimistically as the candidate; if it's stale,
+  // ``POST /api/sessions`` returns 403 and the create handler clears it
+  // and re-prompts via <InviteGate> with a stale-code notice. The
+  // front-side gate is the UX layer; the authenticated, rate-limited
+  // create path is the actual validation boundary.
   const [inviteRequired, setInviteRequired] = useState<boolean | null>(null);
   const [inviteCode, setInviteCode] = useState<string | null>(null);
   const [staleInviteNotice, setStaleInviteNotice] = useState<string | null>(
@@ -356,10 +357,9 @@ export function Facilitator() {
     (async () => {
       const stored = readStoredInviteCode();
       try {
-        // One round-trip resolves both questions:
-        // - status.required → is the gate on?
-        // - status.valid (when ?code= passed) → is the stored code still valid?
-        const status = await api.getInviteStatus(stored ?? undefined);
+        // The probe now resolves a single question: is the gate on?
+        // (status.required). There's no code-match oracle to consult.
+        const status = await api.getInviteStatus();
         if (canceled) return;
         if (!status.required) {
           // Server isn't gating; drop any stale stored value so a
@@ -370,19 +370,14 @@ export function Facilitator() {
           setInviteRequired(false);
           return;
         }
-        if (stored && status.valid === true) {
-          // Returning visitor with a still-valid code: skip the gate.
+        // Gate is on. Carry a stored code forward optimistically as the
+        // candidate so a returning visitor with a still-good code skips
+        // the gate; a stale one is caught at create time (403 →
+        // re-prompt). With no stored code we render the gate.
+        if (stored) {
           setInviteCode(stored);
           setInviteRequired(true);
           return;
-        }
-        // Either no stored code, or the stored one no longer matches.
-        // Drop it so the next render shows the gate cleanly.
-        if (stored && status.valid !== true) {
-          clearStoredInviteCode();
-          console.info(
-            "[facilitator] stored invite code is no longer valid; re-prompting",
-          );
         }
         setInviteCode(null);
         setInviteRequired(true);
@@ -417,6 +412,15 @@ export function Facilitator() {
   // un-exhausts the budget, so it only ever latches on.
   const [setupBudgetExhausted, setSetupBudgetExhausted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // "At capacity" signal: set when ``POST /api/sessions`` returns 503
+  // (the server has hit its live-session cap). Rendered as a distinct,
+  // on-brand card on the intro phase instead of the generic red error
+  // line, because it's a transient "try again shortly" state, not an
+  // operator mistake. ``retryAfterSec`` is the parsed ``Retry-After``
+  // header when present (null otherwise) so the card can name the wait.
+  const [capacityNotice, setCapacityNotice] = useState<{
+    retryAfterSec: number | null;
+  } | null>(null);
   // Creator-only "backend degraded / heavy load" signal (``backend_status``
   // WS event). ``message`` is the latest operator-facing copy; ``nonce``
   // is bumped on every frame so <BackendStatusChip> re-arms its
@@ -821,6 +825,7 @@ export function Facilitator() {
   async function handleCreate(e: FormEvent) {
     e.preventDefault();
     setError(null);
+    setCapacityNotice(null);
     setBusy(true);
     setBusyMessage(
       devMode
@@ -948,6 +953,16 @@ export function Facilitator() {
         setStaleInviteNotice(
           "Your invite code is no longer valid — likely rotated by the operator. Enter the current code to continue.",
         );
+      } else if (err instanceof ApiError && err.status === 503) {
+        // Server is at its live-session cap. Distinct from a generic
+        // failure: it's transient and the operator just needs to wait,
+        // so we surface a calm on-brand "at capacity" card rather than
+        // a red error line. The ``Retry-After`` header (parsed onto the
+        // ApiError) tells them roughly how long.
+        console.warn("[facilitator] create_session_at_capacity", {
+          retryAfter: err.retryAfter,
+        });
+        setCapacityNotice({ retryAfterSec: err.retryAfter });
       } else {
         console.warn("[facilitator] create_session_failed", msg, err);
         setError(msg);
@@ -1845,6 +1860,23 @@ export function Facilitator() {
   };
 
   if (phase === "intro") {
+    // "At capacity" takes priority over everything else on the intro
+    // phase: once the create call comes back 503 the operator's only
+    // useful action is to wait and retry, so we replace the wizard with
+    // a calm card rather than burying a red error line under the form.
+    // RETRY clears the notice and drops them back into the wizard with
+    // their draft intact (form state is untouched on this path).
+    if (capacityNotice !== null) {
+      return (
+        <CapacityNotice
+          retryAfterSec={capacityNotice.retryAfterSec}
+          onRetry={() => {
+            console.info("[facilitator] at-capacity retry");
+            setCapacityNotice(null);
+          }}
+        />
+      );
+    }
     // While the mount-time probe is in flight (``inviteRequired ===
     // null``) we render a tiny <SiteHeader> + <DieLoader> rather
     // than flashing the wizard then snapping to the gate. The probe
@@ -2776,6 +2808,109 @@ export function Facilitator() {
           onClose={() => setShowAarPopup(false)}
         />
       ) : null}
+    </main>
+  );
+}
+
+/**
+ * "At capacity" card shown on the intro phase when ``POST /api/sessions``
+ * returns 503 (the server has hit its live-session cap). Distinct from
+ * the generic red error line: this is a transient, no-fault "try again
+ * shortly" state, so it gets calm on-brand chrome (the same centered
+ * card the <InviteGate> uses) rather than reading as an operator
+ * mistake. ``retryAfterSec`` comes from the response's ``Retry-After``
+ * header when present; we name the wait so the operator isn't guessing.
+ */
+function CapacityNotice({
+  retryAfterSec,
+  onRetry,
+}: {
+  retryAfterSec: number | null;
+  onRetry: () => void;
+}) {
+  // Turn the delta-seconds header into operator-friendly copy. Round up
+  // to the nearest minute past 90 s so "try again in 2 minutes" reads
+  // cleaner than "in 120 seconds"; keep the raw seconds below that.
+  const wait =
+    retryAfterSec == null
+      ? "in a few minutes"
+      : retryAfterSec <= 90
+        ? `in about ${retryAfterSec} second${retryAfterSec === 1 ? "" : "s"}`
+        : `in about ${Math.ceil(retryAfterSec / 60)} minutes`;
+  return (
+    <main
+      className="grid min-h-screen grid-cols-1"
+      style={{ background: "var(--ink-900)" }}
+    >
+      <SiteHeader />
+      <section
+        className="flex flex-1 items-start justify-center overflow-auto p-5 lg:p-8"
+        style={{ minHeight: 0 }}
+      >
+        <div
+          role="alert"
+          className="flex flex-col gap-5"
+          style={{
+            width: "100%",
+            maxWidth: 480,
+            marginTop: "8vh",
+            padding: 24,
+            background: "var(--ink-800)",
+            border: "1px solid var(--warn)",
+            borderRadius: 4,
+          }}
+        >
+          <header className="flex flex-col gap-2">
+            <Eyebrow>Status · At capacity</Eyebrow>
+            <h1
+              className="sans"
+              style={{
+                fontSize: 26,
+                fontWeight: 600,
+                color: "var(--ink-050)",
+                margin: 0,
+                letterSpacing: "-0.01em",
+              }}
+            >
+              Crittable is at capacity
+            </h1>
+            <p
+              className="sans"
+              style={{
+                fontSize: 13,
+                color: "var(--ink-300)",
+                margin: 0,
+                lineHeight: 1.5,
+              }}
+            >
+              Every live session slot is currently in use. Your brief
+              wasn't lost — try again {wait}. If you were invited as a
+              player, your join link still works; this limit only applies
+              to starting a new session.
+            </p>
+          </header>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mono"
+            style={{
+              marginTop: 4,
+              padding: "10px 16px",
+              background: "var(--signal)",
+              color: "var(--ink-950)",
+              border: "1px solid var(--signal-deep)",
+              borderRadius: 2,
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              cursor: "pointer",
+            }}
+          >
+            Back to setup · retry
+          </button>
+        </div>
+      </section>
     </main>
   );
 }

--- a/frontend/src/pages/Facilitator.tsx
+++ b/frontend/src/pages/Facilitator.tsx
@@ -50,6 +50,7 @@ import {
   readStoredSessionDraft,
   writeStoredSessionDraft,
 } from "../lib/sessionDraftStorage";
+import { CenteredCard } from "../components/brand/CenteredCard";
 import { SiteHeader } from "../components/brand/SiteHeader";
 import { Eyebrow } from "../components/brand/Eyebrow";
 import { SetupLobbyView } from "../components/setup/SetupLobbyView";
@@ -345,8 +346,10 @@ export function Facilitator() {
   // is carried forward optimistically as the candidate; if it's stale,
   // ``POST /api/sessions`` returns 403 and the create handler clears it
   // and re-prompts via <InviteGate> with a stale-code notice. The
-  // front-side gate is the UX layer; the authenticated, rate-limited
-  // create path is the actual validation boundary.
+  // front-side gate is the UX layer; the invite-gated, rate-limited
+  // create path is the actual validation boundary — it is intentionally
+  // unauthenticated (the cost-abuse front door), gated by the invite
+  // code and the per-IP create limiter rather than a token.
   const [inviteRequired, setInviteRequired] = useState<boolean | null>(null);
   const [inviteCode, setInviteCode] = useState<string | null>(null);
   const [staleInviteNotice, setStaleInviteNotice] = useState<string | null>(
@@ -2838,80 +2841,57 @@ function CapacityNotice({
         ? `in about ${retryAfterSec} second${retryAfterSec === 1 ? "" : "s"}`
         : `in about ${Math.ceil(retryAfterSec / 60)} minutes`;
   return (
-    <main
-      className="grid min-h-screen grid-cols-1"
-      style={{ background: "var(--ink-900)" }}
-    >
-      <SiteHeader />
-      <section
-        className="flex flex-1 items-start justify-center overflow-auto p-5 lg:p-8"
-        style={{ minHeight: 0 }}
-      >
-        <div
-          role="alert"
-          className="flex flex-col gap-5"
+    <CenteredCard tone="warn" role="alert">
+      <header className="flex flex-col gap-2">
+        <Eyebrow>Status · At capacity</Eyebrow>
+        <h1
+          className="sans"
           style={{
-            width: "100%",
-            maxWidth: 480,
-            marginTop: "8vh",
-            padding: 24,
-            background: "var(--ink-800)",
-            border: "1px solid var(--warn)",
-            borderRadius: 4,
+            fontSize: 26,
+            fontWeight: 600,
+            color: "var(--ink-050)",
+            margin: 0,
+            letterSpacing: "-0.01em",
           }}
         >
-          <header className="flex flex-col gap-2">
-            <Eyebrow>Status · At capacity</Eyebrow>
-            <h1
-              className="sans"
-              style={{
-                fontSize: 26,
-                fontWeight: 600,
-                color: "var(--ink-050)",
-                margin: 0,
-                letterSpacing: "-0.01em",
-              }}
-            >
-              Crittable is at capacity
-            </h1>
-            <p
-              className="sans"
-              style={{
-                fontSize: 13,
-                color: "var(--ink-300)",
-                margin: 0,
-                lineHeight: 1.5,
-              }}
-            >
-              Every live session slot is currently in use. Your brief
-              wasn't lost — try again {wait}. If you were invited as a
-              player, your join link still works; this limit only applies
-              to starting a new session.
-            </p>
-          </header>
-          <button
-            type="button"
-            onClick={onRetry}
-            className="mono"
-            style={{
-              marginTop: 4,
-              padding: "10px 16px",
-              background: "var(--signal)",
-              color: "var(--ink-950)",
-              border: "1px solid var(--signal-deep)",
-              borderRadius: 2,
-              fontSize: 12,
-              fontWeight: 700,
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-              cursor: "pointer",
-            }}
-          >
-            Back to setup · retry
-          </button>
-        </div>
-      </section>
-    </main>
+          Crittable is at capacity
+        </h1>
+        <p
+          className="sans"
+          style={{
+            fontSize: 13,
+            color: "var(--ink-300)",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          Every live session slot is currently in use. Your brief
+          wasn't lost — try again {wait}. If you were invited as a
+          player, your join link still works; this limit only applies
+          to starting a new session.
+        </p>
+      </header>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mono"
+        style={{
+          marginTop: 4,
+          padding: "10px 16px",
+          background: "var(--signal)",
+          color: "var(--ink-950)",
+          border: "1px solid var(--signal-deep)",
+          borderRadius: 2,
+          fontSize: 12,
+          fontWeight: 700,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          cursor: "pointer",
+        }}
+      >
+        Back to setup · retry
+      </button>
+    </CenteredCard>
   );
 }
 


### PR DESCRIPTION
## HTTP-edge / front-door hardening — PR 2 of the pre-launch security audit

Closes the remaining cost-abuse front door (C1) plus the deploy-hardening set. **LLM-blind** (no `llm/`, `turn_*`, or prompt changes), so the gate is backend pytest + ruff + mypy and frontend lint + tsc + vitest — no live-tests.

> ⚠️ **Draft** pending the focused sub-agent reviews (**Security / QA / Product** — this PR is LLM-blind so Prompt-Expert is N/A and the only browser surface is the capacity card) + CI.

### What's in it
- **C1 — front door.** Dedicated per-IP token bucket on `POST /api/sessions` (always-on, `SESSION_CREATE_RATE_PER_MIN`) → 429 + `Retry-After`; plus a **fail-closed boot gate** that refuses to start a non-local deploy (`CORS_ORIGINS` narrowed) with no `INVITE_CODE` **and** no creation cap. Anonymous session-creation loops can no longer burn setup-tier tokens.
- **H7 — XFF trust.** `resolve_client_ip` defaults to the socket peer and trusts `X-Forwarded-For` only from an allowlisted `TRUSTED_PROXIES` peer (right-most untrusted hop). Shared by both limiters.
- **M2 — capacity.** Counts only **live** (non-ENDED) sessions so ending frees a slot immediately; `SessionCapacityError` → **503 + Retry-After** (was 400); frontend renders an "at capacity" card.
- **M5 — security headers.** `Referrer-Policy: no-referrer` (kills the token-in-URL `Referer` leak) + `nosniff` + `DENY` + a self-hosted CSP. Plain-ASGI middleware (correctly skips WS scopes).
- **M7 — invite oracle.** `GET /api/invite/status` drops `valid`; validation is inline on `POST`.
- **M9** — devcontainer pinned to Python 3.13 (was 3.14 → CVE-laden litellm 1.83.0).
- **M11 — CWE-209 / CodeQL alert #5.** No exception string reaches a client response: curated type-keyed constants + call-site overrides where wording is load-bearing; `failed_invitees.reason` is now an enumerated code.

### New env knobs (`docs/configuration.md`)
`SESSION_CREATE_RATE_PER_MIN`, `TRUST_FORWARDED_FOR`, `TRUSTED_PROXIES`, `CONTENT_SECURITY_POLICY`.

backend: ruff + mypy clean, **1097 passed / 1 skipped**; frontend: lint + tsc clean, **635 passed**.

Out of scope (later PRs): PR3 multi-code invite, PR4 LLM I/O safety (inbound guardrail hardening + outbound checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcV5vcbww5We1C6RxuTq7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcV5vcbww5We1C6RxuTq7Y)_